### PR TITLE
EN-2: Backend boundary foundation — behaviours, neutral error kinds, real/local selection

### DIFF
--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -15,6 +15,7 @@
 | # | Decision | Date | Status | ADR |
 |---|----------|------|--------|-----|
 | 1 | No local datastore — drop `ecto_sql`/`postgrex`, keep `ecto` for changesets | 2026-08-07 | Decided | `docs/adr/0001-no-local-datastore.md` |
+| 2 | Backend adapter boundaries — behaviours, tagged-tuple errors, per-boundary real/local selection | 2026-08-07 | Decided | `docs/adr/0002-backend-adapter-boundaries.md` |
 
 Two things this file deliberately does **not** contain:
 
@@ -121,6 +122,79 @@ adapter or migration.
 
 ---
 
+## Decision: Backend Adapter Boundaries
+
+**Date**: 2026-08-07
+**Status**: Decided
+**Owner**: @dave-bell (decided on issue #2, EN-2)
+
+### Context
+Secrets reads from two external systems: the tenant's AWS SSM Parameter Store (the secrets) and
+the tenant's backing API (the authoritative environment list used to validate environment names
+before any parameter path is built). Parameter Store access needs a Terraform-provisioned
+cross-account IAM role, so calling it directly means a fresh clone cannot run and CI cannot
+test — even for a developer touching only environment listing. The earlier prototype also
+leaked backend-specific failures into route code (an SSM `CredentialsExpiredError` caught in a
+route, `KeyError` reused for two meanings), which makes the "pluggable backends" constraint in
+`technical-domain.md` documentation rather than fact.
+
+### Decision
+Every external system sits behind an Elixir **behaviour** with two implementations, `real` and
+`local`, selected **per boundary** via `config :nucleus, :backends` — real in `config.exs`,
+local in `dev.exs`/`test.exs`, overridable at runtime with `SECRETS_BACKEND` and
+`TENANT_API_BACKEND` (`"real"` | `"local"`). Callbacks return
+`{:error, %Nucleus.Backend.Error{}}` — **returned, never raised** — carrying one of six neutral
+`kind`s (`:invalid`, `:not_found`, `:already_exists`, `:auth_expired`, `:unavailable`,
+`:not_configured`). Every behaviour declares `health_check/0`. There is no `:auth` boundary and
+no `AUTH_BACKEND`; auth is never swappable. Local implementations ship in the release, with a
+prominent boot warning naming any boundary serving in-memory data.
+`Nucleus.Backend.Faults.maybe_fault/1` (`LOCAL_LATENCY_MS`, `LOCAL_FORCE_ERROR`) is required,
+not optional.
+
+### Rationale
+Behaviours are the Elixir idiom for a swappable interface, and `@behaviour` plus
+`compile --warnings-as-errors` catches signature drift at build time — no separate conformance
+checker needed. Tagged tuples keep the failure path visible and exhaustively matchable; `rescue`
+in a `handle_event/3` cannot be either. Six kinds instead of the prototype's five splits
+`:invalid` (input rejected before any backend call) out from backend failure, which is precisely
+the conflation that made `KeyError` mean two things. Per-boundary selection matches the shape of
+the cost being avoided. Fault injection is what makes `SEC-S1` (fail closed) and `SEC-S7`
+(credential expiry) testable at all.
+
+### Alternatives Considered
+| Alternative | Pros | Cons | Why Rejected? |
+|-------------|------|------|---------------|
+| Direct `ExAws`/`Req` calls, no boundary | Least code | No way to run without live infra; backend exception types reach LiveViews | The exact state the prototype was leaving |
+| Single global `BACKEND_MODE` | One switch to explain | All-or-nothing when only Parameter Store is expensive to access | The cost is per boundary, so the switch should be |
+| Raise `Nucleus.Backend.Error` instead of returning it | Terser call sites | `rescue` in `handle_event/3` is unverifiable and needed everywhere | Failure handling must be exhaustively matchable |
+| Exclude local implementations from the release build | Local mode physically impossible in prod | Build stage and package list must stay in sync; a mistake breaks dev silently | Auth is never swappable, so the risk is wrong data, not bypass — a boot warning is proportionate |
+| `Mox`/`Hammox` instead of local implementations | No second implementation to maintain | Mocks exist only for tests and drift from what a developer can run | One local implementation serves both dev and test |
+| Detect "local" from the module name suffix | No registry to maintain | Stringly-typed; defeated by a rename | Explicit registry costs two lines per boundary |
+
+### Impact
+- **Positive**: A fresh clone runs and the whole suite passes with zero credentials and no
+  external services. CI needs no dummy env vars. LiveViews match on `Error.kind`, so a backend
+  is replaceable without touching business logic. `health_check/0` closes the readiness
+  boundary violation before it can happen. `Error.kinds/0` is asserted against the `@type kind`
+  union, so a seventh kind cannot be added silently.
+- **Negative**: Two implementations per boundary to keep in agreement — EN-8 owns the shared
+  contract suite, which still cannot catch every nuance (real SSM's eventual consistency).
+  `impl_for/1` raises for both boundaries until EN-3/EN-4 land, by design and by name. Every
+  `mix test` run logs the local-backends warning once.
+- **Risk**: Token passthrough over a long-lived LiveView socket is still unresolved and shapes
+  the callback *arguments* EN-3/EN-4 define. This decision fixes only the return shape.
+
+### Related
+- Issue #2 (EN-2) — the deciding issue and full implementation plan
+- `docs/adr/0002-backend-adapter-boundaries.md` — the formal ADR
+- Issues #3 (EN-3), #4 (EN-4) — the concrete boundaries built on this scaffolding
+- Issue #6 (EN-6) — auth, deliberately outside the boundary set
+- Issue #8 (EN-8) — the contract test harness
+- `docs/adr/0001-no-local-datastore.md` — local implementations are in-memory per process, never
+  persisted
+
+---
+
 ## Deprecated Decisions
 
 Decisions that were later overturned (for historical context):
@@ -131,7 +205,8 @@ Decisions that were later overturned (for historical context):
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001` (no local datastore) is binding
+- [ ] Read the Decision Index above; `adr/0001` (no local datastore) and
+      `adr/0002` (backend adapter boundaries) are binding
 - [ ] Know that the wiki's ADR-0001–0007 are reference only, not adopted
 - [ ] Know that new formal ADRs belong in `docs/adr/`
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/technical-domain.md
+++ b/.opencode/context/project-intelligence/technical-domain.md
@@ -56,6 +56,8 @@ This project is a fresh start. Requirements bind; that architecture does not.
 2026-08-07-nucleus2/
 ├── lib/nucleus/            # Core application + OTP supervision
 │   ├── application.ex      # Supervision tree (no repo — see adr/0001)
+│   ├── backend.ex          # Boundary registry + real/local selection (adr/0002)
+│   ├── backend/            # error.ex (neutral error kinds), faults.ex (injection)
 │   └── mailer.ex
 ├── lib/nucleus_web/        # Web layer
 │   ├── router.ex           # Currently only `get "/"` + dev routes
@@ -64,7 +66,8 @@ This project is a fresh start. Requirements bind; that architecture does not.
 │   └── controllers/        # page_controller.ex, error views
 ├── test/                   # Mirrors lib/ structure
 ├── docs/requirements/      # Wiki submodule — BINDING requirements source
-├── docs/adr/               # This project's own ADRs (0001: no local datastore)
+├── docs/adr/               # This project's own ADRs (0001: no local datastore,
+│                          #   0002: backend adapter boundaries)
 ├── assets/                 # app.js, app.css
 └── config/                 # config.exs, dev/test/prod/runtime
 ```
@@ -80,9 +83,10 @@ This project is a fresh start. Requirements bind; that architecture does not.
 
 | Decision | Rationale | Impact |
 |----------|-----------|--------|
-| *(none recorded)* | — | — |
+| No local datastore (`adr/0001`) | Nothing used the scaffolded repo, and a live repo invites "just cache the secret" | No `ecto_sql`/`postgrex`/`Nucleus.Repo`; `ecto` retained for changesets only. No PostgreSQL for dev or CI |
+| Backend adapter boundaries (`adr/0002`) | A fresh clone must run without the cross-account IAM role Parameter Store needs, and LiveViews must never catch a backend-specific exception | Elixir behaviours per boundary, `real`/`local` selected per boundary via `SECRETS_BACKEND`/`TENANT_API_BACKEND`; callbacks return `{:error, %Nucleus.Backend.Error{}}` with one of six neutral kinds; `health_check/0` on every behaviour; no `AUTH_BACKEND` |
 
-No architectural decisions have been made and recorded yet. See `decisions-log.md`.
+See `decisions-log.md` for the full context behind each.
 
 ## Integration Points
 
@@ -101,7 +105,7 @@ All three are external, tenant-owned, and read live — there is no local mirror
 | Constraint | Origin | Impact |
 |------------|--------|--------|
 | **Stateless — no own datastore** | Adopted from wiki Core model | Every value is fetched live per request. No cache of secrets or config survives a restart. **Structurally enforced since EN-1**: there is no repo, no `ecto_sql`, no database config. Adding one reopens `docs/adr/0001-no-local-datastore.md`. Audit records go to an external log pipeline (EN-5), never a local table. |
-| **Pluggable backends** | Adopted from wiki Core model | Nomad, Parameter Store, and Cognito must sit behind swappable interfaces (idiomatically, Elixir behaviours) so a backing system can be replaced without changing behaviour. Enables local/test implementations. |
+| **Pluggable backends** | Adopted from wiki Core model | Nomad, Parameter Store, the tenant API, and Cognito must sit behind swappable interfaces so a backing system can be replaced without changing behaviour. **Scaffolding landed in EN-2**: `Nucleus.Backend` (registry + per-boundary `real`/`local` selection), `Nucleus.Backend.Error` (six neutral kinds, returned never raised), `Nucleus.Backend.Faults` (latency/error injection). Every behaviour declares `health_check/0`. Auth is deliberately *not* swappable. See `docs/adr/0002-backend-adapter-boundaries.md`. |
 | **Token passthrough** | Adopted from wiki Core model | Nucleus holds no authorisation model of its own for backing APIs; it forwards the signed-in user's access token. **Non-trivial in LiveView** — the token must be held against a long-lived stateful socket and mid-session expiry handled. See `living-notes.md` and requirement `SEC-A18`. |
 | **Fail closed on validation** | Requirements (`SEC-A15`–`SEC-A17`) | Environment names are validated against the tenant's backing API before any path is constructed. If validation is unavailable, requests are rejected, never passed through unvalidated. |
 | **Single tenant per deployment** | Business constraint | Namespace is deployment configuration, not runtime state. |

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,20 @@ config :nucleus, NucleusWeb.Endpoint,
   pubsub_server: Nucleus.PubSub,
   live_view: [signing_salt: "hJS7FKBE"]
 
+# Swappable backend boundaries. One implementation per boundary, selected
+# independently — see lib/nucleus/backend.ex and
+# docs/adr/0002-backend-adapter-boundaries.md.
+#
+# These are the `real` implementations, delivered by EN-3 and EN-4. dev and test
+# override both to the `.Local` implementations so a fresh clone needs no
+# credentials; runtime.exs allows a per-boundary override via SECRETS_BACKEND
+# and TENANT_API_BACKEND.
+#
+# There is deliberately no `auth` boundary. Authentication is never swappable.
+config :nucleus, :backends,
+  secrets: Nucleus.Secrets.Store.Aws,
+  tenant_api: Nucleus.TenantApi.Http
+
 # Configure LiveView
 config :phoenix_live_view,
   # the attribute set on all root tags. Used for Phoenix.LiveView.ColocatedCSS.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -45,6 +45,13 @@ config :nucleus, NucleusWeb.Endpoint,
 # Enable dev routes for dashboard and mailbox
 config :nucleus, dev_routes: true
 
+# Run every boundary against its local implementation, so a fresh clone starts
+# with no AWS role and no tenant API reachable. Override per boundary with
+# SECRETS_BACKEND=real / TENANT_API_BACKEND=real (see config/runtime.exs).
+config :nucleus, :backends,
+  secrets: Nucleus.Secrets.Store.Local,
+  tenant_api: Nucleus.TenantApi.Local
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :default_formatter, format: "[$level] $message\n"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,6 +23,23 @@ end
 config :nucleus, NucleusWeb.Endpoint,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
+# Per-boundary backend override: SECRETS_BACKEND / TENANT_API_BACKEND, each
+# "real" or "local". Unset boundaries keep whatever the compile-time config
+# chose — "real" in prod, "local" in dev and test.
+#
+# Selection is per boundary, not one global switch: Parameter Store needs a
+# Terraform-provisioned cross-account IAM role, and a developer working only on
+# environment listing should not need one. There is deliberately no
+# AUTH_BACKEND — authentication is never swappable.
+#
+# Nucleus.Backend is the single source of truth for which module means "real"
+# and which means "local"; runtime.exs runs after compilation, so it can ask.
+for boundary <- Nucleus.Backend.boundaries(),
+    mode = System.get_env(Nucleus.Backend.env_var(boundary)),
+    mode not in [nil, ""] do
+  config :nucleus, :backends, [{boundary, Nucleus.Backend.impl_for_mode!(boundary, mode)}]
+end
+
 if config_env() == :dev do
   # Reload browser tabs when matching files change.
   config :nucleus, NucleusWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -10,6 +10,12 @@ config :nucleus, NucleusWeb.Endpoint,
 # In test we don't send emails
 config :nucleus, Nucleus.Mailer, adapter: Swoosh.Adapters.Test
 
+# The suite runs with no credentials and no external services. Tests that need a
+# different implementation set it themselves with Application.put_env/3.
+config :nucleus, :backends,
+  secrets: Nucleus.Secrets.Store.Local,
+  tenant_api: Nucleus.TenantApi.Local
+
 # Disable swoosh api client as it is only required for production adapters
 config :swoosh, :api_client, false
 

--- a/docs/adr/0002-backend-adapter-boundaries.md
+++ b/docs/adr/0002-backend-adapter-boundaries.md
@@ -1,0 +1,260 @@
+# ADR-0002: Backend Adapter Boundaries
+
+## Status
+
+Accepted — 2026-08-07
+
+Decided on [EN-2](https://github.com/dave-bell/nucleus/issues/2). Builds on
+`0001-no-local-datastore.md`.
+
+The wiki's `ADR-0001` (plugin architecture) and `ADR-0007` (local backend
+implementations), under `docs/requirements/`, describe an earlier Python
+prototype and are **reference only**. Where this ADR reaches the same conclusion,
+it is because that conclusion was re-tested against this stack — not by
+inheritance. The sections below say explicitly which decisions carry over and
+which change shape because this is Elixir/LiveView rather than FastAPI/React.
+
+## Context
+
+Nucleus holds no data of its own; every value it displays is read live from an
+external system. The Secrets feature alone reads from two:
+
+- the tenant's **AWS SSM Parameter Store**, for the secrets themselves, reached
+  by assuming a scoped role in the tenant's AWS account
+- the tenant's **backing API**, for the authoritative environment list that
+  environment names are validated against before any parameter path is
+  constructed (`SEC-A15`–`SEC-A17`, fail closed)
+
+Two problems follow from calling those systems directly.
+
+**A fresh clone would not run.** Parameter Store access requires a cross-account
+IAM role provisioned by Terraform. Without a local implementation, every
+developer and every CI job needs that role — including a developer touching only
+environment listing, who needs no AWS access at all. The prototype's CI passed
+eight dummy environment variables purely to satisfy configuration validation,
+which is an honest description of the problem: the credentials were required by
+the code's shape, not by the work.
+
+**Backend-specific failures would leak into LiveViews.** The prototype caught an
+SSM-specific `CredentialsExpiredError` in route code and reused `KeyError` for
+two unrelated meanings. Once a LiveView knows a backend's exception types, the
+backend is no longer replaceable, and the "swappable interfaces" constraint in
+`technical-domain.md` is documentation rather than fact.
+
+This ADR covers only the shared scaffolding. The two concrete boundaries are
+delivered by EN-3 (`:tenant_api`) and EN-4 (`:secrets`).
+
+## Decision
+
+### Behaviours, not protocols
+
+Each boundary is an Elixir **behaviour** with `@callback` declarations, and each
+implementation is a module declaring `@behaviour`. This is the same decision as
+the prototype's `Protocol`/ABC in intent, in the idiom of a different language.
+It is also stronger: the prototype needed `mypy` plus a hand-written
+`_conformance_check.py` module because `runtime_checkable` protocols verify only
+that a method exists, not its arity or signature. `@behaviour` warns at compile
+time on a missing or wrongly-arity'd callback, and `mix precommit` compiles with
+`--warnings-as-errors`, so that warning is a build failure.
+
+No further conformance machinery is added. What `@behaviour` gives is enough.
+
+### Tagged tuples, not exceptions
+
+Callbacks return `{:ok, value}` or `{:error, %Nucleus.Backend.Error{}}`. Errors
+are **returned, never raised**.
+
+A `rescue` inside a `handle_event/3` is not an acceptable control-flow
+mechanism: it makes the failure path invisible to the reader, and it cannot be
+made exhaustive. Returning a struct with a `kind` field means a LiveView selects
+its message by pattern-matching, and adding a kind makes every incomplete `case`
+a compile-time warning.
+
+`Nucleus.Backend.Error` is deliberately a plain struct with no `exception/1` —
+if it were an exception, `rescue` would remain a plausible choice.
+
+### Six neutral error kinds
+
+`Nucleus.Backend.Error` carries `kind`, `message`, `boundary` and `details`.
+`business-tech-bridge.md` records that requirement status codes are binding as
+*behaviour*, not as literal HTTP responses in a LiveView, so each kind names the
+meaning rather than the number:
+
+| `kind` | Meaning | Requirement status code |
+|---|---|---|
+| `:invalid` | Caller-supplied input rejected before any backend call | 400 |
+| `:not_found` | Well-formed identifier, no such resource | 404 |
+| `:already_exists` | Create conflicted with an existing resource | 409 |
+| `:auth_expired` | Server-side credentials for the backend expired | 401 |
+| `:unavailable` | Backend unreachable, timed out, or errored | 503 / 502 |
+| `:not_configured` | This boundary has no usable configuration | 503 |
+
+This differs from the prototype's five exception classes by splitting `:invalid`
+out as its own kind: input rejected before any backend call is reached is not a
+backend failure, and conflating the two is how `KeyError` came to mean two
+things.
+
+`:auth_expired` describes *Nucleus's* credentials for a backend — an expired
+assumed role — not the end user's session. Those are separate concerns and
+`SEC-A18` handles the latter.
+
+`Error.kinds/0` returns the full list, and a unit test reads the `@type kind`
+union back out of the compiled type chunk and asserts the two agree. Adding a
+seventh kind therefore fails that test until it is added to both, which is the
+prompt to revisit every `case` matching on one.
+
+`message` is developer-facing and may be logged; secret material never goes in
+it, and never in `details`.
+
+### `health_check/0` on every boundary behaviour
+
+Every behaviour defined by EN-3/EN-4 declares:
+
+```elixir
+@callback health_check() :: :ok | {:error, Nucleus.Backend.Error.t()}
+```
+
+Readiness must be answerable *through* the boundary. The prototype's `/ready`
+reached into a plugin's private client attribute — a boundary violation that
+went unnoticed only because there was a single implementation to test against.
+Declaring the callback on the behaviour makes the same mistake a compile
+warning.
+
+The readiness endpoint that consumes it belongs to Platform Operations
+(`OPS-*`), not here.
+
+### Per-boundary `real`/`local` selection
+
+`Nucleus.Backend.impl_for/1` resolves a boundary to a module from
+`Application.get_env(:nucleus, :backends)`, at call time so that
+`config/runtime.exs` and test overrides both take effect. It **raises** on an
+unknown or unconfigured boundary, or on a configured module that is not loaded:
+that is a deployment mistake, not a runtime condition a LiveView could sensibly
+render, and the message names the boundary and both of its implementations.
+
+- `config/config.exs` selects the real implementations.
+- `config/dev.exs` and `config/test.exs` select the local implementations, so a
+  fresh clone runs and `mix test` passes with no credentials.
+- `config/runtime.exs` overrides per boundary via `SECRETS_BACKEND` and
+  `TENANT_API_BACKEND`, each `"real"` (default) or `"local"`. An unrecognised
+  value raises at boot rather than falling back.
+
+Selection is **per boundary, not one global switch** — carried over from wiki
+ADR-0007 for the same reason it was chosen there. The pain being solved is
+specific to Parameter Store's cross-account role; a single switch would force an
+all-or-nothing choice on a developer who wants a real tenant API and a local
+secrets store.
+
+`Nucleus.Backend` holds the `boundary -> %{real: module, local: module}` registry
+and is the single source of truth for which module means which mode.
+`config/runtime.exs` asks it rather than repeating the mapping, since runtime
+configuration is evaluated after compilation. `config/config.exs` cannot — it is
+evaluated before the module exists — so the default module names are literals
+there. A unit test asserts the test-environment configuration equals the
+registry's local implementations, which is what catches drift between the two.
+
+### Authentication is never swappable
+
+There is no `:auth` boundary and no `AUTH_BACKEND`. Authentication is the actual
+security boundary; making it swappable would make an authorisation bypass a
+configuration mistake. (Auth itself is deferred — see EN-6.)
+
+### Local implementations ship, with a loud boot warning
+
+Local implementations are included in the release, and
+`Nucleus.Application.start/2` calls `Nucleus.Backend.warn_on_local_backends/0`,
+which logs one warning naming every boundary currently serving in-memory data
+and the variable that switched it.
+
+The alternative — excluding them from the production build — is rejected for the
+reason wiki ADR-0007 gives: it requires a package list and a build stage to stay
+in sync, and a mistake there silently breaks local development rather than
+failing loudly. Because auth is never swappable, a stray `*_BACKEND=local` in
+production shows wrong data to users who are already authenticated and
+authorised. That is a functional bug, not an auth bypass, and a warning on every
+boot is the cheap, proportionate signal.
+
+### Fault injection is required, not optional
+
+`Nucleus.Backend.Faults.maybe_fault/1` reads two environment variables and is
+called first in every local implementation callback:
+
+| Variable | Effect |
+|---|---|
+| `LOCAL_LATENCY_MS` | Sleep this long before returning |
+| `LOCAL_FORCE_ERROR` | Return `{:error, %Error{kind: <named kind>}}` instead of succeeding |
+
+Canned data that always succeeds instantly never exercises a spinner or an error
+branch. `SEC-S1` (fail closed on `:unavailable`) and `SEC-S7` (`:auth_expired`
+surfacing as re-authentication) are not testable at all without this, so it is
+part of the boundary scaffolding rather than a developer convenience.
+
+Both variables are read on **every call**, deliberately: a developer flips a
+fault without restarting. Both **raise** on an unparseable value — a typo in a
+fault flag that silently returned `:ok` would turn a test asserting an error path
+into one that passes for the wrong reason.
+
+## Consequences
+
+- **A fresh clone runs and its full test suite passes with no credentials**, no
+  AWS role, and no external services. CI needs no dummy environment variables to
+  satisfy configuration.
+- **Every `mix test` run logs the local-backends warning once.** That is the
+  intended signal, not noise to suppress.
+- **LiveViews match on `Nucleus.Backend.Error.kind`**, and a LiveView that
+  imports a backend-specific error type is a review failure with a named rule to
+  cite.
+- **Two implementations per boundary must stay in agreement.** EN-8's test
+  harness owns the shared behaviour-contract suite that runs the same assertions
+  against both. Contract tests cannot catch every behavioural nuance — real
+  SSM's eventual consistency, for one.
+- **`impl_for/1` raises today for both boundaries**, because
+  `Nucleus.Secrets.Store.Local` and `Nucleus.TenantApi.Local` do not exist until
+  EN-4 and EN-3. The message says so by name. Nothing calls `impl_for/1` yet.
+- **Callback signatures are not yet settled for token passthrough.** How the
+  signed-in user's access token reaches a boundary across a long-lived LiveView
+  socket is an open question (`living-notes.md`). EN-3 and EN-4 define the first
+  real callbacks and will have to answer it; this ADR constrains only the return
+  shape, which is unaffected.
+- **No mocking library is introduced.** Real local implementations plus contract
+  tests replace `Mox`/`Hammox`. Adding one later is a new decision.
+
+## Alternatives considered
+
+**Direct calls to `ExAws`/`Req` from context modules, no boundary.** Rejected.
+It is the state the prototype was trying to leave: no way to run without live
+infrastructure, and backend exception types reaching route code.
+
+**A single global `BACKEND_MODE`.** Rejected, same reasoning as wiki ADR-0007 —
+the cost being avoided is specific to one boundary, so the switch should be too.
+
+**Raising a `Nucleus.Backend.Error` exception instead of returning it.**
+Rejected. It reads more concisely at the call site and much worse at the failure
+site: `rescue` in `handle_event/3` cannot be checked for exhaustiveness, and
+every LiveView would need one.
+
+**Excluding local implementations from the release build.** Rejected — see the
+boot-warning section above.
+
+**A mocking library (`Mox`, `Hammox`) instead of local implementations.**
+Rejected. Mocks exist only for tests, so they drift from anything a developer can
+run, which is exactly how the prototype ended up with hand-written `Fake*`
+classes *and* no local mode. One local implementation per boundary serves both.
+
+**Deriving "is this local?" from the module name suffix.** Rejected as
+stringly-typed: an explicit registry in `Nucleus.Backend` costs two lines per
+boundary and cannot be defeated by a rename.
+
+## References
+
+- EN-2 — the deciding issue, including the full implementation plan
+- `docs/adr/0001-no-local-datastore.md` — the stateless constraint local
+  implementations must not breach (in-memory per process, never persisted)
+- Wiki [ADR-0001](https://github.com/dave-bell/nucleus/wiki/ADR-0001-Monolith-with-Plugin-Architecture),
+  [ADR-0007](https://github.com/dave-bell/nucleus/wiki/ADR-0007-Local-Backend-Implementations)
+  — reference only; prior art, not authority
+- `.opencode/context/project-intelligence/technical-domain.md` — "Pluggable
+  backends" constraint
+- `.opencode/context/project-intelligence/business-tech-bridge.md` — status codes
+  binding as behaviour, not literal HTTP responses
+- EN-3, EN-4 — the concrete boundaries; EN-6 — auth; EN-8 — contract test harness

--- a/lib/nucleus/application.ex
+++ b/lib/nucleus/application.ex
@@ -7,6 +7,8 @@ defmodule Nucleus.Application do
 
   @impl true
   def start(_type, _args) do
+    Nucleus.Backend.warn_on_local_backends()
+
     children = [
       NucleusWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:nucleus, :dns_cluster_query) || :ignore},

--- a/lib/nucleus/backend.ex
+++ b/lib/nucleus/backend.ex
@@ -1,0 +1,218 @@
+defmodule Nucleus.Backend do
+  @moduledoc """
+  Selection and registry for the swappable backend boundaries.
+
+  Nucleus holds no data of its own; every value it shows is read live from an
+  external system. Each of those systems sits behind a *boundary* — an Elixir
+  behaviour with a `real` implementation that talks to the live system and a
+  `local` implementation that serves in-memory data. Which one runs is
+  configuration, decided per boundary.
+
+  ## Boundaries
+
+  | Boundary | External system | Real impl | Local impl |
+  |---|---|---|---|
+  | `:secrets` | AWS SSM Parameter Store, in the tenant's account | `Nucleus.Secrets.Store.Aws` | `Nucleus.Secrets.Store.Local` |
+  | `:tenant_api` | Tenant backing API (authoritative environment list) | `Nucleus.TenantApi.Http` | `Nucleus.TenantApi.Local` |
+
+  The behaviours and both implementations are delivered by EN-3 (`:tenant_api`)
+  and EN-4 (`:secrets`). This module is the shared scaffolding they plug into,
+  so the module names above are registered here before the modules exist.
+
+  Authentication is deliberately absent. There is no `:auth` boundary and no
+  `AUTH_BACKEND` — auth is the actual security boundary and is never swappable.
+
+  ## Selection
+
+      config :nucleus, :backends, secrets: Nucleus.Secrets.Store.Aws, tenant_api: Nucleus.TenantApi.Http
+
+  `config/dev.exs` and `config/test.exs` override both to the local
+  implementations, so a fresh clone runs and its tests pass with no credentials
+  at all. `config/runtime.exs` allows a per-boundary override through
+  `SECRETS_BACKEND` and `TENANT_API_BACKEND`, each `"real"` (the default) or
+  `"local"`.
+
+  Selection is per boundary rather than one global switch because the pain it
+  solves is per boundary: Parameter Store access needs a Terraform-provisioned
+  cross-account IAM role, and a developer working only on environment listing
+  should not have to obtain one.
+
+  ## Required callback on every boundary behaviour
+
+      @callback health_check() :: :ok | {:error, Nucleus.Backend.Error.t()}
+
+  Readiness must be answerable *through* the boundary. The prototype's readiness
+  check reached into a plugin's private client attribute, which only went
+  unnoticed because there was a single implementation of that plugin.
+
+  ## Errors
+
+  Callbacks return `{:error, Nucleus.Backend.Error.t()}` — never a
+  backend-specific exception, and never a raised one. See `Nucleus.Backend.Error`.
+  """
+
+  require Logger
+
+  @impls %{
+    secrets: %{real: Nucleus.Secrets.Store.Aws, local: Nucleus.Secrets.Store.Local},
+    tenant_api: %{real: Nucleus.TenantApi.Http, local: Nucleus.TenantApi.Local}
+  }
+
+  @boundaries Enum.sort(Map.keys(@impls))
+
+  @type boundary :: :secrets | :tenant_api
+  @type mode :: :real | :local
+
+  @doc """
+  Every known boundary.
+
+      iex> Nucleus.Backend.boundaries()
+      [:secrets, :tenant_api]
+  """
+  @spec boundaries() :: [boundary()]
+  def boundaries, do: @boundaries
+
+  @doc """
+  The module implementing `boundary`, from application configuration.
+
+  Resolved at call time rather than compile time so that `config/runtime.exs`
+  and test overrides both take effect. Raises rather than returning an error
+  tuple: an unconfigured boundary is a deployment mistake, not a runtime
+  condition a LiveView could sensibly render.
+  """
+  @spec impl_for(boundary()) :: module()
+  def impl_for(boundary) when is_atom(boundary) do
+    if boundary not in @boundaries do
+      raise ArgumentError, """
+      unknown backend boundary: #{inspect(boundary)}
+
+      Known boundaries: #{inspect(@boundaries)}.
+      Add the boundary to @impls in Nucleus.Backend if it is a new one.
+      """
+    end
+
+    module = Application.get_env(:nucleus, :backends, [])[boundary]
+
+    cond do
+      is_nil(module) ->
+        raise """
+        no backend configured for boundary #{inspect(boundary)}
+
+        Add it to config/config.exs:
+
+            config :nucleus, :backends, #{boundary}: #{inspect(impl_for_mode!(boundary, :real))}
+
+        Or select the local implementation with #{env_var(boundary)}=local.
+        """
+
+      not Code.ensure_loaded?(module) ->
+        raise """
+        backend for boundary #{inspect(boundary)} is configured as #{inspect(module)}, \
+        which is not a loaded module
+
+        Either the module name is misspelled in config, or it has not been \
+        written yet. The implementations for this boundary are \
+        #{inspect(impl_for_mode!(boundary, :real))} (real) and \
+        #{inspect(impl_for_mode!(boundary, :local))} (local).
+        """
+
+      true ->
+        module
+    end
+  end
+
+  @doc """
+  The registered implementation of `boundary` for `mode`.
+
+  Accepts a string mode so `config/runtime.exs` can hand an environment variable
+  straight in. This is the single source of truth for which module means "real"
+  and which means "local" — the boot warning and the runtime env var override
+  both read it.
+
+      iex> Nucleus.Backend.impl_for_mode!(:secrets, "local")
+      Nucleus.Secrets.Store.Local
+  """
+  @spec impl_for_mode!(boundary(), mode() | String.t()) :: module()
+  def impl_for_mode!(boundary, mode) when is_binary(mode) do
+    case mode do
+      "real" -> impl_for_mode!(boundary, :real)
+      "local" -> impl_for_mode!(boundary, :local)
+      other -> raise ArgumentError, bad_mode_message(boundary, other)
+    end
+  end
+
+  def impl_for_mode!(boundary, mode) when mode in [:real, :local] do
+    case @impls[boundary] do
+      nil -> raise ArgumentError, "unknown backend boundary: #{inspect(boundary)}"
+      impls -> impls[mode]
+    end
+  end
+
+  def impl_for_mode!(boundary, mode), do: raise(ArgumentError, bad_mode_message(boundary, mode))
+
+  @doc """
+  The environment variable that overrides `boundary`'s implementation.
+
+      iex> Nucleus.Backend.env_var(:tenant_api)
+      "TENANT_API_BACKEND"
+  """
+  @spec env_var(boundary()) :: String.t()
+  def env_var(boundary) when boundary in @boundaries do
+    boundary |> Atom.to_string() |> String.upcase() |> Kernel.<>("_BACKEND")
+  end
+
+  @doc """
+  Boundaries currently configured to their local implementation.
+  """
+  @spec local_boundaries() :: [boundary()]
+  def local_boundaries do
+    configured = Application.get_env(:nucleus, :backends, [])
+
+    Enum.filter(@boundaries, fn boundary ->
+      configured[boundary] == impl_for_mode!(boundary, :local)
+    end)
+  end
+
+  @doc """
+  Logs one prominent warning if any boundary is serving local data.
+
+  Called on boot. Local implementations are shipped in the release rather than
+  excluded from it — keeping the build and the package list in sync is its own
+  failure mode, and auth is never swappable, so a misconfigured
+  `*_BACKEND=local` in production serves wrong data to already-authorised users
+  rather than bypassing authorisation. This warning is the cheap, loud signal
+  chosen in place of that packaging complexity.
+  """
+  @spec warn_on_local_backends() :: :ok
+  def warn_on_local_backends do
+    case local_boundaries() do
+      [] ->
+        :ok
+
+      boundaries ->
+        Logger.warning("""
+        LOCAL BACKENDS ACTIVE — the following boundaries are serving in-memory data, not the real system:
+        #{Enum.map_join(boundaries, "\n", &describe_local/1)}
+
+        Nothing displayed for these boundaries reflects the tenant's real state.
+        """)
+
+        :ok
+    end
+  end
+
+  defp describe_local(boundary) do
+    "  * #{boundary} -> #{inspect(impl_for_mode!(boundary, :local))} (#{env_var(boundary)}=local)"
+  end
+
+  defp bad_mode_message(boundary, mode) do
+    """
+    invalid backend mode #{inspect(mode)} for boundary #{inspect(boundary)}
+
+    #{env_var_hint(boundary)} must be "real" or "local".
+    """
+  end
+
+  defp env_var_hint(boundary) when boundary in @boundaries, do: env_var(boundary)
+  defp env_var_hint(_boundary), do: "The backend mode"
+end

--- a/lib/nucleus/backend/error.ex
+++ b/lib/nucleus/backend/error.ex
@@ -1,0 +1,97 @@
+defmodule Nucleus.Backend.Error do
+  @moduledoc """
+  The one error value every backend boundary is allowed to return.
+
+  Backend implementations translate whatever their underlying system raises —
+  an `ExAws` tuple, a `Req.TransportError`, an HTTP 500 body — into this struct
+  and return it as `{:error, %Nucleus.Backend.Error{}}`. Callers pattern-match
+  on `kind` to decide what to show the user.
+
+  **These are returned, never raised.** A `rescue` inside a `handle_event/3` is
+  not an acceptable control-flow mechanism, and a LiveView that had to rescue a
+  backend-specific exception would be coupled to that backend — the exact
+  coupling `Nucleus.Backend` exists to prevent.
+
+  ## Kinds
+
+  The six kinds cover the failure modes the requirements describe. Requirement
+  status codes are binding as *behaviour*, not as literal HTTP responses (see
+  `business-tech-bridge.md`), so each kind carries the meaning rather than the
+  number.
+
+  | `kind` | Meaning | Requirement status code |
+  |---|---|---|
+  | `:invalid` | Caller-supplied input rejected before any backend call | 400 |
+  | `:not_found` | Well-formed identifier, no such resource | 404 |
+  | `:already_exists` | Create conflicted with an existing resource | 409 |
+  | `:auth_expired` | Server-side credentials for the backend expired | 401 |
+  | `:unavailable` | Backend unreachable, timed out, or errored | 503 / 502 |
+  | `:not_configured` | This boundary has no usable configuration | 503 |
+
+  `:auth_expired` is about *Nucleus's* credentials for a backend (an expired
+  assumed role, say), not about the end user's session. Adding a seventh kind
+  means revisiting every `case` that matches on one, which is what
+  `kinds/0` and its test exist to force.
+  """
+
+  @kinds [:not_found, :already_exists, :auth_expired, :unavailable, :not_configured, :invalid]
+
+  @type kind ::
+          :not_found | :already_exists | :auth_expired | :unavailable | :not_configured | :invalid
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          message: String.t(),
+          boundary: atom(),
+          details: map()
+        }
+
+  @enforce_keys [:kind, :message, :boundary]
+  defstruct [:kind, :message, :boundary, details: %{}]
+
+  @doc """
+  Every valid `kind`, so a test can assert exhaustive handling.
+
+      iex> :not_found in Nucleus.Backend.Error.kinds()
+      true
+  """
+  @spec kinds() :: [kind()]
+  def kinds, do: @kinds
+
+  @doc """
+  Builds an error for `boundary`.
+
+  `message` is developer-facing and may be logged; it must never contain secret
+  material. `details` carries structured context (a key, a path, an upstream
+  status) for logging and audit.
+
+      iex> error = Nucleus.Backend.Error.new(:not_found, :secrets, "no such parameter")
+      iex> {error.kind, error.boundary, error.message, error.details}
+      {:not_found, :secrets, "no such parameter", %{}}
+  """
+  @spec new(kind(), atom(), String.t(), map()) :: t()
+  def new(kind, boundary, message, details \\ %{})
+      when kind in @kinds and is_atom(boundary) and is_binary(message) and is_map(details) do
+    %__MODULE__{kind: kind, message: message, boundary: boundary, details: details}
+  end
+
+  @doc """
+  Casts an external string (an env var, a query param) to a `kind`.
+
+  Returns `:error` for anything unrecognised rather than guessing. Deliberately
+  avoids `String.to_atom/1` — this takes untrusted input.
+
+      iex> Nucleus.Backend.Error.cast_kind("auth_expired")
+      {:ok, :auth_expired}
+
+      iex> Nucleus.Backend.Error.cast_kind("teapot")
+      :error
+  """
+  @spec cast_kind(String.t()) :: {:ok, kind()} | :error
+  def cast_kind(value) when is_binary(value) do
+    case Enum.find(@kinds, &(Atom.to_string(&1) == value)) do
+      nil -> :error
+      kind -> {:ok, kind}
+    end
+  end
+end

--- a/lib/nucleus/backend/faults.ex
+++ b/lib/nucleus/backend/faults.ex
@@ -1,0 +1,106 @@
+defmodule Nucleus.Backend.Faults do
+  @moduledoc """
+  Optional latency and error injection for local backend implementations.
+
+  Canned data is bad at exercising loading and error states — a local
+  implementation that always succeeds instantly means the spinner and the
+  "backend unavailable" branch are never seen, and their requirements are never
+  testable. Two environment variables make a local implementation misbehave on
+  demand:
+
+  | Variable | Effect |
+  |---|---|
+  | `LOCAL_LATENCY_MS` | Sleep this many milliseconds before returning |
+  | `LOCAL_FORCE_ERROR` | Return `{:error, %Error{kind: <this kind>}}` instead of succeeding |
+
+  `LOCAL_FORCE_ERROR` takes any `Nucleus.Backend.Error` kind, e.g.
+  `LOCAL_FORCE_ERROR=unavailable` or `LOCAL_FORCE_ERROR=auth_expired`.
+
+  ## Usage
+
+  A local implementation calls `maybe_fault/1` first in every callback and
+  returns its result unchanged if it is not `:ok`:
+
+      def list_environments(scope) do
+        with :ok <- Faults.maybe_fault(:tenant_api) do
+          {:ok, seeded_environments(scope)}
+        end
+      end
+
+  Values are read from the environment on every call, deliberately: a developer
+  can flip a fault on and off without restarting the server.
+
+  Nothing gates this to non-production. It cannot fire unless a boundary is
+  already running its local implementation, which `Nucleus.Backend` warns about
+  loudly on boot.
+  """
+
+  alias Nucleus.Backend.Error
+
+  @latency_var "LOCAL_LATENCY_MS"
+  @error_var "LOCAL_FORCE_ERROR"
+
+  @doc """
+  Applies any configured fault for `boundary`.
+
+  Returns `:ok` when no fault is configured, after sleeping for
+  `LOCAL_LATENCY_MS` if that is set. Returns `{:error, Nucleus.Backend.Error.t()}`
+  when `LOCAL_FORCE_ERROR` names a kind.
+
+  Raises on an unparseable value for either variable. A typo in a fault flag
+  must fail loudly — silently returning `:ok` would turn a test that meant to
+  assert an error path into one that passes for the wrong reason.
+  """
+  @spec maybe_fault(atom()) :: :ok | {:error, Error.t()}
+  def maybe_fault(boundary) when is_atom(boundary) do
+    apply_latency()
+    forced_error(boundary)
+  end
+
+  defp apply_latency do
+    case System.get_env(@latency_var) do
+      nil ->
+        :ok
+
+      "" ->
+        :ok
+
+      value ->
+        case Integer.parse(value) do
+          {ms, ""} when ms >= 0 ->
+            Process.sleep(ms)
+            :ok
+
+          _ ->
+            raise ArgumentError,
+                  "#{@latency_var} must be a non-negative integer, got: #{inspect(value)}"
+        end
+    end
+  end
+
+  defp forced_error(boundary) do
+    case System.get_env(@error_var) do
+      nil ->
+        :ok
+
+      "" ->
+        :ok
+
+      value ->
+        case Error.cast_kind(value) do
+          {:ok, kind} ->
+            {:error,
+             Error.new(kind, boundary, "fault injected via #{@error_var}=#{value}", %{
+               injected: true
+             })}
+
+          :error ->
+            raise ArgumentError, """
+            #{@error_var} must name a Nucleus.Backend.Error kind, got: #{inspect(value)}
+
+            Valid kinds: #{Enum.map_join(Error.kinds(), ", ", &Atom.to_string/1)}.
+            """
+        end
+    end
+  end
+end

--- a/test/nucleus/backend/faults_test.exs
+++ b/test/nucleus/backend/faults_test.exs
@@ -1,0 +1,136 @@
+defmodule Nucleus.Backend.FaultsTest do
+  # Mutates OS environment variables, which are global to the VM.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Faults
+
+  @latency_var "LOCAL_LATENCY_MS"
+  @error_var "LOCAL_FORCE_ERROR"
+
+  setup do
+    on_exit(fn ->
+      System.delete_env(@latency_var)
+      System.delete_env(@error_var)
+    end)
+
+    System.delete_env(@latency_var)
+    System.delete_env(@error_var)
+
+    :ok
+  end
+
+  describe "maybe_fault/1 with no faults configured" do
+    @tag :unit
+    test "returns :ok when neither env var is set" do
+      assert Faults.maybe_fault(:secrets) == :ok
+    end
+
+    @tag :unit
+    test "treats an empty value as unset" do
+      System.put_env(@latency_var, "")
+      System.put_env(@error_var, "")
+
+      assert Faults.maybe_fault(:secrets) == :ok
+    end
+  end
+
+  describe "LOCAL_FORCE_ERROR" do
+    @tag :unit
+    test "auth_expired yields an :auth_expired error, so SEC-S7 is testable" do
+      System.put_env(@error_var, "auth_expired")
+
+      assert {:error, %Error{kind: :auth_expired, boundary: :secrets} = error} =
+               Faults.maybe_fault(:secrets)
+
+      assert error.details == %{injected: true}
+      assert error.message =~ @error_var
+    end
+
+    @tag :unit
+    test "unavailable yields an :unavailable error, so SEC-S1 fail-closed is testable" do
+      System.put_env(@error_var, "unavailable")
+
+      assert {:error, %Error{kind: :unavailable, boundary: :tenant_api}} =
+               Faults.maybe_fault(:tenant_api)
+    end
+
+    @tag :unit
+    test "every error kind can be injected" do
+      for kind <- Error.kinds() do
+        System.put_env(@error_var, Atom.to_string(kind))
+        assert {:error, %Error{kind: ^kind}} = Faults.maybe_fault(:secrets)
+      end
+    end
+
+    @tag :unit
+    test "an unparseable value raises rather than silently returning :ok" do
+      # A typo in a fault flag must not produce a false-passing test.
+      System.put_env(@error_var, "auth-expired")
+
+      error = assert_raise ArgumentError, fn -> Faults.maybe_fault(:secrets) end
+
+      assert error.message =~ @error_var
+      assert error.message =~ "auth-expired"
+      assert error.message =~ "auth_expired"
+    end
+
+    @tag :unit
+    test "is read on every call, so a fault can be flipped without a restart" do
+      assert Faults.maybe_fault(:secrets) == :ok
+
+      System.put_env(@error_var, "not_found")
+      assert {:error, %Error{kind: :not_found}} = Faults.maybe_fault(:secrets)
+
+      System.delete_env(@error_var)
+      assert Faults.maybe_fault(:secrets) == :ok
+    end
+  end
+
+  describe "LOCAL_LATENCY_MS" do
+    @tag :unit
+    test "delays the return by at least the configured duration" do
+      System.put_env(@latency_var, "40")
+
+      {elapsed_us, result} = :timer.tc(fn -> Faults.maybe_fault(:secrets) end)
+
+      assert result == :ok
+      assert elapsed_us >= 40_000
+    end
+
+    @tag :unit
+    test "applies before a forced error, so loading states are exercised too" do
+      System.put_env(@latency_var, "20")
+      System.put_env(@error_var, "unavailable")
+
+      {elapsed_us, result} = :timer.tc(fn -> Faults.maybe_fault(:secrets) end)
+
+      assert {:error, %Error{kind: :unavailable}} = result
+      assert elapsed_us >= 20_000
+    end
+
+    @tag :unit
+    test "accepts zero" do
+      System.put_env(@latency_var, "0")
+
+      assert Faults.maybe_fault(:secrets) == :ok
+    end
+
+    @tag :unit
+    test "an unparseable value raises rather than being ignored" do
+      System.put_env(@latency_var, "40ms")
+
+      error = assert_raise ArgumentError, fn -> Faults.maybe_fault(:secrets) end
+
+      assert error.message =~ @latency_var
+      assert error.message =~ "non-negative integer"
+    end
+
+    @tag :unit
+    test "a negative value raises" do
+      System.put_env(@latency_var, "-1")
+
+      assert_raise ArgumentError, fn -> Faults.maybe_fault(:secrets) end
+    end
+  end
+end

--- a/test/nucleus/backend_test.exs
+++ b/test/nucleus/backend_test.exs
@@ -1,0 +1,216 @@
+defmodule Nucleus.BackendTest do
+  # Mutates :nucleus, :backends application config, which is global.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Nucleus.Backend
+  alias Nucleus.Backend.Error
+
+  doctest Nucleus.Backend
+  doctest Nucleus.Backend.Error
+
+  # Any loaded module satisfies impl_for/1 — it checks that the configured module
+  # exists, not that it implements a behaviour. The real and local
+  # implementations arrive in EN-3/EN-4, so tests that need a *loaded* module
+  # stand in with one that already exists.
+  @loaded_module Nucleus.Backend.Error
+
+  setup do
+    original = Application.get_env(:nucleus, :backends)
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+    :ok
+  end
+
+  defp put_backend(boundary, module) do
+    configured = Application.get_env(:nucleus, :backends, [])
+    Application.put_env(:nucleus, :backends, Keyword.put(configured, boundary, module))
+  end
+
+  describe "boundaries/0" do
+    @tag :unit
+    test "covers secrets and tenant_api, and no auth boundary" do
+      assert Backend.boundaries() == [:secrets, :tenant_api]
+      refute :auth in Backend.boundaries()
+    end
+  end
+
+  describe "impl_for/1" do
+    @tag :unit
+    test "returns the configured module for each boundary" do
+      for boundary <- Backend.boundaries() do
+        put_backend(boundary, @loaded_module)
+        assert Backend.impl_for(boundary) == @loaded_module
+      end
+    end
+
+    @tag :unit
+    test "raises an actionable error for an unknown boundary" do
+      # Built at runtime: the compiler's type checker rejects the literal, since
+      # it knows :nomad is outside the declared boundary union.
+      unknown = String.to_atom("nomad")
+
+      error = assert_raise ArgumentError, fn -> Backend.impl_for(unknown) end
+
+      assert error.message =~ "unknown backend boundary: :nomad"
+      assert error.message =~ "Known boundaries: [:secrets, :tenant_api]"
+    end
+
+    @tag :unit
+    test "raises an actionable error when the boundary is unconfigured" do
+      Application.put_env(:nucleus, :backends, [])
+
+      error = assert_raise RuntimeError, fn -> Backend.impl_for(:secrets) end
+
+      assert error.message =~ "no backend configured for boundary :secrets"
+      assert error.message =~ "SECRETS_BACKEND=local"
+    end
+
+    @tag :unit
+    test "raises when configured to a module that does not exist" do
+      put_backend(:secrets, Nucleus.Secrets.Store.DoesNotExist)
+
+      error = assert_raise RuntimeError, fn -> Backend.impl_for(:secrets) end
+
+      assert error.message =~ "Nucleus.Secrets.Store.DoesNotExist"
+      assert error.message =~ "not a loaded module"
+      # Names both alternatives, so the reader knows what to configure instead.
+      assert error.message =~ "Nucleus.Secrets.Store.Aws"
+      assert error.message =~ "Nucleus.Secrets.Store.Local"
+    end
+  end
+
+  describe "impl_for_mode!/2" do
+    @tag :unit
+    test "resolves both modes for every boundary" do
+      for boundary <- Backend.boundaries() do
+        assert is_atom(Backend.impl_for_mode!(boundary, :real))
+        assert is_atom(Backend.impl_for_mode!(boundary, :local))
+        refute Backend.impl_for_mode!(boundary, :real) == Backend.impl_for_mode!(boundary, :local)
+      end
+    end
+
+    @tag :unit
+    test "accepts the string modes runtime.exs reads from the environment" do
+      assert Backend.impl_for_mode!(:secrets, "real") == Backend.impl_for_mode!(:secrets, :real)
+      assert Backend.impl_for_mode!(:secrets, "local") == Backend.impl_for_mode!(:secrets, :local)
+    end
+
+    @tag :unit
+    test "raises on an unrecognised mode rather than falling back to real" do
+      error = assert_raise ArgumentError, fn -> Backend.impl_for_mode!(:secrets, "Local") end
+
+      assert error.message =~ "invalid backend mode \"Local\""
+      assert error.message =~ "SECRETS_BACKEND"
+    end
+  end
+
+  describe "env_var/1" do
+    @tag :unit
+    test "matches the documented variable names" do
+      assert Backend.env_var(:secrets) == "SECRETS_BACKEND"
+      assert Backend.env_var(:tenant_api) == "TENANT_API_BACKEND"
+    end
+  end
+
+  describe "local backend warning" do
+    @tag :unit
+    test "config/test.exs selects the local implementation for every boundary" do
+      # Guards against drift between the literal module names in config and the
+      # registry in Nucleus.Backend — config files cannot call the registry.
+      assert Backend.local_boundaries() == Backend.boundaries()
+    end
+
+    @tag :unit
+    test "warns once, naming each local boundary and its override variable" do
+      log = capture_log(fn -> assert Backend.warn_on_local_backends() == :ok end)
+
+      assert log =~ "LOCAL BACKENDS ACTIVE"
+      assert log =~ "secrets -> Nucleus.Secrets.Store.Local (SECRETS_BACKEND=local)"
+      assert log =~ "tenant_api -> Nucleus.TenantApi.Local (TENANT_API_BACKEND=local)"
+    end
+
+    @tag :unit
+    test "stays silent when every boundary is real" do
+      for boundary <- Backend.boundaries() do
+        put_backend(boundary, Backend.impl_for_mode!(boundary, :real))
+      end
+
+      assert Backend.local_boundaries() == []
+      assert capture_log(fn -> Backend.warn_on_local_backends() end) == ""
+    end
+  end
+
+  describe "Error" do
+    @tag :unit
+    test "new/4 populates boundary and defaults details to %{}" do
+      error = Error.new(:not_found, :secrets, "no such parameter")
+
+      assert %Error{kind: :not_found, boundary: :secrets, message: "no such parameter"} = error
+      assert error.details == %{}
+    end
+
+    @tag :unit
+    test "new/4 carries structured details" do
+      error = Error.new(:unavailable, :tenant_api, "timeout", %{status: 504})
+
+      assert error.details == %{status: 504}
+    end
+
+    @tag :unit
+    test "new/4 rejects a kind outside the union" do
+      # Built at runtime for the same reason as above.
+      invalid_kind = String.to_atom("teapot")
+
+      assert_raise FunctionClauseError, fn -> Error.new(invalid_kind, :secrets, "nope") end
+    end
+
+    @tag :unit
+    test "kinds/0 matches the @type kind union" do
+      # The guard that stops a seventh kind being added without every `case`
+      # that matches on one being revisited.
+      assert Enum.sort(Error.kinds()) == Enum.sort(declared_kinds())
+    end
+
+    @tag :unit
+    test "kinds/0 covers every requirement failure mode" do
+      assert Enum.sort(Error.kinds()) ==
+               Enum.sort([
+                 :invalid,
+                 :not_found,
+                 :already_exists,
+                 :auth_expired,
+                 :unavailable,
+                 :not_configured
+               ])
+    end
+
+    @tag :unit
+    test "cast_kind/1 round-trips every kind and rejects anything else" do
+      for kind <- Error.kinds() do
+        assert Error.cast_kind(Atom.to_string(kind)) == {:ok, kind}
+      end
+
+      assert Error.cast_kind("teapot") == :error
+      assert Error.cast_kind("") == :error
+    end
+
+    @tag :unit
+    test "is a plain struct, not an exception" do
+      # Backends return these; they never raise them. If Error ever became an
+      # exception, `rescue` would become a plausible control-flow choice in a
+      # handle_event/3.
+      refute function_exported?(Error, :exception, 1)
+    end
+  end
+
+  # The kinds declared by `@type kind`, read back out of the compiled type chunk.
+  defp declared_kinds do
+    {:ok, types} = Code.Typespec.fetch_types(Error)
+
+    {:type, {:kind, {:type, _meta, :union, members}, []}} =
+      Enum.find(types, &match?({:type, {:kind, _definition, []}}, &1))
+
+    Enum.map(members, fn {:atom, _line, kind} -> kind end)
+  end
+end


### PR DESCRIPTION
Closes #2.

Shared scaffolding for the swappable backend boundaries. No concrete boundary — EN-3 (`:tenant_api`) and EN-4 (`:secrets`) define the behaviours and both implementations; this gives them something to plug into.

## What landed

**`Nucleus.Backend.Error`** — a plain struct with `kind`, `message`, `boundary`, `details`, and `kinds/0`. Deliberately *not* an exception: backends return `{:error, %Error{}}` so a LiveView selects its message by pattern-matching on `kind`, rather than rescuing in a `handle_event/3` — which cannot be checked for exhaustiveness and would couple the LiveView to a specific backend.

Six kinds, encoding the requirement status codes as *behaviour* rather than as literal HTTP responses (per `business-tech-bridge.md`):

| `kind` | Meaning | Status code |
|---|---|---|
| `:invalid` | Input rejected before any backend call | 400 |
| `:not_found` | Well-formed identifier, no such resource | 404 |
| `:already_exists` | Create conflicted | 409 |
| `:auth_expired` | Nucleus's credentials for the backend expired | 401 |
| `:unavailable` | Unreachable, timed out, errored | 503 / 502 |
| `:not_configured` | Boundary has no usable configuration | 503 |

`:invalid` is split out from the prototype's five classes — input rejected before any backend call is not a backend failure, and conflating the two is exactly how `KeyError` came to mean two things there.

**`Nucleus.Backend`** — the `boundary -> %{real:, local:}` registry, `impl_for/1`, and the boot warning. Resolution happens at call time so `runtime.exs` and test overrides both take effect. It **raises** on an unknown boundary, an unconfigured one, or a module that isn't loaded: a deployment mistake, not a runtime condition a LiveView could sensibly render. Every message names the boundary and both of its implementations.

**Per-boundary selection.** `config.exs` picks real, `dev.exs`/`test.exs` pick local, `runtime.exs` overrides per boundary via `SECRETS_BACKEND` / `TENANT_API_BACKEND` (`"real"` | `"local"`, unrecognised values raise at boot). Not one global switch — the cost being avoided is specific to Parameter Store's cross-account role, so a developer wanting a real tenant API with a local secrets store shouldn't face an all-or-nothing choice. **No `AUTH_BACKEND`**; auth is the actual security boundary and is never swappable.

**`Nucleus.Backend.Faults`** — `LOCAL_LATENCY_MS` and `LOCAL_FORCE_ERROR`. Treated as required, not a convenience: SEC-S1 (fail closed on `:unavailable`) and SEC-S7 (`:auth_expired` → re-authentication) are not testable at all without it. Read on every call so a fault flips without a restart, and both variables **raise** on an unparseable value — a typo in a fault flag that silently returned `:ok` would turn a test asserting an error path into one that passes for the wrong reason.

**Boot warning** — `Nucleus.Application.start/2` logs one warning naming every boundary serving in-memory data and the variable that switched it. Local implementations ship in the release rather than being excluded from it: keeping a build stage and package list in sync is its own silent-failure mode, and because auth is never swappable a stray `*_BACKEND=local` in production shows wrong data to already-authorised users — a functional bug, not a bypass.

**`docs/adr/0002-backend-adapter-boundaries.md`** — records all of the above, and says explicitly which decisions carry over from wiki ADR-0001/0007 and which change shape because this is Elixir/LiveView rather than FastAPI/React (behaviour not `Protocol`; `@behaviour` + `--warnings-as-errors` replaces `mypy` plus a hand-written conformance module).

## Two things not spelled out in the ticket plan

**The boot warning needs to know which modules count as "local", and `config.exs` can't ask.** Config is evaluated before `Nucleus.Backend` exists, so the default module names have to be literals there. Rather than deriving "local" from a module-name suffix — stringly-typed, defeated by a rename — the registry in `Nucleus.Backend` is the single source of truth, `runtime.exs` asks it (runtime config runs after compilation), and a unit test asserts the test-env config equals the registry's local implementations. That test is what catches drift.

**`impl_for/1` raises for both boundaries today.** `Nucleus.Secrets.Store.Local` and `Nucleus.TenantApi.Local` don't exist until EN-4/EN-3, and the "not a loaded module" message names them. Nothing calls `impl_for/1` yet, so this is latent by design rather than broken.

## `health_check/0`

Not defined here — this ticket adds no behaviour. It's recorded in the ADR and `Nucleus.Backend`'s moduledoc as a requirement on the behaviours EN-3/EN-4 define, so readiness is answerable *through* the boundary. The prototype's `/ready` reached into a plugin's private client attribute, which went unnoticed only because there was one implementation.

## Tests

43 passing (36 tests, 7 doctests). Both new files are `async: false` — one mutates application config, the other OS environment variables.

The notable one: `kinds/0 matches the @type kind union` reads the union back out of the compiled type chunk via `Code.Typespec.fetch_types/1` and asserts the two agree. Adding a seventh kind fails that test until it's added to both, which is the prompt to revisit every `case` matching on one.

Also covered: `impl_for/1`'s three raise paths, string and atom modes, unrecognised modes not falling back to real, the warning firing and staying silent, every kind being injectable, and latency applying before a forced error so loading states are exercised too.

Verified the runtime override end to end — `SECRETS_BACKEND=real` alone flips one boundary and deep-merge preserves the other; `SECRETS_BACKEND=bogus` fails at boot.

## Out of scope

Either concrete boundary (EN-3, EN-4), a Nomad boundary, a readiness endpoint consuming `health_check/0` (`OPS-*`), and conformance checking beyond `@behaviour`. No mocking library — real local implementations plus EN-8's contract suite instead; adding `Mox`/`Hammox` later would be its own decision.

`mix precommit` passes.
