### PR TITLE
EN-3: Tenant API adapter — list_environments/1 with Req impl and seeded local impl

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,18 @@ config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Aws,
   tenant_api: Nucleus.TenantApi.Http
 
+# The tenant's backing API — the authority on environments. `base_url` has no
+# default on purpose: there is no sensible host to fall back to, and a boundary
+# that quietly talks to the wrong one is worse than one that reports
+# `:not_configured`. runtime.exs fills it from TENANT_API_BASE_URL.
+#
+# Connect and receive timeouts are separate. They fail for different reasons, and
+# an unbounded call here would hang a LiveView mount.
+config :nucleus, Nucleus.TenantApi.Http,
+  base_url: nil,
+  connect_timeout_ms: 5_000,
+  receive_timeout_ms: 10_000
+
 # Configure LiveView
 config :phoenix_live_view,
   # the attribute set on all root tags. Used for Phoenix.LiveView.ColocatedCSS.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -40,6 +40,35 @@ for boundary <- Nucleus.Backend.boundaries(),
   config :nucleus, :backends, [{boundary, Nucleus.Backend.impl_for_mode!(boundary, mode)}]
 end
 
+# The tenant's backing API. Needed only when the :tenant_api boundary is running
+# its real implementation — a developer running fully local must not have to
+# invent a URL to boot the app.
+#
+# There is deliberately **no boot-time check** that the base URL is present. A
+# missing one surfaces as `%Nucleus.Backend.Error{kind: :not_configured}` on the
+# call, because the adapter must never crash and must never fall back to a
+# default host. A boot check could not be written usefully anyway: prod defaults
+# to the real implementation with TENANT_API_BACKEND *unset*, so it would have to
+# fire on a variable's absence rather than on its value.
+#
+# The timeouts are different — a value that is present but not a number is a
+# typo, and `String.to_integer/1` raising at boot is the right response to it.
+tenant_api_config =
+  [
+    base_url: System.get_env("TENANT_API_BASE_URL"),
+    connect_timeout_ms: System.get_env("TENANT_API_CONNECT_TIMEOUT_MS"),
+    receive_timeout_ms: System.get_env("TENANT_API_RECEIVE_TIMEOUT_MS")
+  ]
+  |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
+  |> Enum.map(fn
+    {:base_url, value} -> {:base_url, value}
+    {key, value} -> {key, String.to_integer(value)}
+  end)
+
+if tenant_api_config != [] do
+  config :nucleus, Nucleus.TenantApi.Http, tenant_api_config
+end
+
 if config_env() == :dev do
   # Reload browser tabs when matching files change.
   config :nucleus, NucleusWeb.Endpoint,

--- a/lib/nucleus/application.ex
+++ b/lib/nucleus/application.ex
@@ -13,6 +13,10 @@ defmodule Nucleus.Application do
       NucleusWeb.Telemetry,
       {DNSCluster, query: Application.get_env(:nucleus, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: Nucleus.PubSub},
+      # State for the local backend implementations, in every environment. They
+      # ship in the release but are never selected in production, so gating this
+      # would only add a "seed owner missing" branch for readers to handle.
+      Nucleus.Backend.Seed,
       # Start a worker by calling: Nucleus.Worker.start_link(arg)
       # {Nucleus.Worker, arg},
       # Start to serve requests, typically the last entry

--- a/lib/nucleus/backend/seed.ex
+++ b/lib/nucleus/backend/seed.ex
@@ -1,0 +1,157 @@
+defmodule Nucleus.Backend.Seed do
+  @moduledoc """
+  The seeded state that local backend implementations serve, held in one `Agent`.
+
+  Nucleus has no datastore (`docs/adr/0001-no-local-datastore.md`), so a local
+  implementation has nowhere to keep the data it pretends to own. This `Agent`
+  is that nowhere: it parses `priv/backends/local_seed.json` once at start-up
+  and holds the decoded document as its state, offering read *and* write access
+  for the lifetime of the node. Restart the node and the seed is back to what is
+  checked in.
+
+  An `Agent` rather than a `GenServer` over an ETS table: an `Agent` is a
+  `GenServer` specialised for exactly this — holding state on behalf of other
+  processes — and a decoded JSON document is a map that needs no table.
+
+  ## Namespaced by boundary
+
+  The file carries one top-level key per boundary rather than a flat document,
+  so the boundaries can be built and changed independently:
+
+      {
+        "tenant_api": { "environments": [...] },
+        "secrets": { ... }
+      }
+
+  Each boundary reads only its own section, through `read/2`, and must ignore
+  the others. A section this module knows nothing about is served back
+  unchanged, so a new boundary needs no change here.
+
+  ## Started everywhere
+
+  This is in the supervision tree in every environment, not gated to `:dev` and
+  `:test`. The local implementations ship in the release regardless — see
+  `docs/adr/0002-backend-adapter-boundaries.md` on why they are not excluded
+  from the build — but they are never *selected* in production, so a conditional
+  child spec would buy nothing while adding a "seed owner missing" branch for
+  every reader to handle.
+
+  ## A malformed seed fails at boot
+
+  A missing or undecodable file raises from `init`, which brings the node down.
+  The file is checked in, so it cannot be valid in CI and invalid in
+  production; the only way to reach this is a packaging mistake or a bad edit,
+  and both should be loud. This is the single error path for the seed — no
+  caller of `read/2` has to consider a parse failure.
+  """
+
+  use Agent
+
+  @default_path "backends/local_seed.json"
+
+  @doc """
+  Starts the seed owner.
+
+  ## Options
+
+    * `:name` — process name, `#{inspect(__MODULE__)}` by default. Tests that
+      want an isolated instance over a fixture pass their own.
+    * `:path` — absolute path to the seed file. Defaults to
+      `priv/#{@default_path}` inside the application directory, which resolves
+      correctly from a release as well as from a checkout.
+
+  """
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    path = Keyword.get(opts, :path, default_path())
+
+    Agent.start_link(fn -> %{path: path, document: load!(path)} end, name: name)
+  end
+
+  @doc """
+  The default seed file path.
+  """
+  @spec default_path() :: Path.t()
+  def default_path, do: Application.app_dir(:nucleus, Path.join("priv", @default_path))
+
+  @doc """
+  The section of the seed belonging to `boundary`.
+
+  Returns `nil` when the seed carries no such section, which is how a boundary
+  whose implementation has landed before its seed data reads: absent, not
+  broken. Callers that cannot work without their section should say so in their
+  own vocabulary — a `Nucleus.Backend.Error` of kind `:not_configured` — rather
+  than crashing here.
+  """
+  @spec read(atom(), GenServer.server()) :: term() | nil
+  def read(boundary, server \\ __MODULE__) when is_atom(boundary) do
+    Agent.get(server, &get_in(&1, [:document, key(boundary)]))
+  end
+
+  @doc """
+  Replaces `boundary`'s section with `section`.
+  """
+  @spec write(atom(), term(), GenServer.server()) :: :ok
+  def write(boundary, section, server \\ __MODULE__) when is_atom(boundary) do
+    Agent.update(server, &put_in(&1, [:document, key(boundary)], section))
+  end
+
+  @doc """
+  Replaces `boundary`'s section with `fun` applied to its current value.
+
+  The update runs inside the `Agent`, so a read-modify-write from two processes
+  cannot interleave.
+
+      Nucleus.Backend.Seed.update(:secrets, fn secrets ->
+        Map.put(secrets, "prod", %{})
+      end)
+
+  """
+  @spec update(atom(), (term() -> term()), GenServer.server()) :: :ok
+  def update(boundary, fun, server \\ __MODULE__)
+      when is_atom(boundary) and is_function(fun, 1) do
+    Agent.update(server, fn %{document: document} = state ->
+      %{
+        state
+        | document: Map.put(document, key(boundary), fun.(Map.get(document, key(boundary))))
+      }
+    end)
+  end
+
+  @doc """
+  Re-reads the seed file, discarding every runtime mutation.
+
+  The seed is mutable and the owner outlives a single test, so a test that
+  writes must undo it or it leaks into whatever runs next. Call this from
+  `setup` rather than trying to reverse individual writes.
+  """
+  @spec reset(GenServer.server()) :: :ok
+  def reset(server \\ __MODULE__) do
+    Agent.update(server, fn %{path: path} = state -> %{state | document: load!(path)} end)
+  end
+
+  defp key(boundary), do: Atom.to_string(boundary)
+
+  defp load!(path) do
+    case File.read(path) do
+      {:ok, contents} ->
+        decode!(contents, path)
+
+      {:error, reason} ->
+        raise "cannot read backend seed at #{path}: #{:file.format_error(reason)}"
+    end
+  end
+
+  defp decode!(contents, path) do
+    case Jason.decode(contents) do
+      {:ok, %{} = seed} ->
+        seed
+
+      {:ok, other} ->
+        raise "backend seed at #{path} must be a JSON object, got: #{inspect(other)}"
+
+      {:error, error} ->
+        raise "backend seed at #{path} is not valid JSON: #{Exception.message(error)}"
+    end
+  end
+end

--- a/lib/nucleus/tenant_api.ex
+++ b/lib/nucleus/tenant_api.ex
@@ -1,0 +1,88 @@
+defmodule Nucleus.TenantApi do
+  @moduledoc """
+  The boundary to the tenant's own backing API — the authority on environments.
+
+  Nucleus is **not** authoritative for environments. The tenant's API is, and
+  `SEC-A15`–`SEC-A17` require an environment name be validated against it
+  *before* any Parameter Store path is built, with the request rejected outright
+  when validation is unavailable. This boundary supplies the list that
+  validation reads; the validation ladder itself is SEC-S1.
+
+  Two implementations, selected per boundary by `TENANT_API_BACKEND` — see
+  `Nucleus.Backend`:
+
+  | Mode | Module | |
+  |---|---|---|
+  | `real` | `Nucleus.TenantApi.Http` | `Req` against the tenant's API |
+  | `local` | `Nucleus.TenantApi.Local` | `priv/backends/local_seed.json` |
+
+  ## Call through this module, not an implementation
+
+  `list_environments/1` and `health_check/0` here resolve the implementation on
+  every call. Nothing outside this module should name `Http` or `Local` — that
+  is the coupling `Nucleus.Backend` exists to prevent, and resolving per call is
+  what lets `config/runtime.exs` and a test override both take effect.
+
+  ## Archived environments are returned
+
+  Every environment comes back, archived ones included. `ENV-A06` requires an
+  archived environment stay reachable by direct URL and usable for secrets
+  management, while `NAV-A04` requires it be hidden from the sidebar. Those are
+  different answers to different questions, so filtering belongs to the caller
+  that knows which question it is asking. An adapter that dropped them would
+  make `ENV-A06` unimplementable.
+
+  ## On the token argument
+
+  `list_environments/1` takes the signed-in user's access token, so the tenant's
+  API applies *their* permissions rather than a service account's.
+
+  Authentication is deferred to EN-6, so callers pass `nil` today and the HTTP
+  implementation sends no `Authorization` header. The parameter exists now
+  regardless: adding it later would touch every call site, and the alternative —
+  inventing a service-account token to fill the gap — would build in exactly the
+  permission escalation the passthrough model exists to avoid.
+  """
+
+  alias Nucleus.Backend
+  alias Nucleus.Backend.Error
+  alias Nucleus.TenantApi.Environment
+
+  @boundary :tenant_api
+
+  @doc """
+  Every environment the tenant's API reports, archived ones included.
+  """
+  @callback list_environments(token :: String.t() | nil) ::
+              {:ok, [Environment.t()]} | {:error, Error.t()}
+
+  @doc """
+  Whether this boundary can reach the system behind it.
+  """
+  @callback health_check() :: :ok | {:error, Error.t()}
+
+  @doc """
+  The boundary name, for `Nucleus.Backend` and error construction.
+  """
+  @spec boundary() :: atom()
+  def boundary, do: @boundary
+
+  @doc """
+  Lists environments through the configured implementation.
+
+  See the module documentation on why `token` may be `nil`, and why archived
+  environments are included.
+  """
+  @spec list_environments(String.t() | nil) :: {:ok, [Environment.t()]} | {:error, Error.t()}
+  def list_environments(token) when is_binary(token) or is_nil(token) do
+    impl().list_environments(token)
+  end
+
+  @doc """
+  Checks the configured implementation can reach the tenant's API.
+  """
+  @spec health_check() :: :ok | {:error, Error.t()}
+  def health_check, do: impl().health_check()
+
+  defp impl, do: Backend.impl_for(@boundary)
+end

--- a/lib/nucleus/tenant_api/environment.ex
+++ b/lib/nucleus/tenant_api/environment.ex
@@ -1,0 +1,186 @@
+defmodule Nucleus.TenantApi.Environment do
+  @moduledoc """
+  One of the tenant's deployment stages, as reported by their backing API.
+
+  Nucleus does not own environments (`ENV-A07`) — it reads them live and
+  displays them. This struct is the shape the rest of the application sees.
+
+  ## Translation happens here, once
+
+  The backing API speaks camelCase (`shortName`, `accentColor`, `isArchived`);
+  this codebase is snake_case, and a boolean reads as a predicate (`archived?`)
+  per `AGENTS.md`. `from_api/1` is the only place that translation happens, and
+  both `Nucleus.TenantApi.Http` and `Nucleus.TenantApi.Local` go through it —
+  which is also what stops the two implementations drifting apart on shape. No
+  camelCase key reaches a LiveView or a template.
+
+  ## `short_name` is enforced
+
+  `short_name` is the URL path segment *and* a Parameter Store path segment. An
+  `%Environment{}` carrying `nil` there would build a path that silently
+  addresses the wrong thing, so it is an enforced key: the struct cannot be
+  constructed without one. `from_api/1` rejects a missing or blank value rather
+  than defaulting it, and its callers fail the whole call rather than dropping
+  the element (see `Nucleus.TenantApi.Http`).
+
+  ## One absence case per field
+
+  Optional strings are `nil` when the API omits them *or* sends a blank string,
+  so a caller has exactly one absence to handle. `ENV-A02` requires a
+  description be "shown when the environment has one, and omitted when it does
+  not" — a template testing both `nil` and `""` is a template that will
+  eventually test only one.
+
+  `categories` is always a list of strings, never `nil`, for the same reason.
+  """
+
+  @enforce_keys [:short_name]
+  defstruct [
+    :short_name,
+    :label,
+    :iri,
+    :accent_color,
+    :description,
+    categories: [],
+    archived?: false
+  ]
+
+  @type t :: %__MODULE__{
+          short_name: String.t(),
+          label: String.t() | nil,
+          iri: String.t() | nil,
+          accent_color: String.t() | nil,
+          description: String.t() | nil,
+          categories: [String.t()],
+          archived?: boolean()
+        }
+
+  @type reason ::
+          :not_an_object
+          | :missing_short_name
+          | :invalid_label
+          | :invalid_iri
+          | :invalid_accent_color
+          | :invalid_description
+          | :invalid_categories
+          | :invalid_archived
+
+  @doc """
+  Builds an `%Environment{}` from one decoded API object.
+
+  Returns `{:error, reason}` on anything unexpected rather than guessing. The
+  caller turns the reason into a `Nucleus.Backend.Error` in its own boundary's
+  vocabulary, because this module has no opinion about whether a bad payload is
+  `:unavailable` or something else.
+
+      iex> {:ok, env} = Nucleus.TenantApi.Environment.from_api(%{"shortName" => "prod", "description" => ""})
+      iex> {env.short_name, env.description, env.categories, env.archived?}
+      {"prod", nil, [], false}
+
+      iex> Nucleus.TenantApi.Environment.from_api(%{"label" => "Production"})
+      {:error, :missing_short_name}
+  """
+  @spec from_api(map()) :: {:ok, t()} | {:error, reason()}
+  def from_api(%{} = attrs) do
+    with {:ok, short_name} <- required_string(attrs, "shortName", :missing_short_name),
+         {:ok, label} <- optional_string(attrs, "label", :invalid_label),
+         {:ok, iri} <- optional_string(attrs, "iri", :invalid_iri),
+         {:ok, accent_color} <- optional_string(attrs, "accentColor", :invalid_accent_color),
+         {:ok, description} <- optional_string(attrs, "description", :invalid_description),
+         {:ok, categories} <- categories(attrs),
+         {:ok, archived?} <- archived(attrs) do
+      {:ok,
+       %__MODULE__{
+         short_name: short_name,
+         label: label,
+         iri: iri,
+         accent_color: accent_color,
+         description: description,
+         categories: categories,
+         archived?: archived?
+       }}
+    end
+  end
+
+  def from_api(_other), do: {:error, :not_an_object}
+
+  @doc """
+  Builds a list of environments, failing on the first unusable element.
+
+  **All or nothing, deliberately.** Returning the elements that happened to
+  parse would hand a caller a list that is quietly missing an environment — and
+  the caller has no way to tell a tenant with four environments from a tenant
+  with five and one bad record. `SEC-A15`–`A17` want a definite answer or a
+  definite failure; a plausible-looking subset is neither.
+
+      iex> {:ok, envs} = Nucleus.TenantApi.Environment.from_api_list([%{"shortName" => "prod"}])
+      iex> Enum.map(envs, & &1.short_name)
+      ["prod"]
+
+      iex> Nucleus.TenantApi.Environment.from_api_list([%{"shortName" => "prod"}, %{"shortName" => " "}])
+      {:error, :missing_short_name}
+  """
+  @spec from_api_list(list()) :: {:ok, [t()]} | {:error, reason()}
+  def from_api_list(list) when is_list(list) do
+    Enum.reduce_while(list, {:ok, []}, fn attrs, {:ok, acc} ->
+      case from_api(attrs) do
+        {:ok, environment} -> {:cont, {:ok, [environment | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, environments} -> {:ok, Enum.reverse(environments)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def from_api_list(_other), do: {:error, :not_an_object}
+
+  defp required_string(attrs, key, reason) do
+    case blank_to_nil(Map.get(attrs, key)) do
+      nil -> {:error, reason}
+      value when is_binary(value) -> {:ok, value}
+      _other -> {:error, reason}
+    end
+  end
+
+  defp optional_string(attrs, key, reason) do
+    case Map.get(attrs, key) do
+      nil -> {:ok, nil}
+      value when is_binary(value) -> {:ok, blank_to_nil(value)}
+      _other -> {:error, reason}
+    end
+  end
+
+  defp categories(attrs) do
+    case Map.get(attrs, "categories") do
+      nil ->
+        {:ok, []}
+
+      list when is_list(list) ->
+        if Enum.all?(list, &is_binary/1),
+          do: {:ok, list},
+          else: {:error, :invalid_categories}
+
+      _other ->
+        {:error, :invalid_categories}
+    end
+  end
+
+  defp archived(attrs) do
+    case Map.get(attrs, "isArchived") do
+      nil -> {:ok, false}
+      value when is_boolean(value) -> {:ok, value}
+      _other -> {:error, :invalid_archived}
+    end
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      _trimmed -> value
+    end
+  end
+
+  defp blank_to_nil(value), do: value
+end

--- a/lib/nucleus/tenant_api/http.ex
+++ b/lib/nucleus/tenant_api/http.ex
@@ -1,0 +1,269 @@
+defmodule Nucleus.TenantApi.Http do
+  @moduledoc """
+  The tenant API over HTTP, using `Req`.
+
+  ## The destination is deployment configuration, never a caller's choice
+
+  The base URL comes from `TENANT_API_BASE_URL` and the path is the literal
+  `/environment`. No caller input reaches the URL, which is the guarantee
+  `PRX-A07` makes: a boundary that could be pointed at an arbitrary host by its
+  caller is an SSRF primitive, and this one takes no argument that could do it.
+
+  A missing, blank or unparseable base URL is `{:error, %Error{kind:
+  :not_configured}}` **with no request attempted** — never a crash, and never a
+  request to some default host.
+
+  ## Failure is prompt and total
+
+  `retry: false`. `SEC-A17` requires a request be rejected outright when
+  environment validation is unavailable, and rejection has to be *prompt*: a
+  retry ladder turns a clean fail-closed rejection into a LiveView `mount` that
+  hangs. Connect and receive timeouts are set explicitly and separately — they
+  fail for different reasons, and one knob for both forces one of them wrong.
+
+  `redirect: false`. A redirect is an unexpected response from this API, and
+  following one risks carrying the user's `Authorization` header to whatever host
+  the redirect names. It maps to `:unavailable` like any other unexpected status.
+
+  ## A bad element fails the whole call
+
+  An element with a missing or blank `shortName` fails the entire request. The
+  adapter does not drop it and does not emit an `%Environment{}` without a short
+  name — that value builds Parameter Store paths, so a silently absent one is a
+  security-adjacent defect rather than a cosmetic one. See
+  `Nucleus.TenantApi.Environment.from_api_list/1`.
+
+  ## Never log the token, never log the body
+
+  Only the status, a per-call request identifier, and — on transport failure —
+  the error's reason. A response body may contain anything; a token must not be
+  written anywhere. The request identifier exists so a user-reported failure can
+  be correlated with a log line without either.
+
+  ## Assumed response shape
+
+  A top-level JSON array of objects, per the wiki's Environments contract. This
+  is asserted rather than guessed at: an unexpected shape is `:unavailable`, not
+  a best-effort parse. If a real tenant API turns out to wrap the list in an
+  envelope, `unwrap/1` is the single place that changes.
+  """
+
+  @behaviour Nucleus.TenantApi
+
+  require Logger
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.TenantApi
+  alias Nucleus.TenantApi.Environment
+
+  @path "/environment"
+  @default_connect_timeout_ms 5_000
+  @default_receive_timeout_ms 10_000
+
+  @impl Nucleus.TenantApi
+  def list_environments(token) do
+    request_id = request_id()
+
+    case perform(token, request_id) do
+      {:response, 200, body} ->
+        decode(body, request_id)
+
+      {:response, status, _body} when status in [401, 403] ->
+        {:error,
+         error(:auth_expired, "the tenant API rejected our credentials", %{
+           status: status,
+           request_id: request_id
+         })}
+
+      # 400, 404, 429, 5xx and anything else. Each has its own cause but the same
+      # consequence for a caller: no authoritative environment list exists right
+      # now, so `SEC-A17` fails closed. An explicit catch-all, so no status can
+      # fall through to incidental behaviour.
+      {:response, status, _body} ->
+        {:error,
+         error(:unavailable, "the tenant API answered #{status}", %{
+           status: status,
+           request_id: request_id
+         })}
+
+      {:transport_error, exception} ->
+        {:error, transport_error(exception, request_id)}
+
+      {:error, %Error{} = error} ->
+        {:error, error}
+    end
+  end
+
+  @impl Nucleus.TenantApi
+  def health_check do
+    request_id = request_id()
+
+    # Reachability, not permission. Any status at all means the service answered,
+    # so 401 and 403 are healthy — without that, every health check would start
+    # failing the moment EN-6 makes anonymous calls unauthorised. The body is
+    # discarded undecoded: a malformed list is a listing problem, not an
+    # unreachable dependency.
+    case perform(nil, request_id) do
+      {:response, status, _body} when status >= 500 ->
+        {:error,
+         error(:unavailable, "the tenant API answered #{status}", %{
+           status: status,
+           request_id: request_id
+         })}
+
+      {:response, _status, _body} ->
+        :ok
+
+      {:transport_error, exception} ->
+        {:error, transport_error(exception, request_id)}
+
+      {:error, %Error{} = error} ->
+        {:error, error}
+    end
+  end
+
+  defp perform(token, request_id) do
+    with {:ok, url} <- url() do
+      request =
+        Req.new(
+          [
+            method: :get,
+            url: url,
+            headers: headers(token),
+            retry: false,
+            redirect: false,
+            decode_body: false,
+            receive_timeout: timeout(:receive_timeout_ms, @default_receive_timeout_ms),
+            connect_options: [timeout: timeout(:connect_timeout_ms, @default_connect_timeout_ms)]
+          ] ++ Keyword.take(config(), [:plug])
+        )
+
+      case Req.request(request) do
+        {:ok, %Req.Response{status: status, body: body}} ->
+          Logger.info("tenant_api GET #{@path} -> #{status} request_id=#{request_id}")
+          {:response, status, body}
+
+        {:error, exception} ->
+          Logger.warning(
+            "tenant_api GET #{@path} failed: #{transport_reason(exception)} request_id=#{request_id}"
+          )
+
+          {:transport_error, exception}
+      end
+    end
+  end
+
+  defp decode(body, request_id) do
+    with {:ok, decoded} <- json(body, request_id),
+         {:ok, list} <- unwrap(decoded, request_id),
+         {:ok, environments} <- environments(list, request_id) do
+      {:ok, environments}
+    end
+  end
+
+  defp json(body, request_id) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} ->
+        {:ok, decoded}
+
+      {:error, _error} ->
+        # The decoder's message quotes the offending input, so it is deliberately
+        # not carried into `details` — that would put the response body in a log.
+        {:error,
+         error(:unavailable, "the tenant API returned a body that is not JSON", %{
+           request_id: request_id
+         })}
+    end
+  end
+
+  defp json(_body, request_id) do
+    {:error, error(:unavailable, "the tenant API returned no body", %{request_id: request_id})}
+  end
+
+  defp unwrap(list, _request_id) when is_list(list), do: {:ok, list}
+
+  defp unwrap(_other, request_id) do
+    {:error,
+     error(:unavailable, "the tenant API returned an unexpected shape", %{
+       request_id: request_id
+     })}
+  end
+
+  defp environments(list, request_id) do
+    case Environment.from_api_list(list) do
+      {:ok, environments} ->
+        {:ok, environments}
+
+      {:error, reason} ->
+        {:error,
+         error(:unavailable, "the tenant API returned an unusable environment", %{
+           reason: reason,
+           request_id: request_id
+         })}
+    end
+  end
+
+  defp url do
+    case config()[:base_url] do
+      value when is_binary(value) -> validate_base_url(String.trim(value))
+      _absent -> {:error, not_configured()}
+    end
+  end
+
+  defp validate_base_url(base_url) do
+    case URI.new(base_url) do
+      {:ok, %URI{scheme: scheme, host: host}}
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        {:ok, String.trim_trailing(base_url, "/") <> @path}
+
+      _invalid ->
+        {:error, not_configured()}
+    end
+  end
+
+  defp not_configured do
+    error(
+      :not_configured,
+      "TENANT_API_BASE_URL is missing or is not an http(s) URL",
+      %{variable: "TENANT_API_BASE_URL"}
+    )
+  end
+
+  defp headers(token) do
+    case token do
+      token when is_binary(token) and token != "" ->
+        [{"accept", "application/json"}, {"authorization", "Bearer " <> token}]
+
+      _blank_or_nil ->
+        # Auth is deferred to EN-6, so an anonymous call is the norm today. Sending
+        # a header with an empty token would be worse than sending none.
+        [{"accept", "application/json"}]
+    end
+  end
+
+  defp timeout(key, default) do
+    case config()[key] do
+      ms when is_integer(ms) and ms > 0 -> ms
+      _absent_or_invalid -> default
+    end
+  end
+
+  defp transport_error(exception, request_id) do
+    error(:unavailable, "the tenant API is unreachable", %{
+      reason: transport_reason(exception),
+      request_id: request_id
+    })
+  end
+
+  defp transport_reason(%{reason: reason}), do: inspect(reason)
+  defp transport_reason(%module{}), do: inspect(module)
+  defp transport_reason(other), do: inspect(other)
+
+  defp request_id, do: 8 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  defp config, do: Application.get_env(:nucleus, __MODULE__, [])
+
+  defp error(kind, message, details) do
+    Error.new(kind, TenantApi.boundary(), message, details)
+  end
+end

--- a/lib/nucleus/tenant_api/local.ex
+++ b/lib/nucleus/tenant_api/local.ex
@@ -1,0 +1,99 @@
+defmodule Nucleus.TenantApi.Local do
+  @moduledoc """
+  The tenant API served from `priv/backends/local_seed.json`.
+
+  This is what makes a fresh clone run: environment listing needs no credentials,
+  no network and no tenant. It is a real implementation of the behaviour, not a
+  test double — the same module serves `mix phx.server` in development and the
+  test suite, so there is nothing to drift.
+
+  Reads the `tenant_api` section of the shared seed through
+  `Nucleus.Backend.Seed`, which parses the file once at start-up. The other
+  sections belong to other boundaries and are ignored here.
+
+  ## The fixtures are deliberate
+
+  Downstream tickets need edge cases to build against, and inventing them per
+  ticket is how two tickets end up disagreeing about what "no description" looks
+  like:
+
+  | Environment | Exercises |
+  |---|---|
+  | `prod` | multiple categories, has a description |
+  | `staging` | a single category |
+  | `dev` | **no categories** — `ENV-A02`/`NAV-A04` grouping fallback |
+  | `sandbox` | **no description** — `ENV-A02` omission, must surface as `nil` |
+  | `legacy-qa` | **archived** — `ENV-A06` reachable but hidden |
+
+  ## Faults come first
+
+  Every callback calls `Nucleus.Backend.Faults.maybe_fault/1` before doing
+  anything. Data that always succeeds instantly never exercises a spinner or an
+  error branch, and `SEC-S1`'s fail-closed behaviour is not testable without a
+  way to make this implementation fail on demand (`LOCAL_FORCE_ERROR=unavailable`).
+  """
+
+  @behaviour Nucleus.TenantApi
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Faults
+  alias Nucleus.Backend.Seed
+  alias Nucleus.TenantApi
+  alias Nucleus.TenantApi.Environment
+
+  @impl Nucleus.TenantApi
+  def list_environments(_token) do
+    with :ok <- Faults.maybe_fault(TenantApi.boundary()) do
+      environments()
+    end
+  end
+
+  @impl Nucleus.TenantApi
+  def health_check do
+    with :ok <- Faults.maybe_fault(TenantApi.boundary()),
+         {:ok, _environments} <- environments() do
+      :ok
+    end
+  end
+
+  defp environments do
+    case Seed.read(TenantApi.boundary()) do
+      %{"environments" => raw} when is_list(raw) ->
+        decode(raw)
+
+      nil ->
+        {:error,
+         error(
+           :not_configured,
+           ~s(the backend seed has no "tenant_api" section),
+           %{seed_path: Seed.default_path()}
+         )}
+
+      other ->
+        {:error,
+         error(
+           :not_configured,
+           ~s(the seed's "tenant_api" section has no "environments" list),
+           %{section: inspect(other)}
+         )}
+    end
+  end
+
+  defp decode(raw) do
+    case Environment.from_api_list(raw) do
+      {:ok, environments} ->
+        {:ok, environments}
+
+      {:error, reason} ->
+        # A bad seed is a bad checked-in file, not an unreachable backend, so it
+        # reads as `:not_configured` here where the same payload from a real API
+        # would be `:unavailable`.
+        {:error,
+         error(:not_configured, "the seeded environment list is malformed", %{reason: reason})}
+    end
+  end
+
+  defp error(kind, message, details) do
+    Error.new(kind, TenantApi.boundary(), message, details)
+  end
+end

--- a/priv/backends/local_seed.json
+++ b/priv/backends/local_seed.json
@@ -1,0 +1,50 @@
+{
+  "tenant_api": {
+    "environments": [
+      {
+        "shortName": "prod",
+        "label": "Production",
+        "iri": "https://tenant.example.com/environment/prod",
+        "accentColor": "#b91c1c",
+        "categories": ["Customer Facing", "Regulated"],
+        "isArchived": false,
+        "description": "Live customer traffic. Changes take effect immediately and are visible to end users."
+      },
+      {
+        "shortName": "staging",
+        "label": "Staging",
+        "iri": "https://tenant.example.com/environment/staging",
+        "accentColor": "#a16207",
+        "categories": ["Pre-Production"],
+        "isArchived": false,
+        "description": "Release candidate verification. Mirrors production configuration."
+      },
+      {
+        "shortName": "dev",
+        "label": "Development",
+        "iri": "https://tenant.example.com/environment/dev",
+        "accentColor": "#1d4ed8",
+        "categories": [],
+        "isArchived": false,
+        "description": "Shared integration environment for work in progress."
+      },
+      {
+        "shortName": "sandbox",
+        "label": "Sandbox",
+        "iri": "https://tenant.example.com/environment/sandbox",
+        "accentColor": "#7e22ce",
+        "categories": ["Experimental"],
+        "isArchived": false
+      },
+      {
+        "shortName": "legacy-qa",
+        "label": "Legacy QA",
+        "iri": "https://tenant.example.com/environment/legacy-qa",
+        "accentColor": "#4b5563",
+        "categories": ["Deprecated"],
+        "isArchived": true,
+        "description": "Retired QA stage. Retained because long-lived secrets still resolve against it."
+      }
+    ]
+  }
+}

--- a/test/nucleus/backend/seed_test.exs
+++ b/test/nucleus/backend/seed_test.exs
@@ -1,0 +1,114 @@
+defmodule Nucleus.Backend.SeedTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.Backend.Seed
+
+  @fixture %{
+    "tenant_api" => %{"environments" => [%{"shortName" => "fixture"}]},
+    "secrets" => %{"prod" => %{"KEY" => "value"}}
+  }
+
+  defp seed_file(contents) do
+    path = Path.join(System.tmp_dir!(), "seed-#{System.unique_integer([:positive])}.json")
+    File.write!(path, contents)
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+
+  defp isolated_seed(contents \\ Jason.encode!(@fixture)) do
+    start_supervised!(
+      {Seed, name: :"seed_#{System.unique_integer([:positive])}", path: seed_file(contents)},
+      id: System.unique_integer([:positive])
+    )
+  end
+
+  describe "the checked-in seed" do
+    test "is served by the process the application supervises" do
+      assert %{"environments" => environments} = Seed.read(:tenant_api)
+      assert is_list(environments)
+    end
+
+    test "returns nil for a boundary with no section, rather than raising" do
+      # #4 has not landed, so there is no "secrets" section yet. A boundary whose
+      # data arrives later must read as absent, not as broken.
+      assert Seed.read(:no_such_boundary) == nil
+    end
+  end
+
+  describe "sections" do
+    test "each boundary reads only its own" do
+      seed = isolated_seed()
+
+      assert Seed.read(:tenant_api, seed) == @fixture["tenant_api"]
+      assert Seed.read(:secrets, seed) == @fixture["secrets"]
+    end
+
+    test "writing one leaves the others untouched" do
+      seed = isolated_seed()
+
+      Seed.write(:tenant_api, %{"environments" => []}, seed)
+
+      assert Seed.read(:tenant_api, seed) == %{"environments" => []}
+      assert Seed.read(:secrets, seed) == @fixture["secrets"]
+    end
+
+    test "update/3 applies a function to the current section" do
+      seed = isolated_seed()
+
+      Seed.update(:secrets, &Map.put(&1, "staging", %{}), seed)
+
+      assert Seed.read(:secrets, seed) == %{"prod" => %{"KEY" => "value"}, "staging" => %{}}
+    end
+
+    test "update/3 on an absent section is handed nil" do
+      seed = isolated_seed()
+
+      Seed.update(:brand_new, fn nil -> %{"created" => true} end, seed)
+
+      assert Seed.read(:brand_new, seed) == %{"created" => true}
+    end
+  end
+
+  describe "reset/1" do
+    test "discards runtime mutations, re-reading the file the instance was started with" do
+      seed = isolated_seed()
+      Seed.write(:tenant_api, %{"environments" => []}, seed)
+
+      Seed.reset(seed)
+
+      assert Seed.read(:tenant_api, seed) == @fixture["tenant_api"]
+    end
+  end
+
+  describe "a malformed seed" do
+    @describetag :capture_log
+
+    test "raises rather than starting with a partial document" do
+      path = seed_file(~s({"tenant_api": ))
+
+      assert start_failure({Seed, name: :malformed_seed, path: path}) =~ "not valid JSON"
+    end
+
+    test "raises when the document is not an object" do
+      path = seed_file(~s(["prod"]))
+
+      assert start_failure({Seed, name: :non_object_seed, path: path}) =~ "must be a JSON object"
+    end
+
+    test "raises when the file is missing" do
+      assert start_failure({Seed, name: :missing_seed, path: "/nonexistent/seed.json"}) =~
+               "cannot read backend seed"
+    end
+  end
+
+  # A crash in `init` surfaces as a nested `{{exception, stacktrace}, child_spec}`
+  # reason. Dig the message out rather than asserting on that shape, which is an
+  # OTP detail this suite has no interest in pinning.
+  defp start_failure(child_spec) do
+    assert {:error, reason} = start_supervised(child_spec)
+    message(reason)
+  end
+
+  defp message({nested, _info}), do: message(nested)
+  defp message(%_struct{} = exception), do: Exception.message(exception)
+end

--- a/test/nucleus/tenant_api/contract_test.exs
+++ b/test/nucleus/tenant_api/contract_test.exs
@@ -1,0 +1,72 @@
+defmodule Nucleus.TenantApi.ContractTest do
+  @moduledoc """
+  The same assertions against every implementation of the boundary.
+
+  `Local` always runs. `Http` runs only when `TEST_TENANT_API_BASE_URL` names a
+  real tenant API — it is tagged `:external` and excluded by default in
+  `test_helper.exs`, so a fresh clone with no credentials still goes green.
+
+      TEST_TENANT_API_BASE_URL=https://tenant.example.com mix test --include external
+
+  """
+  use ExUnit.Case, async: false
+
+  alias Nucleus.TenantApi.Http
+  alias Nucleus.TenantApi.Local
+  alias NucleusTest.TenantApiContract, as: Contract
+
+  describe "Nucleus.TenantApi.Local" do
+    test "returns a list of environments" do
+      Contract.assert_lists_environments(Local)
+    end
+
+    test "every element is a fully-formed Environment" do
+      Contract.assert_element_shape(Local)
+    end
+
+    test "optional strings are nil or non-blank, never an empty string" do
+      Contract.assert_one_absence_case(Local)
+    end
+
+    test "health_check/0 returns :ok" do
+      Contract.assert_health_check(Local)
+    end
+  end
+
+  describe "Nucleus.TenantApi.Http" do
+    @describetag :external
+
+    setup do
+      base_url =
+        System.get_env("TEST_TENANT_API_BASE_URL") ||
+          flunk("TEST_TENANT_API_BASE_URL must be set to run the external contract tests")
+
+      original = Application.get_env(:nucleus, Http)
+
+      Application.put_env(:nucleus, Http,
+        base_url: base_url,
+        connect_timeout_ms: 5_000,
+        receive_timeout_ms: 10_000
+      )
+
+      on_exit(fn -> Application.put_env(:nucleus, Http, original) end)
+      :ok
+    end
+
+    test "returns a list of environments" do
+      Contract.assert_lists_environments(Http)
+    end
+
+    test "every element is a fully-formed Environment" do
+      Contract.assert_element_shape(Http)
+    end
+
+    test "optional strings are nil or non-blank, never an empty string" do
+      Contract.assert_one_absence_case(Http)
+    end
+
+    test "health_check/0 returns :ok" do
+      Contract.assert_health_check(Http)
+    end
+  end
+end

--- a/test/nucleus/tenant_api/environment_test.exs
+++ b/test/nucleus/tenant_api/environment_test.exs
@@ -1,0 +1,147 @@
+defmodule Nucleus.TenantApi.EnvironmentTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.TenantApi.Environment
+
+  doctest Environment
+
+  describe "naming translation" do
+    test "camelCase becomes snake_case, and isArchived becomes a predicate" do
+      assert {:ok, environment} =
+               Environment.from_api(%{
+                 "shortName" => "prod",
+                 "label" => "Production",
+                 "iri" => "https://tenant.example.com/environment/prod",
+                 "accentColor" => "#b91c1c",
+                 "categories" => ["Customer Facing"],
+                 "isArchived" => true,
+                 "description" => "Live traffic."
+               })
+
+      assert environment.short_name == "prod"
+      assert environment.label == "Production"
+      assert environment.iri == "https://tenant.example.com/environment/prod"
+      assert environment.accent_color == "#b91c1c"
+      assert environment.categories == ["Customer Facing"]
+      assert environment.archived? == true
+      assert environment.description == "Live traffic."
+    end
+
+    test "no camelCase key survives onto the struct" do
+      assert {:ok, environment} = Environment.from_api(%{"shortName" => "prod"})
+
+      keys = environment |> Map.from_struct() |> Map.keys() |> Enum.map(&Atom.to_string/1)
+
+      refute Enum.any?(keys, &(&1 =~ ~r/[a-z][A-Z]/))
+    end
+  end
+
+  describe "short_name" do
+    test "is required" do
+      assert Environment.from_api(%{"label" => "Production"}) == {:error, :missing_short_name}
+    end
+
+    test "rejects nil, empty and whitespace-only, so no path segment is ever blank" do
+      for value <- [nil, "", "   ", "\t\n"] do
+        assert Environment.from_api(%{"shortName" => value}) == {:error, :missing_short_name}
+      end
+    end
+
+    test "rejects a non-string" do
+      assert Environment.from_api(%{"shortName" => 42}) == {:error, :missing_short_name}
+    end
+
+    test "cannot be omitted when building the struct directly either" do
+      assert_raise ArgumentError, fn -> struct!(Environment, label: "Production") end
+    end
+  end
+
+  describe "one absence case per optional field" do
+    test "an omitted description is nil" do
+      assert {:ok, %Environment{description: nil}} = Environment.from_api(%{"shortName" => "x"})
+    end
+
+    test "a blank description is nil, not an empty string" do
+      for value <- ["", "   "] do
+        assert {:ok, %Environment{description: nil}} =
+                 Environment.from_api(%{"shortName" => "x", "description" => value})
+      end
+    end
+
+    test "blank optional strings all normalise to nil" do
+      assert {:ok, environment} =
+               Environment.from_api(%{
+                 "shortName" => "x",
+                 "label" => "",
+                 "iri" => "",
+                 "accentColor" => ""
+               })
+
+      assert environment.label == nil
+      assert environment.iri == nil
+      assert environment.accent_color == nil
+    end
+  end
+
+  describe "categories" do
+    test "an omitted or null list is an empty list, never nil" do
+      assert {:ok, %Environment{categories: []}} = Environment.from_api(%{"shortName" => "x"})
+
+      assert {:ok, %Environment{categories: []}} =
+               Environment.from_api(%{"shortName" => "x", "categories" => nil})
+    end
+
+    test "is rejected when it is not a list of strings" do
+      for value <- ["Customer Facing", %{"name" => "x"}, [%{"name" => "x"}], [1]] do
+        assert Environment.from_api(%{"shortName" => "x", "categories" => value}) ==
+                 {:error, :invalid_categories}
+      end
+    end
+  end
+
+  describe "archived?" do
+    test "defaults to false when absent" do
+      assert {:ok, %Environment{archived?: false}} = Environment.from_api(%{"shortName" => "x"})
+    end
+
+    test "is rejected when it is not a boolean" do
+      for value <- ["true", 1] do
+        assert Environment.from_api(%{"shortName" => "x", "isArchived" => value}) ==
+                 {:error, :invalid_archived}
+      end
+    end
+  end
+
+  describe "from_api_list/1" do
+    test "preserves order" do
+      assert {:ok, environments} =
+               Environment.from_api_list([
+                 %{"shortName" => "prod"},
+                 %{"shortName" => "staging"},
+                 %{"shortName" => "dev"}
+               ])
+
+      assert Enum.map(environments, & &1.short_name) == ["prod", "staging", "dev"]
+    end
+
+    test "fails the whole list on one bad element, returning no partial result" do
+      # All or nothing: a caller handed the three good elements has no way to know
+      # a fourth existed, and cannot tell that tenant from one with three.
+      assert Environment.from_api_list([
+               %{"shortName" => "prod"},
+               %{"shortName" => "staging"},
+               %{"shortName" => ""},
+               %{"shortName" => "dev"}
+             ]) == {:error, :missing_short_name}
+    end
+
+    test "rejects a non-list and a non-object element" do
+      assert Environment.from_api_list(%{"environments" => []}) == {:error, :not_an_object}
+      assert Environment.from_api_list(["prod"]) == {:error, :not_an_object}
+    end
+
+    test "an empty list is a valid answer" do
+      assert Environment.from_api_list([]) == {:ok, []}
+    end
+  end
+end

--- a/test/nucleus/tenant_api/http_test.exs
+++ b/test/nucleus/tenant_api/http_test.exs
@@ -1,0 +1,383 @@
+defmodule Nucleus.TenantApi.HttpTest do
+  # Configuration is application-global, so these cannot run concurrently.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  # Several cases deliberately provoke a transport failure, which logs a warning.
+  # Captured so the suite's output stays readable; the logging assertions below
+  # still read what was captured.
+  @moduletag :capture_log
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.TenantApi.Http
+
+  @stub __MODULE__
+
+  setup do
+    original = Application.get_env(:nucleus, Http)
+    on_exit(fn -> Application.put_env(:nucleus, Http, original) end)
+    :ok
+  end
+
+  defp configure(overrides \\ []) do
+    Application.put_env(
+      :nucleus,
+      Http,
+      Keyword.merge(
+        [base_url: "https://tenant.example.com", plug: {Req.Test, @stub}],
+        overrides
+      )
+    )
+  end
+
+  defp stub(fun), do: Req.Test.stub(@stub, fun)
+
+  defp respond(status, body, content_type \\ "application/json") do
+    stub(fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type(content_type)
+      |> Plug.Conn.resp(status, body)
+    end)
+  end
+
+  defp respond_json(status, data), do: respond(status, Jason.encode!(data))
+
+  defp environment(attrs \\ %{}), do: Map.merge(%{"shortName" => "prod"}, attrs)
+
+  # The suite runs at :warning, which filters an :info message before any capture
+  # handler sees it. Successful calls log at :info — the level a routine, expected
+  # event belongs at — so the level has to come down for the duration.
+  defp capture_info(fun) do
+    original = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: original) end)
+
+    capture_log(fun)
+  end
+
+  describe "the request" do
+    test "hits the hardcoded /environment path on the configured base URL" do
+      configure()
+
+      stub(fn conn ->
+        assert conn.request_path == "/environment"
+        assert conn.host == "tenant.example.com"
+        assert conn.method == "GET"
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = Http.list_environments(nil)
+    end
+
+    test "preserves a path prefix on the base URL and tolerates a trailing slash" do
+      configure(base_url: "https://tenant.example.com/api/v2/")
+
+      stub(fn conn ->
+        assert conn.request_path == "/api/v2/environment"
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = Http.list_environments(nil)
+    end
+
+    test "sends no Authorization header for a nil token" do
+      configure()
+
+      stub(fn conn ->
+        assert Plug.Conn.get_req_header(conn, "authorization") == []
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = Http.list_environments(nil)
+    end
+
+    test "sends a bearer token when there is one" do
+      configure()
+
+      stub(fn conn ->
+        assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer tok_abc123"]
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = Http.list_environments("tok_abc123")
+    end
+
+    test "sends no Authorization header for a blank token, rather than an empty bearer" do
+      configure()
+
+      stub(fn conn ->
+        assert Plug.Conn.get_req_header(conn, "authorization") == []
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = Http.list_environments("")
+    end
+  end
+
+  describe "translation" do
+    test "camelCase becomes snake_case, including isArchived -> archived?" do
+      configure()
+
+      respond_json(200, [
+        %{
+          "shortName" => "legacy-qa",
+          "label" => "Legacy QA",
+          "iri" => "https://tenant.example.com/environment/legacy-qa",
+          "accentColor" => "#4b5563",
+          "categories" => ["Deprecated"],
+          "isArchived" => true,
+          "description" => "Retired."
+        }
+      ])
+
+      assert {:ok, [environment]} = Http.list_environments(nil)
+      assert environment.short_name == "legacy-qa"
+      assert environment.accent_color == "#4b5563"
+      assert environment.archived? == true
+    end
+
+    test "an empty description normalises to nil" do
+      configure()
+      respond_json(200, [environment(%{"description" => ""})])
+
+      assert {:ok, [%{description: nil}]} = Http.list_environments(nil)
+    end
+
+    test "absent or null categories normalise to []" do
+      configure()
+      respond_json(200, [environment(), environment(%{"categories" => nil})])
+
+      assert {:ok, [%{categories: []}, %{categories: []}]} = Http.list_environments(nil)
+    end
+
+    test "archived environments are returned, not filtered" do
+      configure()
+
+      respond_json(200, [
+        environment(%{"shortName" => "prod"}),
+        environment(%{"shortName" => "legacy-qa", "isArchived" => true})
+      ])
+
+      assert {:ok, environments} = Http.list_environments(nil)
+      assert Enum.map(environments, & &1.short_name) == ["prod", "legacy-qa"]
+    end
+  end
+
+  describe "a bad shortName fails the whole call" do
+    for {label, value} <- [{"missing", :absent}, {"nil", nil}, {"blank", ""}] do
+      test "#{label} shortName yields :unavailable and no partial list" do
+        configure()
+
+        bad =
+          case unquote(Macro.escape(value)) do
+            :absent -> %{"label" => "No short name"}
+            other -> %{"shortName" => other}
+          end
+
+        respond_json(200, [environment(%{"shortName" => "prod"}), bad])
+
+        assert {:error, %Error{kind: :unavailable, details: details}} =
+                 Http.list_environments(nil)
+
+        assert details.reason == :missing_short_name
+      end
+    end
+  end
+
+  describe "status mapping" do
+    for status <- [400, 404, 429, 500, 502, 503, 418, 301] do
+      test "#{status} maps to :unavailable" do
+        configure()
+        respond(unquote(status), "{}")
+
+        assert {:error, %Error{kind: :unavailable, boundary: :tenant_api, details: details}} =
+                 Http.list_environments(nil)
+
+        assert details.status == unquote(status)
+      end
+    end
+
+    for status <- [401, 403] do
+      test "#{status} maps to :auth_expired" do
+        configure()
+        respond(unquote(status), "{}")
+
+        assert {:error, %Error{kind: :auth_expired, details: %{status: unquote(status)}}} =
+                 Http.list_environments(nil)
+      end
+    end
+
+    test "a transport error maps to :unavailable" do
+      configure()
+      stub(fn conn -> Req.Test.transport_error(conn, :econnrefused) end)
+
+      assert {:error, %Error{kind: :unavailable, details: details}} = Http.list_environments(nil)
+      assert details.reason =~ "econnrefused"
+    end
+
+    test "an undecodable body maps to :unavailable" do
+      configure()
+      respond(200, "{not json")
+
+      assert {:error, %Error{kind: :unavailable, message: message}} = Http.list_environments(nil)
+      assert message =~ "not JSON"
+    end
+
+    test "a decodable body of the wrong shape maps to :unavailable" do
+      configure()
+      respond_json(200, %{"environments" => [environment()]})
+
+      assert {:error, %Error{kind: :unavailable, message: message}} = Http.list_environments(nil)
+      assert message =~ "unexpected shape"
+    end
+
+    test "a redirect is not followed — the token never reaches the redirect target" do
+      configure()
+
+      stub(fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://attacker.example.com/environment")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      assert {:error, %Error{kind: :unavailable, details: %{status: 302}}} =
+               Http.list_environments("tok_abc123")
+    end
+  end
+
+  describe "an unusable base URL" do
+    for {label, base_url} <- [
+          {"unset", nil},
+          {"blank", "   "},
+          {"not a URL", "tenant.example.com"},
+          {"a non-http scheme", "file:///etc/passwd"},
+          {"missing a host", "https://"}
+        ] do
+      test "#{label} yields :not_configured and attempts no request" do
+        configure(base_url: unquote(base_url))
+
+        test_pid = self()
+
+        stub(fn conn ->
+          send(test_pid, :request_attempted)
+          Req.Test.json(conn, [])
+        end)
+
+        assert {:error, %Error{kind: :not_configured, details: %{variable: var}}} =
+                 Http.list_environments(nil)
+
+        assert var == "TENANT_API_BASE_URL"
+        refute_received :request_attempted
+      end
+    end
+  end
+
+  describe "health_check/0" do
+    test "is :ok on 200" do
+      configure()
+      respond_json(200, [environment()])
+
+      assert Http.health_check() == :ok
+    end
+
+    for status <- [400, 401, 403, 404, 429] do
+      test "is :ok on #{status} — reachability, not permission" do
+        # A 401 means the service answered. Treating it as unhealthy would make
+        # every health check start failing the moment EN-6 makes anonymous calls
+        # unauthorised.
+        configure()
+        respond(unquote(status), "{}")
+
+        assert Http.health_check() == :ok
+      end
+    end
+
+    for status <- [500, 502, 503] do
+      test "is :unavailable on #{status}" do
+        configure()
+        respond(unquote(status), "{}")
+
+        assert {:error, %Error{kind: :unavailable}} = Http.health_check()
+      end
+    end
+
+    test "is :unavailable on a transport error" do
+      configure()
+      stub(fn conn -> Req.Test.transport_error(conn, :timeout) end)
+
+      assert {:error, %Error{kind: :unavailable}} = Http.health_check()
+    end
+
+    test "is :not_configured with no base URL" do
+      configure(base_url: nil)
+
+      assert {:error, %Error{kind: :not_configured}} = Http.health_check()
+    end
+
+    test "is :ok on a malformed body — a bad list is not an unreachable dependency" do
+      configure()
+      respond(200, "{not json")
+
+      assert Http.health_check() == :ok
+    end
+  end
+
+  describe "logging" do
+    test "records the status and a request id, and never the token" do
+      # Deliberately two-sided. Asserting only that the token is absent passes
+      # vacuously when the code logs nothing at all, which would leave the real
+      # requirement — that a call is traceable without its credentials — untested.
+      configure()
+      respond_json(200, [environment()])
+
+      log = capture_info(fn -> Http.list_environments("tok_supersecret") end)
+
+      assert log =~ "-> 200"
+      assert log =~ ~r/request_id=[0-9a-f]{16}/
+      refute log =~ "tok_supersecret"
+      refute log =~ "Bearer"
+    end
+
+    test "never logs the response body" do
+      configure()
+      respond_json(200, [environment(%{"description" => "leak-me-please"})])
+
+      log = capture_info(fn -> Http.list_environments(nil) end)
+
+      assert log =~ "-> 200"
+      refute log =~ "leak-me-please"
+    end
+
+    test "records the reason on a transport failure, without the token" do
+      configure()
+      stub(fn conn -> Req.Test.transport_error(conn, :econnrefused) end)
+
+      log = capture_info(fn -> Http.list_environments("tok_supersecret") end)
+
+      assert log =~ "econnrefused"
+      assert log =~ ~r/request_id=[0-9a-f]{16}/
+      refute log =~ "tok_supersecret"
+    end
+
+    test "does not log an undecodable body when it reports one" do
+      configure()
+      respond(200, ~s({"secret": "leak-me-please"))
+
+      log = capture_info(fn -> Http.list_environments(nil) end)
+
+      refute log =~ "leak-me-please"
+    end
+  end
+
+  describe "timeouts" do
+    test "are configured independently, and fall back to sane defaults" do
+      configure(connect_timeout_ms: nil, receive_timeout_ms: nil)
+      respond_json(200, [])
+
+      # The defaults must be usable, not merely present: a nil reaching Req's
+      # `receive_timeout` would wait forever and hang a LiveView mount.
+      assert {:ok, []} = Http.list_environments(nil)
+    end
+  end
+end

--- a/test/nucleus/tenant_api/local_test.exs
+++ b/test/nucleus/tenant_api/local_test.exs
@@ -1,0 +1,142 @@
+defmodule Nucleus.TenantApi.LocalTest do
+  # Fault injection is read from the OS environment, which is global to the node.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Seed
+  alias Nucleus.TenantApi.Environment
+  alias Nucleus.TenantApi.Local
+
+  setup do
+    # The seed owner is mutable and outlives any one test.
+    on_exit(&Seed.reset/0)
+    :ok
+  end
+
+  defp force_error(kind) do
+    System.put_env("LOCAL_FORCE_ERROR", kind)
+    on_exit(fn -> System.delete_env("LOCAL_FORCE_ERROR") end)
+  end
+
+  defp environment!(short_name) do
+    assert {:ok, environments} = Local.list_environments(nil)
+    assert environment = Enum.find(environments, &(&1.short_name == short_name))
+    environment
+  end
+
+  describe "the seeded fixtures" do
+    test "all five are present, so downstream tickets need not invent their own" do
+      assert {:ok, environments} = Local.list_environments(nil)
+
+      assert Enum.map(environments, & &1.short_name) |> Enum.sort() ==
+               ["dev", "legacy-qa", "prod", "sandbox", "staging"]
+    end
+
+    test "prod has multiple categories and a description" do
+      environment = environment!("prod")
+
+      assert length(environment.categories) > 1
+      assert is_binary(environment.description)
+    end
+
+    test "staging has a single category" do
+      assert length(environment!("staging").categories) == 1
+    end
+
+    test "dev has no categories — the ENV-A02/NAV-A04 grouping fallback" do
+      assert environment!("dev").categories == []
+    end
+
+    test "sandbox has description: nil, not an empty string — the ENV-A02 omission case" do
+      assert environment!("sandbox").description == nil
+    end
+
+    test "legacy-qa is archived" do
+      assert environment!("legacy-qa").archived? == true
+    end
+  end
+
+  describe "archived environments" do
+    test "are returned, not filtered — the ENV-A06 regression guard" do
+      # `NAV-A04` hides archived environments from the sidebar and `ENV-A06`
+      # requires they stay reachable by direct URL. Filtering here would make the
+      # second unimplementable, so this is deliberately asserted, not incidental.
+      assert {:ok, environments} = Local.list_environments(nil)
+
+      assert Enum.any?(environments, &(&1.short_name == "legacy-qa" and &1.archived?))
+    end
+  end
+
+  describe "the shared translation" do
+    test "every element is a fully-formed Environment struct" do
+      assert {:ok, environments} = Local.list_environments(nil)
+
+      for environment <- environments do
+        assert %Environment{} = environment
+        assert is_binary(environment.short_name) and environment.short_name != ""
+        assert is_list(environment.categories)
+        assert is_boolean(environment.archived?)
+      end
+    end
+  end
+
+  describe "fault injection" do
+    test "LOCAL_FORCE_ERROR=unavailable is the hook SEC-S1 uses for fail-closed" do
+      force_error("unavailable")
+
+      assert {:error, %Error{kind: :unavailable, boundary: :tenant_api}} =
+               Local.list_environments(nil)
+    end
+
+    test "LOCAL_FORCE_ERROR=auth_expired surfaces as :auth_expired" do
+      force_error("auth_expired")
+
+      assert {:error, %Error{kind: :auth_expired}} = Local.list_environments(nil)
+    end
+
+    test "applies to health_check/0 as well" do
+      force_error("unavailable")
+
+      assert {:error, %Error{kind: :unavailable}} = Local.health_check()
+    end
+
+    test "an unparseable value raises rather than passing silently" do
+      force_error("teapot")
+
+      assert_raise ArgumentError, fn -> Local.list_environments(nil) end
+    end
+  end
+
+  describe "health_check/0" do
+    test "is :ok when the seed is readable" do
+      assert Local.health_check() == :ok
+    end
+  end
+
+  describe "a broken seed section" do
+    test "reads as :not_configured, not :unavailable — a bad file is not an unreachable API" do
+      Seed.write(:tenant_api, %{"environments" => [%{"label" => "no short name"}]})
+
+      assert {:error, %Error{kind: :not_configured, details: %{reason: :missing_short_name}}} =
+               Local.list_environments(nil)
+    end
+
+    test "reads as :not_configured when the section is absent" do
+      Seed.write(:tenant_api, nil)
+
+      assert {:error, %Error{kind: :not_configured}} = Local.list_environments(nil)
+    end
+
+    test "reads as :not_configured when the section has no environments list" do
+      Seed.write(:tenant_api, %{})
+
+      assert {:error, %Error{kind: :not_configured}} = Local.list_environments(nil)
+    end
+
+    test "fails health_check/0" do
+      Seed.write(:tenant_api, %{})
+
+      assert {:error, %Error{kind: :not_configured}} = Local.health_check()
+    end
+  end
+end

--- a/test/nucleus/tenant_api_test.exs
+++ b/test/nucleus/tenant_api_test.exs
@@ -1,0 +1,93 @@
+defmodule Nucleus.TenantApiTest do
+  # Swaps the configured implementation, which is application-global.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Backend
+  alias Nucleus.Backend.Error
+  alias Nucleus.TenantApi
+
+  setup do
+    original = Application.get_env(:nucleus, :backends)
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+    :ok
+  end
+
+  defp use_backend(module) do
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(Application.get_env(:nucleus, :backends, []), :tenant_api, module)
+    )
+  end
+
+  describe "the boundary now resolves" do
+    test "impl_for(:tenant_api) no longer raises" do
+      # `adr/0002` recorded that this raised until EN-3 landed. It is the one
+      # externally visible thing this ticket had to change about EN-2's scaffolding.
+      assert Backend.impl_for(:tenant_api) == Nucleus.TenantApi.Local
+    end
+
+    test "both registered implementations exist and implement the behaviour" do
+      for mode <- [:real, :local] do
+        module = Backend.impl_for_mode!(:tenant_api, mode)
+
+        assert Code.ensure_loaded?(module)
+        assert TenantApi in module.module_info(:attributes)[:behaviour]
+      end
+    end
+  end
+
+  describe "dispatch" do
+    test "list_environments/1 goes to the configured implementation" do
+      use_backend(Nucleus.TenantApi.Local)
+      assert {:ok, environments} = TenantApi.list_environments(nil)
+      assert environments != []
+    end
+
+    test "health_check/0 goes to the configured implementation" do
+      use_backend(Nucleus.TenantApi.Local)
+      assert TenantApi.health_check() == :ok
+    end
+
+    test "resolves on every call, so a config change takes effect immediately" do
+      # Resolution is per call rather than at compile time so that runtime.exs and
+      # a test override both take effect. Two implementations that fail differently
+      # is the cheapest way to prove the switch actually moved.
+      use_backend(Nucleus.TenantApi.Local)
+      assert {:ok, _environments} = TenantApi.list_environments(nil)
+
+      original_http = Application.get_env(:nucleus, Nucleus.TenantApi.Http)
+      on_exit(fn -> Application.put_env(:nucleus, Nucleus.TenantApi.Http, original_http) end)
+      Application.put_env(:nucleus, Nucleus.TenantApi.Http, base_url: nil)
+      use_backend(Nucleus.TenantApi.Http)
+
+      assert {:error, %Error{kind: :not_configured}} = TenantApi.list_environments(nil)
+    end
+  end
+
+  describe "the token argument" do
+    test "accepts a binary and nil, because auth is deferred to EN-6" do
+      use_backend(Nucleus.TenantApi.Local)
+
+      assert {:ok, _} = TenantApi.list_environments(nil)
+      assert {:ok, _} = TenantApi.list_environments("tok_abc123")
+    end
+
+    test "rejects anything else at the boundary rather than passing it down" do
+      use_backend(Nucleus.TenantApi.Local)
+
+      # Built at runtime: the compiler's type checker rejects the literal, since
+      # the guard on list_environments/1 declares what it accepts.
+      not_a_token = Jason.decode!(~s({"token": "x"}))
+
+      assert_raise FunctionClauseError, fn -> TenantApi.list_environments(not_a_token) end
+    end
+  end
+
+  describe "boundary/0" do
+    test "names the boundary the errors are tagged with" do
+      assert TenantApi.boundary() == :tenant_api
+      assert TenantApi.boundary() in Backend.boundaries()
+    end
+  end
+end

--- a/test/support/tenant_api_contract.ex
+++ b/test/support/tenant_api_contract.ex
@@ -1,0 +1,82 @@
+defmodule NucleusTest.TenantApiContract do
+  @moduledoc """
+  Assertions every `Nucleus.TenantApi` implementation must satisfy.
+
+  Two implementations of a boundary are two chances to be wrong in different
+  ways. `Nucleus.TenantApi.Local` is what every developer and every CI job runs
+  against, so if it drifts from `Nucleus.TenantApi.Http` the whole local-backend
+  approach stops being worth anything — the suite would be green against
+  behaviour production never exhibits.
+
+  These are plain functions rather than a `__using__` macro so the assertions are
+  literally shared, not generated twice: `test/nucleus/tenant_api/contract_test.exs`
+  calls the same function for both implementations.
+
+  EN-8 owns the general harness for this pattern. This module is the first
+  instance of it, not the abstraction — resist generalising it until there is a
+  second boundary to generalise from.
+  """
+
+  import ExUnit.Assertions
+
+  alias Nucleus.TenantApi.Environment
+
+  @doc """
+  Asserts `impl` returns a usable environment list.
+  """
+  def assert_lists_environments(impl) do
+    assert {:ok, environments} = impl.list_environments(nil)
+    assert is_list(environments)
+
+    environments
+  end
+
+  @doc """
+  Asserts every element is a fully-formed `%Environment{}`.
+
+  `short_name` is checked hardest because it becomes a URL segment *and* a
+  Parameter Store path segment: a `nil` or blank one builds a path that
+  addresses the wrong thing (`SEC-A15`–`A17`).
+  """
+  def assert_element_shape(impl) do
+    for environment <- assert_lists_environments(impl) do
+      assert %Environment{} = environment
+
+      assert is_binary(environment.short_name),
+             "short_name must be a binary, got: #{inspect(environment.short_name)}"
+
+      assert String.trim(environment.short_name) != "", "short_name must not be blank"
+
+      assert is_list(environment.categories),
+             "categories must always be a list, never nil"
+
+      assert Enum.all?(environment.categories, &is_binary/1),
+             "categories must be a list of strings"
+
+      assert is_boolean(environment.archived?),
+             "archived? must always be a boolean"
+    end
+  end
+
+  @doc """
+  Asserts optional strings have exactly one absence value.
+
+  `ENV-A02` requires a description be shown when present and omitted when not.
+  A template that has to test both `nil` and `""` will eventually test only one,
+  so both implementations must collapse blank to `nil`.
+  """
+  def assert_one_absence_case(impl) do
+    for environment <- assert_lists_environments(impl),
+        {field, value} <- Map.take(environment, [:label, :iri, :accent_color, :description]) do
+      assert is_nil(value) or (is_binary(value) and String.trim(value) != ""),
+             "#{field} must be nil or a non-blank binary, got: #{inspect(value)}"
+    end
+  end
+
+  @doc """
+  Asserts `impl` reports itself reachable.
+  """
+  def assert_health_check(impl) do
+    assert impl.health_check() == :ok
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(exclude: [:external])


### PR DESCRIPTION
## What

This delivers the tenant API adapter that `SEC-S1`'s environment-validation ladder will consume: a `list_environments/1`/`health_check/0` behaviour with a `Req`-based HTTP implementation against the tenant's real backing API, and a seeded local implementation that lets a fresh clone list environments with no network and no tenant. It also introduces `Nucleus.Backend.Seed`, the boundary-neutral `Agent` that owns the local seed state, since this ticket's seed file is shared with #4 (secrets).

## How

- `Nucleus.TenantApi` is a thin dispatching facade (`Nucleus.Backend.impl_for/1`) over the `Http`/`Local` implementations, so no caller ever names an implementation directly. `list_environments/1` accepts a `token :: String.t() | nil` per the deferred-auth passthrough model, and both implementations return archived environments — satisfying `ENV-A06` (reachable) while leaving `NAV-A04` (hidden from sidebar) to the caller.
- `Nucleus.TenantApi.Environment` does the camelCase→snake_case and `isArchived`→`archived?` translation in one place (`from_api/1`), shared by both implementations. `short_name` is an `@enforce_keys` field per the superseding decision, and `from_api_list/1` fails the whole call on the first unusable element rather than returning a partial list — the security-relevant guarantee that no `%Environment{}` with a `nil`/blank `short_name` can exist (`ENV-A02`, `SEC-A15`–`A17`).
- `Nucleus.TenantApi.Http` builds the request URL from `TENANT_API_BASE_URL` plus a hardcoded `/environment` path (never caller-influenced, mirroring `PRX-A07`'s SSRF guarantee), uses `retry: false` for prompt fail-closed behaviour, and adds `redirect: false` (not in the original plan) so a redirect can't carry the `Authorization` header off-host — it maps to `:unavailable` like any other unexpected status. The full error table (400/404/429/5xx/401/403/transport/malformed-shortName) is implemented as an explicit catch-all, and `health_check/0` treats any answered status other than 5xx as `:ok` per the reachability semantics from the issue comments. Only status, request id, and (on transport failure) the reason are logged — never the token or body.
- `Nucleus.TenantApi.Local` reads the `tenant_api` section of the shared, boundary-namespaced `priv/backends/local_seed.json` via `Nucleus.Backend.Seed`, calls `Faults.maybe_fault/1` first in every callback, and ships all five required fixtures (`prod`, `staging`, `dev`, `sandbox`, `legacy-qa`) covering the category/description/archived edge cases the issue specifies.
- `Nucleus.Backend.Seed` is a supervised `Agent` (not the originally-planned `GenServer`+ETS pair), started unconditionally in `Nucleus.Application`'s supervision tree in every environment, exposing `read/2`, `write/3`, `update/3`, and a test-only `reset/1`. A malformed or unreadable seed file raises at boot rather than being handled per-caller.
- `config/runtime.exs` splits `TENANT_API_CONNECT_TIMEOUT_MS` and `TENANT_API_RECEIVE_TIMEOUT_MS` into two independent variables and performs no boot-time base-URL validation — a missing one surfaces as `:not_configured` at call time.

## Divergence from the plan

The issue body was amended twice by superseding decision comments before implementation, and the code follows the amended plan, not the original text:

- **Seed loading**: originally a `GenServer` + ETS table, gated to `:dev`/`:test`. A decision comment changed this to a supervised `Agent`; a follow-on decision then made it start unconditionally in every environment and moved it to the boundary-neutral `Nucleus.Backend.Seed` rather than living inside `TenantApi`. Implemented as specified in the final decision.
- **`health_check/0`**: the first decision comment defined it as `:ok` for 401/403 specifically; a later comment broadened this to "any answered status, only 5xx/transport/timeout/`:not_configured` are unhealthy." Implemented per the final, broader definition.
- **`short_name` and `categories`**: `@enforce_keys [:short_name]` and `categories: [String.t()]` were added per a decision comment, superseding the original struct sketch. Implemented as specified.
- **Timeouts**: split into `TENANT_API_CONNECT_TIMEOUT_MS`/`TENANT_API_RECEIVE_TIMEOUT_MS` per a decision comment, superseding the single-variable original plan.
- One addition beyond any plan text: `Req.new(redirect: false)` on the HTTP client, to stop a redirect from carrying the bearer token to an unintended host. This wasn't called out in any decision comment but follows directly from the "never let the token leak" principle already in the plan.

The two-sided token-logging assertion the issue comments called for is implemented in `http_test.exs` (`log =~ "-> 200"` and `refute log =~ token`), closing the gap the first decision comment left open.

## Verification

- `test/nucleus/tenant_api/contract_test.exs` runs the shared assertions (`test/support/tenant_api_contract.ex`) against `Local` always, and against `Http` only when `TEST_TENANT_API_BASE_URL` is set — excluded by default via the new `ExUnit.start(exclude: [:external])` in `test_helper.exs`.
- `test/nucleus/tenant_api/http_test.exs` covers the full status-mapping table, `shortName` failure (missing/nil/blank), base-URL validation, redirect handling, timeout fallback, and both logging assertions (status+request-id present, token and body absent), using `Req.Test` stubs — no network.
- `test/nucleus/tenant_api/local_test.exs` asserts all five fixtures are present with their documented edge cases, that `legacy-qa` (archived) is returned rather than filtered, `LOCAL_FORCE_ERROR` fault injection for both `unavailable` and `auth_expired`, and that a broken/absent seed section reads as `:not_configured`.
- `test/nucleus/backend/seed_test.exs`, `test/nucleus/tenant_api_test.exs`, and `test/nucleus/tenant_api/environment_test.exs` add unit coverage for the seed `Agent`, the dispatching facade, and `Environment.from_api/1`/`from_api_list/1` respectively.
- `mix precommit` (`compile --warnings-as-errors`, `deps.unlock --unused`, `format`, `test`) passes clean: 151 tests (11 doctests, 140 tests), 4 excluded (`:external`, no `TEST_TENANT_API_BASE_URL` set).

Closes #3
