### PR TITLE
EN-5: Nucleus.Audit — synchronous, structured, separate stream, values never logged

### DIFF
--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.2 | Updated: 2026-08-11 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.3 | Updated: 2026-08-11 -->
 
 # Decisions Log
 
@@ -19,6 +19,7 @@
 | 1 | No local datastore — drop `ecto_sql`/`postgrex`, keep `ecto` for changesets | 2026-08-07 | Decided | `docs/adr/0001-no-local-datastore.md` |
 | 2 | Backend adapter boundaries — behaviours, tagged-tuple errors, per-boundary real/local selection | 2026-08-07 | Decided | `docs/adr/0002-backend-adapter-boundaries.md` |
 | 3 | Shared local backend seed — one supervised `Agent`, boundary-neutral, started everywhere | 2026-08-11 | Decided | `docs/adr/0003-shared-local-backend-seed.md` |
+| 4 | Audit emission — bypasses `Logger`, synchronous `Sink` behaviour, per-event field allowlist | 2026-08-11 | Decided | `docs/adr/0004-audit-emission.md` |
 
 Two things this file deliberately does **not** contain:
 
@@ -91,6 +92,24 @@ file) · `docs/adr/0002-backend-adapter-boundaries.md` (the real/local split thi
 
 ---
 
+## Decision: Audit Emission
+
+**Date**: 2026-08-11 | **Status**: Decided | **ADR**: `docs/adr/0004-audit-emission.md`
+
+`Nucleus.Audit.emit/2` bypasses `Logger` entirely and writes through a `Nucleus.Audit.Sink`
+behaviour, synchronously, in the caller's process, never rescuing a sink failure — `Logger` is
+only synchronous under overload, and a rescued failure would look identical to a successful
+record. Every field a caller can pass is allowlisted per event (`details` included), so there is
+no key named `value` for a call site to pass a secret through by accident. The default sink
+writes to `:stderr`, distinct from `Logger`'s standard-output default, for free.
+
+**Related**: Issue #5 (EN-5, the deciding issue) · Issue #8 (EN-8, `AuditCase` depends on
+`Nucleus.Audit.Sink.Test`) · Issues #12/#13/#14 (SEC-S4/S5/S6, wire the three Secrets events) ·
+`docs/adr/0001-no-local-datastore.md` (audit records go to an external log pipeline; there is no
+local option)
+
+---
+
 ## Deprecated Decisions
 
 Decisions that were later overturned (for historical context):
@@ -101,7 +120,7 @@ Decisions that were later overturned (for historical context):
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0003` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0004` are binding
 - [ ] Know that the wiki's ADR-0001–0007 are reference only, not adopted
 - [ ] Know that new formal ADRs belong in `docs/adr/`, with only a short summary mirrored here
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/config/config.exs
+++ b/config/config.exs
@@ -44,6 +44,17 @@ config :nucleus, Nucleus.TenantApi.Http,
   connect_timeout_ms: 5_000,
   receive_timeout_ms: 10_000
 
+# Compliance audit trail (SOC2 CC7.2 / HIPAA 164.312(b)) — bypasses Logger and
+# writes synchronously to a dedicated sink, distinct from application logs
+# (AUD-A06/A07). See lib/nucleus/audit.ex and
+# docs/adr/0004-audit-emission.md. dev overrides format to :text; test
+# overrides sink to Nucleus.Audit.Sink.Test; runtime.exs reads AUDIT_FORMAT
+# and AUDIT_DEVICE.
+config :nucleus, Nucleus.Audit,
+  sink: Nucleus.Audit.Sink.Device,
+  format: :json,
+  device: :stderr
+
 # Configure LiveView
 config :phoenix_live_view,
   # the attribute set on all root tags. Used for Phoenix.LiveView.ColocatedCSS.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -52,6 +52,11 @@ config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Local,
   tenant_api: Nucleus.TenantApi.Local
 
+# Human-readable audit records for local development. AUD-A05 requires the
+# set of recorded events to be unchanged by the format — only the encoding
+# differs here, not which events are audited.
+config :nucleus, Nucleus.Audit, format: :text
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :default_formatter, format: "[$level] $message\n"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -69,6 +69,31 @@ if tenant_api_config != [] do
   config :nucleus, Nucleus.TenantApi.Http, tenant_api_config
 end
 
+# Audit sink overrides. AUDIT_FORMAT is "json" or "text" (see
+# Nucleus.Audit.Format); anything else raises at boot rather than silently
+# falling back — a typo here should not silently change what a compliance
+# pipeline receives. AUDIT_DEVICE is "stdout", "stderr", or a file path
+# opened once at boot in append mode.
+if audit_format = System.get_env("AUDIT_FORMAT") do
+  format =
+    case Nucleus.Audit.Format.cast(audit_format) do
+      {:ok, format} -> format
+      :error -> raise "AUDIT_FORMAT must be \"json\" or \"text\", got: #{inspect(audit_format)}"
+    end
+
+  config :nucleus, Nucleus.Audit, format: format
+end
+
+if audit_device = System.get_env("AUDIT_DEVICE") do
+  device =
+    case Nucleus.Audit.Sink.Device.cast_device_name(audit_device) do
+      {:ok, device} -> device
+      :error -> File.open!(audit_device, [:append, :utf8])
+    end
+
+  config :nucleus, Nucleus.Audit, device: device
+end
+
 if config_env() == :dev do
   # Reload browser tabs when matching files change.
   config :nucleus, NucleusWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,6 +16,10 @@ config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Local,
   tenant_api: Nucleus.TenantApi.Local
 
+# Tests assert on emitted audit records via Nucleus.Audit.Sink.Test's
+# registered process, rather than parsing :stderr.
+config :nucleus, Nucleus.Audit, sink: Nucleus.Audit.Sink.Test
+
 # Disable swoosh api client as it is only required for production adapters
 config :swoosh, :api_client, false
 

--- a/docs/adr/0004-audit-emission.md
+++ b/docs/adr/0004-audit-emission.md
@@ -1,0 +1,213 @@
+# ADR-0004: Audit Emission
+
+## Status
+
+Accepted — 2026-08-11
+
+Decided on [EN-5](https://github.com/dave-bell/nucleus/issues/5). Builds on
+`0001-no-local-datastore.md`.
+
+The wiki's `ADR-0003` (Compliance Audit Logging), under `docs/requirements/`,
+describes the earlier Python prototype's two-tier audit design and is
+**reference only**. Where this ADR reaches the same conclusion — the field
+list, the `X-Forwarded-For` extraction algorithm — it is because that
+conclusion was re-tested against this stack, not by inheritance. The sections
+below say explicitly which decisions carry over and which change shape
+because this is Elixir/Plug rather than FastAPI/Python.
+
+## Context
+
+Three of the Secrets actions — `secret_created` (SEC-A09), `secret_viewed`
+(SEC-A03), `secret_updated` (SEC-A06) — must produce a compliance-grade audit
+record, in a SOC2 (CC7.2) / HIPAA (164.312(b)) context. The wiki's
+[Audit & Compliance](https://github.com/dave-bell/nucleus/wiki/Audit-and-Compliance)
+page states four constraints a plain `Logger.info` call does not satisfy:
+
+- **AUD-A02** — the value touched is never recorded, only the path
+- **AUD-A05** — structured and machine-parseable, with a plain-text mode for
+  local development that does not change *which* events are recorded
+- **AUD-A06** — a distinct output stream from application logs, so audit
+  records can be retained independently of routine logging noise
+- **AUD-A07** — the write is synchronous, so a record cannot be lost to
+  buffering or asynchronous delivery
+
+## Decision
+
+### `Logger` is bypassed entirely
+
+Elixir's `Logger` is asynchronous by default and switches to synchronous
+delivery only under overload (`sync_mode_qlen`) — "usually synchronous" is
+not the same guarantee as AUD-A07 requires. `Logger` handlers can also drop
+messages under overload protection, and a dropped audit record is a
+compliance failure, not a performance trade-off. Sharing `Logger` would also
+put audit records and application logs on the same pipeline, in tension with
+AUD-A06.
+
+`Nucleus.Audit.emit/2` never calls `Logger`. It formats a record and writes
+it through a `Nucleus.Audit.Sink` directly.
+
+### A `Sink` behaviour, two implementations
+
+```elixir
+@callback write(iodata()) :: :ok
+```
+
+- `Nucleus.Audit.Sink.Device` (default) — `IO.write/2` to a configured
+  device, `:stderr` unless overridden. `IO.write/2` to a device is
+  synchronous, so AUD-A07 holds by construction: the call does not return
+  until the write has happened.
+- `Nucleus.Audit.Sink.Test` — delivers the record to a registered test
+  process instead. EN-8's `AuditCase` and its `refute_audit_contains/1`
+  helper are built on this.
+
+Using `:stderr` as the default gives AUD-A06 for free: application logs go
+to `:stdout` (`Logger`'s default), audit records to `:stderr`, and a
+container runtime can route the two streams separately with no application
+change. `AUDIT_DEVICE` overrides to `:stdout`, a file path, or any other IO
+device (a `pid`, e.g. a `StringIO` process for tests).
+
+### Sink failures propagate, never rescued
+
+`emit/2` has no `rescue` around the sink call. If the device write fails —
+disk full, pipe closed — the exception reaches the caller. A silently
+swallowed failure would look identical to a successful audit record from
+every other part of the system, which is a worse failure mode than a crash:
+the crash is visible, and AUD-A07 is not satisfied either way. The
+Secrets features wiring these events (SEC-S4/S5/S6) get no automatic
+retry or fallback; a failed audit write fails the action it was auditing.
+
+### The struct is the AUD-A02 defence, not a convention
+
+`Nucleus.Audit.Event` has no field named `value`, `secret`, `plaintext`, or
+`new_value` — there is no key for a call site to pass one through by
+accident. `emit/2` rejects any keyword key outside a fixed struct field list,
+and separately rejects any key inside `details` outside a **per-event**
+allowlist built from the wiki's event catalogue
+(`docs/requirements/Audit-and-Compliance.md`). A permissive `details: map()`
+would have reopened exactly this hole, since nothing would then stop a
+`value` key from hiding inside it. The per-event required/allowed field
+lists live in `Nucleus.Audit.Event.spec/1`.
+
+The `@type event` union covers all eleven catalogued events, so a future
+feature does not invent its own spelling — only the three Secrets events are
+wired to a call site by this ticket. `auth_failure` and the Nomad Variable
+and M2M events are defined but unused until EN-6 and their owning features.
+
+### Format is decided strictly after recording, never before
+
+`Nucleus.Audit.Format.encode/2` takes an already-built `%Event{}` and a
+format (`:json` or `:text`); it adds, drops, or renames nothing. AUD-A05
+requires the recorded *event set* to be format-independent, so formatting is
+the last step, downstream of every validation `emit/2` performs — a
+formatter cannot make a field disappear that validation already decided
+belongs in the record.
+
+`:json` is the default and the only format supported in any deployed
+environment: one `Jason`-encoded record per line, newline-terminated,
+`timestamp` as ISO 8601 UTC. `:text` (the dev default) is one
+human-readable line, `key="quoted value"` pairs, with `%` and `{}` handled
+safely because every value is quoted and escaped — a resource path
+containing either cannot be mistaken for a field delimiter.
+
+### Source IP: first `X-Forwarded-For` entry, peer fallback, never raises
+
+Re-derived for `Plug.Conn` from the wiki ADR's algorithm:
+`X-Forwarded-For: client, proxy1, proxy2` uses the first entry (the original
+client); a direct connection with no proxy in front (a health check, local
+dev) falls back to `Plug.Conn.get_peer_data/1`. `Nucleus.Audit.Source.from_conn/1`
+never raises — a malformed header, or a peer lookup that itself fails, both
+fall through to `nil`, because source IP is audit context, not a value
+anything should crash the request over.
+
+`Nucleus.Audit.Source` deliberately knows nothing about LiveView sockets. As
+the ticket notes, `X-Forwarded-For` is unavailable on the socket after the
+initial connection — capturing it during `on_mount` via
+`get_connect_info/2` and carrying it in the auth scope is EN-6's job, not
+this module's.
+
+## Consequences
+
+### Positive
+
+- AUD-A02, AUD-A05, AUD-A06, and AUD-A07 are each satisfied by construction —
+  a struct with no `value` field, a synchronous device write, a distinct
+  default stream, and a sink call with no `rescue` — rather than by
+  discipline at each call site.
+- The full event catalogue exists in one place (`Nucleus.Audit.Event`)
+  before any feature beyond Secrets needs it, so later tickets extend a
+  table instead of inventing field names.
+- `Nucleus.Audit.Sink.Test` gives EN-8's `AuditCase` a way to assert on
+  emitted records without touching `:stderr` or parsing text output.
+
+### Negative
+
+- **Nucleus persists no audit history of its own.** There is no query
+  interface, no local store, and no way to answer "show me every access to
+  this secret" from within Nucleus. This follows directly from the
+  stateless constraint in `docs/adr/0001-no-local-datastore.md` — see that
+  ADR's "No Local Datastore" consequence: *"Audit records must go to an
+  external log pipeline; there is no local option."*
+- A raising sink means a transient write failure (a full disk, a broken
+  pipe on `:stderr`) fails the audited action itself, not just the audit
+  write. This is deliberate — see "Sink failures propagate" above — but it
+  is a real availability trade-off, not a free guarantee.
+- `AUDIT_DEVICE` pointed at a file path opens that file once at boot
+  (`config/runtime.exs`) and keeps the handle for the life of the process.
+  Log rotation of that file (e.g. by an external tool renaming it) is not
+  handled — the deployment's log pipeline should prefer `:stderr`/`:stdout`
+  and let the container runtime do rotation, rather than relying on this
+  path.
+
+### Operational dependency — external retention is not optional
+
+**Audit records are not persisted by Nucleus.** Retention, tamper-evident
+storage, and the 1–7 year retention window the wiki ADR mentions for
+SOC2/HIPAA are entirely the deployment's log pipeline's responsibility — a
+container runtime or log shipper capturing `:stderr` into append-only,
+tamper-evident storage with the required retention period. This is a real
+operational dependency for any Nucleus deployment claiming SOC2/HIPAA
+compliance, not an implementation detail, and it is written down here so it
+is not assumed.
+
+## Alternatives considered
+
+**Writing audit records through `Logger` with a dedicated handler.**
+Rejected — see "`Logger` is bypassed entirely" above. A `:logger` handler
+tuned for `sync_mode_qlen: 0` approximates synchronous delivery but is not
+guaranteed synchronous, and AUD-A07 requires the guarantee, not the
+approximation.
+
+**Rescuing sink failures into a logged warning and continuing.** Rejected.
+A rescued audit failure is indistinguishable from a successful one to
+everything downstream of `emit/2` — the action it was auditing completes
+looking compliant when it was not audited at all. AUD-A07 exists precisely
+to rule this out.
+
+**A free-form `details: map()` with no per-event allowlist.** Rejected. It
+would satisfy the struct's own field list while reopening the exact hole the
+struct closes — nothing would stop a `secret_created` call site from adding
+`details: %{value: "..."}`.
+
+**Deriving source IP handling for LiveView sockets in
+`Nucleus.Audit.Source` itself.** Rejected. `X-Forwarded-For` is not
+available on the socket after the initial connect; capturing it belongs to
+`on_mount` and the auth scope (EN-6), not to a module whose only input is a
+`Plug.Conn`.
+
+## References
+
+- EN-5 — the deciding issue, including the full implementation plan
+- `docs/adr/0001-no-local-datastore.md` — the stateless constraint that
+  makes external retention the deployment's responsibility, not Nucleus's
+- Wiki [Audit & Compliance](https://github.com/dave-bell/nucleus/wiki/Audit-and-Compliance),
+  [ADR-0003](https://github.com/dave-bell/nucleus/wiki/ADR-0003-Compliance-Audit-Logging)
+  — reference only; prior art, not authority
+- `docs/requirements/Audit-and-Compliance.md` — the binding `AUD-A01`–`A07`
+  actions and the complete event catalogue this module's field lists are
+  built from
+- `.opencode/context/project-intelligence/decisions-log.md` — "No Local
+  Datastore" decision, noting audit records go to an external log pipeline
+- EN-8 — the contract test harness whose `AuditCase` depends on
+  `Nucleus.Audit.Sink.Test`
+- SEC-S4/S5/S6 — wire the three Secrets events at their call sites; EN-6 —
+  auth, `auth_failure`, and LiveView source-IP capture

--- a/lib/nucleus/audit.ex
+++ b/lib/nucleus/audit.ex
@@ -1,0 +1,122 @@
+defmodule Nucleus.Audit do
+  @moduledoc """
+  The single entry point for writing a compliance audit record.
+
+  Bypasses `Logger` entirely — see `docs/adr/0004-audit-emission.md` for why.
+  `emit/2` validates against the catalogue in `Nucleus.Audit.Event`, stamps
+  its own timestamp, formats via `Nucleus.Audit.Format`, and writes via the
+  configured `Nucleus.Audit.Sink`, synchronously, in the caller's process.
+
+  Configure via `config :nucleus, Nucleus.Audit, sink:, format:, device:` —
+  see `config/config.exs`, `config/dev.exs`, `config/test.exs`, and
+  `config/runtime.exs`.
+  """
+
+  alias Nucleus.Audit.{Event, Format}
+
+  @doc """
+  Emits one audit record for `event`, built from `fields`.
+
+  `fields` is a keyword list of the `Nucleus.Audit.Event` struct fields this
+  event accepts — see `Nucleus.Audit.Event.spec/1` for the per-event allowed
+  and required lists. Notably:
+
+  - `:timestamp` is never accepted here — it is always stamped with
+    `DateTime.utc_now/0`, so a caller cannot backdate or forge a record.
+  - `:user` defaults to `"anonymous"` when absent.
+  - `:details` (when the event allows it) is itself key-allowlisted per
+    event — an unlisted key inside `details` raises exactly like an unlisted
+    top-level key.
+
+  Raises `ArgumentError` for: an unknown event, an unlisted field or detail
+  key (this is the AUD-A02 defence — there is no `value` key to pass), or a
+  missing required field. Never rescues a raise from the underlying sink —
+  a silently-failing audit emitter is worse than a crash, because it looks
+  compliant (AUD-A07).
+  """
+  @spec emit(Event.event(), keyword()) :: :ok
+  def emit(event, fields \\ []) when is_atom(event) and is_list(fields) do
+    unless Event.known?(event) do
+      raise ArgumentError,
+            "unknown audit event #{inspect(event)}. Known events: #{inspect(Event.events())}"
+    end
+
+    spec = Event.spec(event)
+    details = Keyword.get(fields, :details, %{})
+
+    validate_top_level!(event, fields, spec)
+    validate_details!(event, details, spec)
+    validate_required!(event, fields, details, spec)
+
+    record = %Event{
+      event: event,
+      user: Keyword.get(fields, :user) || "anonymous",
+      tenant: Keyword.get(fields, :tenant),
+      timestamp: DateTime.utc_now(),
+      source_ip: Keyword.get(fields, :source_ip),
+      resource: Keyword.get(fields, :resource),
+      reason: Keyword.get(fields, :reason),
+      details: details
+    }
+
+    format = Keyword.fetch!(config(), :format)
+    sink = Keyword.fetch!(config(), :sink)
+
+    record
+    |> Format.encode(format)
+    |> sink.write()
+
+    :ok
+  end
+
+  defp validate_top_level!(event, fields, spec) do
+    allowed = MapSet.new([:user | spec.allowed])
+
+    case Enum.find(fields, fn {key, _value} -> not MapSet.member?(allowed, key) end) do
+      nil ->
+        :ok
+
+      {key, _value} ->
+        raise ArgumentError,
+              "unknown field #{inspect(key)} for audit event #{inspect(event)}. " <>
+                "Allowed fields: #{inspect(MapSet.to_list(allowed))}"
+    end
+  end
+
+  defp validate_details!(_event, details, _spec) when details == %{}, do: :ok
+
+  defp validate_details!(event, details, spec) when is_map(details) do
+    allowed = MapSet.new(spec.details_allowed)
+
+    case Enum.find(details, fn {key, _value} -> not MapSet.member?(allowed, key) end) do
+      nil ->
+        :ok
+
+      {key, _value} ->
+        raise ArgumentError,
+              "unknown detail #{inspect(key)} for audit event #{inspect(event)}. " <>
+                "Allowed details: #{inspect(spec.details_allowed)}"
+    end
+  end
+
+  defp validate_details!(event, other, _spec) do
+    raise ArgumentError,
+          "details for audit event #{inspect(event)} must be a map, got: #{inspect(other)}"
+  end
+
+  defp validate_required!(event, fields, details, spec) do
+    missing_top = Enum.filter(spec.required, &is_nil(Keyword.get(fields, &1)))
+    missing_details = Enum.filter(spec.details_required, &is_nil(Map.get(details, &1)))
+
+    case missing_top ++ missing_details do
+      [] ->
+        :ok
+
+      missing ->
+        raise ArgumentError,
+              "audit event #{inspect(event)} is missing required field(s): #{inspect(missing)}"
+    end
+  end
+
+  defp config, do: Application.fetch_env!(:nucleus, __MODULE__)
+end

--- a/lib/nucleus/audit/event.ex
+++ b/lib/nucleus/audit/event.ex
@@ -1,0 +1,165 @@
+defmodule Nucleus.Audit.Event do
+  @moduledoc """
+  The one record shape every audited action produces.
+
+  This struct — and the catalogue below it — is the AUD-A02 defence: there is
+  no field named `value`, `secret`, `plaintext`, or `new_value`, so a call site
+  cannot pass a secret value through by accident. `resource` carries *what was
+  accessed* (a path or key), never the value itself.
+
+  The `event` type union covers all eleven events from the wiki's
+  [Audit & Compliance](https://github.com/dave-bell/nucleus/wiki/Audit-and-Compliance)
+  catalogue, so later features do not each invent their own spelling. Only the
+  three Secrets events (`:secret_created`, `:secret_viewed`, `:secret_updated`)
+  are wired to a call site today — see `docs/requirements/Audit-and-Compliance.md`
+  for the full table this catalogue is built from.
+
+  Fields the catalogue lists that have no dedicated struct field (`path`,
+  `key`, `added`, `removed`, `client_name`, `ticket_id`) live in `details`,
+  which is key-allowlisted per event by `catalogue/0` — a free-form
+  `details: map()` would reopen exactly the hole the struct closes, since
+  nothing would stop a `value` key from hiding inside it.
+  """
+
+  @type event ::
+          :auth_failure
+          | :nomad_vars_listed
+          | :nomad_var_viewed
+          | :nomad_var_updated
+          | :env_names_updated
+          | :secret_created
+          | :secret_viewed
+          | :secret_updated
+          | :m2m_client_viewed
+          | :m2m_client_created
+          | :m2m_secret_rotated
+
+  @type t :: %__MODULE__{
+          event: event(),
+          user: String.t(),
+          tenant: String.t() | nil,
+          timestamp: DateTime.t(),
+          source_ip: String.t() | nil,
+          resource: String.t() | nil,
+          reason: String.t() | nil,
+          details: map()
+        }
+
+  @derive {Jason.Encoder,
+           only: [:event, :user, :tenant, :timestamp, :source_ip, :resource, :reason, :details]}
+  @enforce_keys [:event, :user, :timestamp]
+  defstruct [:event, :user, :tenant, :timestamp, :source_ip, :resource, :reason, details: %{}]
+
+  # Per-event field lists. `allowed` are the keyword keys `Nucleus.Audit.emit/2`
+  # accepts for that event (beyond `:user`, which every event accepts and
+  # defaults from); `required` is the subset that must be present and
+  # non-nil. `details_allowed`/`details_required` are the same two ideas, one
+  # level down, for keys inside the `details` map.
+  #
+  # Built directly from the wiki catalogue table — do not invent a field here
+  # that table does not list.
+  @catalogue %{
+    auth_failure: %{
+      allowed: [:user, :tenant, :source_ip, :reason, :details],
+      required: [:tenant, :reason],
+      details_allowed: [:path],
+      details_required: [:path]
+    },
+    nomad_vars_listed: %{
+      allowed: [:user, :tenant, :details],
+      required: [:tenant],
+      details_allowed: [:path],
+      details_required: [:path]
+    },
+    nomad_var_viewed: %{
+      allowed: [:user, :tenant, :details],
+      required: [:tenant],
+      details_allowed: [:path, :key],
+      details_required: [:path, :key]
+    },
+    nomad_var_updated: %{
+      allowed: [:user, :tenant, :details],
+      required: [:tenant],
+      details_allowed: [:path, :key],
+      details_required: [:path, :key]
+    },
+    env_names_updated: %{
+      allowed: [:user, :tenant, :details],
+      required: [:tenant],
+      details_allowed: [:path, :added, :removed],
+      details_required: [:path, :added, :removed]
+    },
+    secret_created: %{
+      allowed: [:user, :tenant, :resource],
+      required: [:tenant, :resource],
+      details_allowed: [],
+      details_required: []
+    },
+    secret_viewed: %{
+      allowed: [:user, :tenant, :resource],
+      required: [:tenant, :resource],
+      details_allowed: [],
+      details_required: []
+    },
+    secret_updated: %{
+      allowed: [:user, :tenant, :resource],
+      required: [:tenant, :resource],
+      details_allowed: [],
+      details_required: []
+    },
+    m2m_client_viewed: %{
+      allowed: [:user, :tenant, :details],
+      required: [:tenant],
+      details_allowed: [:client_name],
+      details_required: [:client_name]
+    },
+    m2m_client_created: %{
+      allowed: [:user, :tenant, :details],
+      required: [:tenant],
+      details_allowed: [:client_name, :ticket_id],
+      details_required: [:client_name, :ticket_id]
+    },
+    m2m_secret_rotated: %{
+      allowed: [:user, :tenant, :details],
+      required: [:tenant],
+      details_allowed: [:client_name],
+      details_required: [:client_name]
+    }
+  }
+
+  @doc """
+  Every catalogued event, so a caller (or a test) can assert exhaustive
+  handling instead of guessing at the union.
+
+      iex> :secret_viewed in Nucleus.Audit.Event.events()
+      true
+  """
+  @spec events() :: [event()]
+  def events, do: Map.keys(@catalogue)
+
+  @doc """
+  Whether `event` is in the catalogue.
+
+      iex> Nucleus.Audit.Event.known?(:secret_viewed)
+      true
+
+      iex> Nucleus.Audit.Event.known?(:secret_view)
+      false
+  """
+  @spec known?(term()) :: boolean()
+  def known?(event), do: is_map_key(@catalogue, event)
+
+  @doc """
+  The field spec for `event`: `%{allowed:, required:, details_allowed:, details_required:}`.
+
+  Raises `KeyError` for an unknown event — callers must check `known?/1` first,
+  which is exactly what `Nucleus.Audit.emit/2` does before calling this.
+  """
+  @spec spec(event()) :: %{
+          allowed: [atom()],
+          required: [atom()],
+          details_allowed: [atom()],
+          details_required: [atom()]
+        }
+  def spec(event), do: Map.fetch!(@catalogue, event)
+end

--- a/lib/nucleus/audit/format.ex
+++ b/lib/nucleus/audit/format.ex
@@ -1,0 +1,97 @@
+defmodule Nucleus.Audit.Format do
+  @moduledoc """
+  Serialises a `%Nucleus.Audit.Event{}` for a sink.
+
+  Two formats, selected strictly downstream of every decision about whether
+  and what to record — `Nucleus.Audit.emit/2` builds the full `Event` struct
+  first, and formatting never adds, drops, or renames a field. AUD-A05
+  requires the *set* of recorded fields to be identical across formats; only
+  the encoding differs.
+
+  - `:json` — the default, and required in any deployed environment. One
+    record per line, newline-terminated, `Jason`-encoded. `event` is a
+    string, `timestamp` is ISO 8601 UTC.
+  - `:text` — the dev default. A single human-readable line. Values are
+    quoted and escaped so a `%` or `{}` in a resource path cannot be
+    mistaken for a field delimiter.
+  """
+
+  alias Nucleus.Audit.Event
+
+  @type format :: :json | :text
+
+  @top_level_fields [:event, :user, :tenant, :timestamp, :source_ip, :resource, :reason]
+
+  @doc """
+  Encodes `event` as `format`, returning iodata ready for a sink.
+  """
+  @spec encode(Event.t(), format()) :: iodata()
+  def encode(%Event{} = event, :json), do: encode_json(event)
+  def encode(%Event{} = event, :text), do: encode_text(event)
+
+  @doc """
+  Casts an `AUDIT_FORMAT` value (`"json"` or `"text"`) to a `format()`.
+
+  Returns `:error` for anything else so `config/runtime.exs` can raise with
+  the offending value rather than silently falling back to a default — a
+  typo here should not silently change what a compliance pipeline receives.
+
+      iex> Nucleus.Audit.Format.cast("json")
+      {:ok, :json}
+
+      iex> Nucleus.Audit.Format.cast("bogus")
+      :error
+  """
+  @spec cast(String.t()) :: {:ok, format()} | :error
+  def cast("json"), do: {:ok, :json}
+  def cast("text"), do: {:ok, :text}
+  def cast(_other), do: :error
+
+  defp encode_json(event) do
+    map = %{
+      event: Atom.to_string(event.event),
+      user: event.user,
+      tenant: event.tenant,
+      timestamp: DateTime.to_iso8601(event.timestamp),
+      source_ip: event.source_ip,
+      resource: event.resource,
+      reason: event.reason,
+      details: event.details
+    }
+
+    [Jason.encode!(map), "\n"]
+  end
+
+  defp encode_text(event) do
+    # Every top-level field is always printed, even when nil (as `key=""`).
+    # AUD-A05 requires the recorded field *set* to be identical across
+    # formats — `:json` always carries every key (nil as `null`), so
+    # dropping a nil field here instead of the caller (e.g. `secret_viewed`,
+    # which never has a `reason` or `source_ip`) would make the two formats
+    # disagree about what was recorded for the exact events this ticket
+    # wires up.
+    top_level = Enum.map(@top_level_fields, &{&1, top_level_value(event, &1)})
+
+    details = Enum.map(event.details, fn {key, value} -> {key, value} end)
+
+    (top_level ++ details)
+    |> Enum.map(fn {key, value} -> "#{key}=#{quote_value(value)}" end)
+    |> Enum.join(" ")
+    |> then(&[&1, "\n"])
+  end
+
+  defp top_level_value(event, :event), do: Atom.to_string(event.event)
+  defp top_level_value(event, :timestamp), do: DateTime.to_iso8601(event.timestamp)
+  defp top_level_value(event, key), do: Map.fetch!(Map.from_struct(event), key)
+
+  defp quote_value(value) do
+    escaped =
+      value
+      |> to_string()
+      |> String.replace("\\", "\\\\")
+      |> String.replace("\"", "\\\"")
+      |> String.replace("\n", "\\n")
+
+    "\"#{escaped}\""
+  end
+end

--- a/lib/nucleus/audit/sink.ex
+++ b/lib/nucleus/audit/sink.ex
@@ -1,0 +1,25 @@
+defmodule Nucleus.Audit.Sink do
+  @moduledoc """
+  Where an already-encoded audit record goes.
+
+  `Nucleus.Audit.emit/2` calls `write/1` once per record, synchronously, in
+  the caller's process, after serialisation — never before, and never
+  rescued. AUD-A07 (writes do not silently fail) holds because a raise here
+  propagates all the way to the caller of `emit/2`, not because a sink
+  happens to be reliable.
+
+  Two implementations exist:
+
+  - `Nucleus.Audit.Sink.Device` — the default, writes to a configured IO
+    device (`:stderr` unless overridden).
+  - `Nucleus.Audit.Sink.Test` — configured in `config/test.exs`, delivers the
+    record to a registered test process instead of a real device.
+  """
+
+  @doc """
+  Writes one encoded record. `iodata` is already the fully-formatted record
+  (JSON or text, per `Nucleus.Audit.Format`) — a sink's only job is to get it
+  to its destination.
+  """
+  @callback write(iodata()) :: :ok
+end

--- a/lib/nucleus/audit/sink/device.ex
+++ b/lib/nucleus/audit/sink/device.ex
@@ -1,0 +1,54 @@
+defmodule Nucleus.Audit.Sink.Device do
+  @moduledoc """
+  Writes each audit record synchronously to a configured IO device.
+
+  Default device is `:stderr`, distinct from `Logger`'s default of
+  `:stdio` (standard output) — this is AUD-A06 (a separate stream from
+  application logs) satisfied for free by the runtime, with no
+  application-level routing. Override with `AUDIT_DEVICE` (see
+  `config/runtime.exs`) to point at standard output, a file, or any other
+  IO device (a `pid`, e.g. a `StringIO` process — useful for tests that want
+  to assert on the exact bytes written).
+
+  `IO.write/2` to a device is synchronous, which is what AUD-A07 requires:
+  the write completes before this function returns, and this module raises
+  rather than rescuing if the underlying device write fails.
+  """
+
+  @behaviour Nucleus.Audit.Sink
+
+  @impl Nucleus.Audit.Sink
+  def write(iodata) do
+    IO.write(device(), iodata)
+    :ok
+  end
+
+  @doc """
+  Casts an `AUDIT_DEVICE` name (`"stdout"` or `"stderr"`) to the IO device
+  atom Erlang recognises.
+
+  There is no `:stdout` IO device in Erlang/Elixir — standard output is
+  `:stdio` — so `config/runtime.exs` must not pass the env var's literal
+  string through as an atom. Returns `:error` for anything else, which
+  `config/runtime.exs` treats as a file path to open instead.
+
+      iex> Nucleus.Audit.Sink.Device.cast_device_name("stdout")
+      {:ok, :stdio}
+
+      iex> Nucleus.Audit.Sink.Device.cast_device_name("stderr")
+      {:ok, :stderr}
+
+      iex> Nucleus.Audit.Sink.Device.cast_device_name("/var/log/audit.log")
+      :error
+  """
+  @spec cast_device_name(String.t()) :: {:ok, atom()} | :error
+  def cast_device_name("stdout"), do: {:ok, :stdio}
+  def cast_device_name("stderr"), do: {:ok, :stderr}
+  def cast_device_name(_other), do: :error
+
+  defp device do
+    :nucleus
+    |> Application.get_env(Nucleus.Audit, [])
+    |> Keyword.get(:device, :stderr)
+  end
+end

--- a/lib/nucleus/audit/sink/test.ex
+++ b/lib/nucleus/audit/sink/test.ex
@@ -1,0 +1,41 @@
+defmodule Nucleus.Audit.Sink.Test do
+  @moduledoc """
+  Delivers each encoded audit record to a registered test process instead of
+  a real IO device. Configured as the sink in `config/test.exs`.
+
+  `Nucleus.Audit.emit/2` runs entirely in the calling process and writes
+  synchronously (AUD-A07), so `register/1` stores the receiving pid in the
+  *calling* process's dictionary — safe under `async: true`, since no other
+  test's process shares it.
+
+  EN-8's `AuditCase` and its `refute_audit_contains/1` helper are built on
+  this module.
+  """
+
+  @behaviour Nucleus.Audit.Sink
+
+  @key :nucleus_audit_test_pid
+
+  @doc """
+  Registers `pid` (default `self()`) to receive `{:audit, binary}` messages
+  for every record `Nucleus.Audit.emit/2` writes from the current process.
+  """
+  @spec register(pid()) :: :ok
+  def register(pid \\ self()) do
+    Process.put(@key, pid)
+    :ok
+  end
+
+  @impl Nucleus.Audit.Sink
+  def write(iodata) do
+    case Process.get(@key) do
+      nil ->
+        raise "Nucleus.Audit.Sink.Test has no registered process — call " <>
+                "Nucleus.Audit.Sink.Test.register/1 before emitting an audit event in a test"
+
+      pid ->
+        send(pid, {:audit, IO.iodata_to_binary(iodata)})
+        :ok
+    end
+  end
+end

--- a/lib/nucleus/audit/source.ex
+++ b/lib/nucleus/audit/source.ex
@@ -1,0 +1,48 @@
+defmodule Nucleus.Audit.Source do
+  @moduledoc """
+  Extracts the caller's source IP for an audit record from a `Plug.Conn`.
+
+  Per the wiki's [ADR-0003](https://github.com/dave-bell/nucleus/wiki/ADR-0003-Compliance-Audit-Logging)
+  (reference-only prior art — re-derived here for `Plug.Conn` rather than
+  inherited): prefer the **first** entry of `X-Forwarded-For` — the original
+  client, closest to the browser, as opposed to any intermediate proxy — and
+  fall back to the direct peer address for connections with nothing in front
+  of them (health checks, local dev).
+
+  A malformed or empty header never raises; it falls through to the peer
+  address, and if that is unavailable too, this returns `nil`. A source IP is
+  useful audit context, not a value anything should crash over.
+  """
+
+  @spec from_conn(Plug.Conn.t()) :: String.t() | nil
+  def from_conn(%Plug.Conn{} = conn) do
+    do_from_conn(conn)
+  rescue
+    _ -> nil
+  end
+
+  defp do_from_conn(conn) do
+    case Plug.Conn.get_req_header(conn, "x-forwarded-for") do
+      [value | _] -> first_entry(value) || peer(conn)
+      [] -> peer(conn)
+    end
+  end
+
+  defp first_entry(value) do
+    value
+    |> String.split(",")
+    |> List.first("")
+    |> String.trim()
+    |> case do
+      "" -> nil
+      entry -> entry
+    end
+  end
+
+  defp peer(conn) do
+    case Plug.Conn.get_peer_data(conn) do
+      %{address: address} -> address |> :inet.ntoa() |> to_string()
+      _ -> nil
+    end
+  end
+end

--- a/test/nucleus/audit/format_test.exs
+++ b/test/nucleus/audit/format_test.exs
@@ -1,0 +1,147 @@
+defmodule Nucleus.Audit.FormatTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.Audit.Event
+  alias Nucleus.Audit.Format
+
+  doctest Format
+
+  defp event(overrides \\ %{}) do
+    struct(
+      %Event{
+        event: :secret_viewed,
+        user: "alice",
+        tenant: "acme",
+        timestamp: ~U[2026-08-11 12:34:56Z],
+        source_ip: "203.0.113.7",
+        resource: "acme/prod/api-key",
+        reason: nil,
+        details: %{}
+      },
+      overrides
+    )
+  end
+
+  describe "encode/2 with :json" do
+    @tag :unit
+    test "is a single newline-terminated line, decodable, with an ISO 8601 UTC timestamp" do
+      encoded = Format.encode(event(), :json) |> IO.iodata_to_binary()
+
+      assert String.ends_with?(encoded, "\n")
+      assert [line] = String.split(encoded, "\n", trim: true)
+
+      decoded = Jason.decode!(line)
+
+      assert decoded["event"] == "secret_viewed"
+      assert decoded["user"] == "alice"
+      assert decoded["tenant"] == "acme"
+      assert decoded["timestamp"] == "2026-08-11T12:34:56Z"
+      assert decoded["source_ip"] == "203.0.113.7"
+      assert decoded["resource"] == "acme/prod/api-key"
+    end
+  end
+
+  describe "encode/2 with :text" do
+    @tag :unit
+    test "contains event, user, tenant, resource" do
+      text = Format.encode(event(), :text) |> IO.iodata_to_binary()
+
+      assert text =~ ~s(event="secret_viewed")
+      assert text =~ ~s(user="alice")
+      assert text =~ ~s(tenant="acme")
+      assert text =~ ~s(resource="acme/prod/api-key")
+    end
+
+    @tag :unit
+    test "a % or {} in the resource path does not corrupt the output" do
+      tricky = event(%{resource: ~s(acme/prod/{weird}%20path)})
+
+      text = Format.encode(tricky, :text) |> IO.iodata_to_binary()
+
+      assert [line] = String.split(text, "\n", trim: true)
+      assert line =~ ~s(resource="acme/prod/{weird}%20path")
+    end
+  end
+
+  describe "the AUD-A05 guard" do
+    @tag :unit
+    test "the same event produces the same field set under both formats" do
+      full =
+        event(%{
+          event: :auth_failure,
+          reason: "token expired",
+          details: %{path: "/api/secrets"}
+        })
+
+      json_fields =
+        Format.encode(full, :json)
+        |> IO.iodata_to_binary()
+        |> Jason.decode!()
+        |> Map.keys()
+        |> MapSet.new()
+
+      text = Format.encode(full, :text) |> IO.iodata_to_binary()
+
+      text_keys =
+        text
+        |> String.trim()
+        |> String.split(" ")
+        |> Enum.map(fn pair -> pair |> String.split("=", parts: 2) |> List.first() end)
+        |> MapSet.new()
+
+      # JSON always carries "details" as a nested object; text flattens each
+      # detail key to the top level instead of a container key — the field
+      # *set* recorded is identical, only its shape differs, which is what
+      # AUD-A05 requires.
+      json_without_container = MapSet.delete(json_fields, "details")
+
+      assert MapSet.subset?(json_without_container, text_keys)
+      assert MapSet.subset?(MapSet.new(["path"]), text_keys)
+    end
+
+    @tag :unit
+    test "holds for a record with nil optional fields, as a real secret_viewed emits" do
+      # secret_viewed never carries reason, source_ip, or details — nil
+      # top-level fields are exactly the case that must not vanish from one
+      # format and not the other.
+      sparse =
+        event(%{
+          source_ip: nil,
+          reason: nil,
+          details: %{}
+        })
+
+      json_keys =
+        Format.encode(sparse, :json)
+        |> IO.iodata_to_binary()
+        |> Jason.decode!()
+        |> Map.keys()
+        |> MapSet.new()
+        |> MapSet.delete("details")
+
+      text_keys =
+        Format.encode(sparse, :text)
+        |> IO.iodata_to_binary()
+        |> String.trim()
+        |> String.split(" ")
+        |> Enum.map(fn pair -> pair |> String.split("=", parts: 2) |> List.first() end)
+        |> MapSet.new()
+
+      assert json_keys == text_keys
+    end
+  end
+
+  describe "cast/1" do
+    @tag :unit
+    test "maps the AUDIT_FORMAT values to real formats" do
+      assert Format.cast("json") == {:ok, :json}
+      assert Format.cast("text") == {:ok, :text}
+    end
+
+    @tag :unit
+    test "returns :error for anything else" do
+      assert Format.cast("bogus") == :error
+      assert Format.cast("") == :error
+    end
+  end
+end

--- a/test/nucleus/audit/sink/device_test.exs
+++ b/test/nucleus/audit/sink/device_test.exs
@@ -1,0 +1,56 @@
+defmodule Nucleus.Audit.Sink.DeviceTest do
+  # Mutates :nucleus, Nucleus.Audit application config, which is global.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Audit.Sink.Device
+
+  doctest Device
+
+  setup do
+    original = Application.fetch_env!(:nucleus, Nucleus.Audit)
+    on_exit(fn -> Application.put_env(:nucleus, Nucleus.Audit, original) end)
+    {:ok, original: original}
+  end
+
+  describe "write/1" do
+    @tag :unit
+    test "writes to the configured device", %{original: original} do
+      {:ok, string_io} = StringIO.open("")
+      Application.put_env(:nucleus, Nucleus.Audit, Keyword.put(original, :device, string_io))
+
+      assert Device.write(["hello audit\n"]) == :ok
+      assert {_input, "hello audit\n"} = StringIO.contents(string_io)
+    end
+
+    @tag :unit
+    test ":stderr default is distinct from the Logger device (AUD-A06)" do
+      configured = Application.fetch_env!(:nucleus, Nucleus.Audit) |> Keyword.get(:device)
+
+      assert configured == :stderr
+      # Logger's default handler writes to :stdio (standard output) unless a
+      # deployment redirects it — see docs/adr/0004-audit-emission.md.
+      refute configured == :stdio
+    end
+  end
+
+  describe "cast_device_name/1" do
+    @tag :unit
+    test "maps the AUDIT_DEVICE names to real IO device atoms" do
+      assert Device.cast_device_name("stdout") == {:ok, :stdio}
+      assert Device.cast_device_name("stderr") == {:ok, :stderr}
+    end
+
+    @tag :unit
+    test "there is no :stdout IO device — writing to it raises" do
+      # The bug this guards against: config/runtime.exs must never pass
+      # "stdout" through as the literal atom :stdout.
+      assert_raise ArgumentError, fn -> IO.write(:stdout, "x") end
+    end
+
+    @tag :unit
+    test "returns :error for anything else, treated as a file path upstream" do
+      assert Device.cast_device_name("/var/log/audit.log") == :error
+      assert Device.cast_device_name("") == :error
+    end
+  end
+end

--- a/test/nucleus/audit/source_test.exs
+++ b/test/nucleus/audit/source_test.exs
@@ -1,0 +1,50 @@
+defmodule Nucleus.Audit.SourceTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.Audit.Source
+
+  describe "from_conn/1" do
+    @tag :unit
+    test "chooses the first entry of a multi-hop X-Forwarded-For" do
+      conn =
+        Plug.Test.conn(:get, "/")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "198.51.100.1, 10.0.0.1, 10.0.0.2")
+
+      assert Source.from_conn(conn) == "198.51.100.1"
+    end
+
+    @tag :unit
+    test "trims whitespace around the first entry" do
+      conn =
+        Plug.Test.conn(:get, "/")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "  198.51.100.1 , 10.0.0.1")
+
+      assert Source.from_conn(conn) == "198.51.100.1"
+    end
+
+    @tag :unit
+    test "falls back to the peer address when the header is absent" do
+      conn = Plug.Test.conn(:get, "/")
+
+      assert Source.from_conn(conn) == "127.0.0.1"
+    end
+
+    @tag :unit
+    test "falls back to the peer address when the header is empty" do
+      conn =
+        Plug.Test.conn(:get, "/")
+        |> Plug.Conn.put_req_header("x-forwarded-for", "")
+
+      assert Source.from_conn(conn) == "127.0.0.1"
+    end
+
+    @tag :unit
+    test "a malformed header yields nil rather than raising" do
+      # A bare conn has no adapter, so get_peer_data/1 itself raises — from_conn
+      # must catch that and return nil instead of crashing the caller.
+      conn = %Plug.Conn{req_headers: [{"x-forwarded-for", ""}]}
+
+      assert Source.from_conn(conn) == nil
+    end
+  end
+end

--- a/test/nucleus/audit_test.exs
+++ b/test/nucleus/audit_test.exs
@@ -1,0 +1,162 @@
+defmodule Nucleus.AuditTest do
+  # Mutates :nucleus, Nucleus.Audit application config in the sink-failure
+  # test below, which is global.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Audit
+  alias Nucleus.Audit.Sink
+
+  doctest Nucleus.Audit.Event
+
+  setup do
+    Sink.Test.register(self())
+    :ok
+  end
+
+  defp assert_audit_record do
+    assert_receive {:audit, binary}, 100
+    refute_receive {:audit, _other}, 0
+    Jason.decode!(binary)
+  end
+
+  describe "emit/2 with valid fields" do
+    @tag :unit
+    test "returns :ok and produces exactly one record" do
+      assert Audit.emit(:secret_viewed, tenant: "acme", resource: "acme/prod/api-key") == :ok
+
+      record = assert_audit_record()
+
+      assert record["event"] == "secret_viewed"
+      assert record["tenant"] == "acme"
+      assert record["resource"] == "acme/prod/api-key"
+    end
+  end
+
+  describe "emit/2 validation" do
+    @tag :unit
+    test "an unknown event atom raises" do
+      # Built at runtime: the compiler's type checker rejects the literal,
+      # since it knows :secret_view is outside the declared event union.
+      unknown = String.to_atom("secret_view")
+
+      error = assert_raise ArgumentError, fn -> Audit.emit(unknown, tenant: "acme") end
+
+      assert error.message =~ "unknown audit event :secret_view"
+    end
+
+    @tag :unit
+    test ":secret_viewed without resource raises" do
+      error = assert_raise ArgumentError, fn -> Audit.emit(:secret_viewed, tenant: "acme") end
+
+      assert error.message =~ "missing required field(s)"
+      assert error.message =~ ":resource"
+    end
+
+    @tag :unit
+    test "an unknown field key raises" do
+      error =
+        assert_raise ArgumentError, fn ->
+          Audit.emit(:secret_viewed, tenant: "acme", resource: "x", bogus: 1)
+        end
+
+      assert error.message =~ "unknown field :bogus"
+    end
+
+    @tag :unit
+    test "a value: key raises — the explicit AUD-A02 guard" do
+      error =
+        assert_raise ArgumentError, fn ->
+          Audit.emit(:secret_viewed, tenant: "acme", resource: "x", value: "super-secret")
+        end
+
+      assert error.message =~ "unknown field :value"
+    end
+
+    @tag :unit
+    test "a caller-supplied timestamp is rejected; the emitted timestamp is UTC and current" do
+      error =
+        assert_raise ArgumentError, fn ->
+          Audit.emit(:secret_viewed,
+            tenant: "acme",
+            resource: "x",
+            timestamp: ~U[2000-01-01 00:00:00Z]
+          )
+        end
+
+      assert error.message =~ "unknown field :timestamp"
+
+      before = DateTime.utc_now()
+      assert Audit.emit(:secret_viewed, tenant: "acme", resource: "x") == :ok
+      afterward = DateTime.utc_now()
+
+      record = assert_audit_record()
+      {:ok, timestamp, 0} = DateTime.from_iso8601(record["timestamp"])
+
+      assert DateTime.compare(timestamp, before) != :lt
+      assert DateTime.compare(timestamp, afterward) != :gt
+    end
+
+    @tag :unit
+    test "absent user becomes \"anonymous\"" do
+      assert Audit.emit(:secret_viewed, tenant: "acme", resource: "x") == :ok
+
+      assert assert_audit_record()["user"] == "anonymous"
+    end
+
+    @tag :unit
+    test "an unknown field key raises even when nested under :details" do
+      # secret_created's spec doesn't allow a top-level :details key at all,
+      # so this only proves the top-level check, not the per-event details
+      # allowlist below.
+      error =
+        assert_raise ArgumentError, fn ->
+          Audit.emit(:secret_created,
+            tenant: "acme",
+            resource: "x",
+            details: %{value: "super-secret"}
+          )
+        end
+
+      assert error.message =~ "unknown field :details for audit event :secret_created"
+    end
+
+    @tag :unit
+    test "an unknown key inside details raises — the per-event details allowlist" do
+      # nomad_var_viewed does support :details, so this exercises the inner
+      # key allowlist itself, not the outer :details rejection above.
+      error =
+        assert_raise ArgumentError, fn ->
+          Audit.emit(:nomad_var_viewed,
+            tenant: "acme",
+            details: %{path: "/api/secrets", key: "DATABASE_URL", value: "super-secret"}
+          )
+        end
+
+      assert error.message =~ "unknown detail :value for audit event :nomad_var_viewed"
+    end
+
+    @tag :unit
+    test "a required detail key raises when missing" do
+      error =
+        assert_raise ArgumentError, fn ->
+          Audit.emit(:nomad_var_viewed, tenant: "acme", details: %{key: "DATABASE_URL"})
+        end
+
+      assert error.message =~ "missing required field(s)"
+      assert error.message =~ ":path"
+    end
+  end
+
+  describe "emit/2 sink failure (AUD-A07)" do
+    @tag :unit
+    test "a raising sink propagates rather than being swallowed" do
+      original = Application.fetch_env!(:nucleus, Audit)
+      Application.put_env(:nucleus, Audit, Keyword.put(original, :sink, Sink.Raising))
+      on_exit(fn -> Application.put_env(:nucleus, Audit, original) end)
+
+      assert_raise RuntimeError, "boom: the sink is down", fn ->
+        Audit.emit(:secret_viewed, tenant: "acme", resource: "x")
+      end
+    end
+  end
+end

--- a/test/support/audit_sink_raising.ex
+++ b/test/support/audit_sink_raising.ex
@@ -1,0 +1,14 @@
+defmodule Nucleus.Audit.Sink.Raising do
+  @moduledoc """
+  A `Nucleus.Audit.Sink` that always raises, for asserting AUD-A07 — that a
+  sink failure propagates out of `Nucleus.Audit.emit/2` instead of being
+  swallowed into a silent no-op.
+  """
+
+  @behaviour Nucleus.Audit.Sink
+
+  @impl Nucleus.Audit.Sink
+  def write(_iodata) do
+    raise "boom: the sink is down"
+  end
+end


### PR DESCRIPTION
## What

`Nucleus.Audit` adds a synchronous, structured audit emitter that bypasses `Logger` entirely, so that the three Secrets actions (`secret_created`, `secret_viewed`, `secret_updated`) — and eight more catalogued events reserved for later features — have a place to write compliance-grade records without any risk of the value itself leaking into them. The emitter enforces a strict per-event field allowlist (including a per-event `details` allowlist), stamps its own UTC timestamp, defaults `user` to `"anonymous"`, and never rescues a sink failure into a silent no-op.

## How

- `Nucleus.Audit.emit/2` validates the event atom, required fields, and allowed fields (including nested `details` keys) before building a `%Nucleus.Audit.Event{}` — there is no `value`/`secret`/`plaintext` key anywhere in the struct, so a call site cannot pass one through by accident (**AUD-A02**).
- `Nucleus.Audit.Sink` behaviour (`@callback write(iodata()) :: :ok`) with two implementations: `Sink.Device`, which writes synchronously via `IO.write/2` to a configured device (default `:stderr`, distinct from `Logger`'s `:stdio` default — **AUD-A06** for free, no application routing needed), and `Sink.Test`, which delivers records to a registered test process for EN-8's `AuditCase`. Neither implementation rescues a raise, so a failing sink fails the audited action itself (**AUD-A07**).
- `Nucleus.Audit.Format` serialises strictly downstream of `emit/2`'s validation, so `:json` and `:text` always carry the identical field set — the **AUD-A05** guarantee that format cannot change what is recorded.
- `Nucleus.Audit.Source.from_conn/1` extracts `source_ip` from the first entry of `X-Forwarded-For`, falling back to the peer address.
- Config wiring in `config/config.exs` (JSON/`:stderr` default), `config/dev.exs` (`:text`), `config/test.exs` (`Sink.Test`), and `config/runtime.exs` (`AUDIT_FORMAT`/`AUDIT_DEVICE` overrides), following the same cast-then-raise-on-typo pattern already used for `Nucleus.Backend.impl_for_mode!/2`.

## Divergence from the plan

Two bugs were found and fixed during review that the issue didn't anticipate:

1. **`AUDIT_DEVICE=stdout` crashed every audit write.** The env var's literal string was going to be passed straight through as an atom, but `:stdout` is not a real Erlang IO device — the actual name is `:stdio`. Fixed by extracting `Nucleus.Audit.Sink.Device.cast_device_name/1`, which maps `"stdout"` → `:stdio` and `"stderr"` → `:stderr` (anything else is treated as a file path), with doctests and a regression test in `test/nucleus/audit/sink/device_test.exs`.
2. **`:text` format silently dropped `nil` fields, breaking AUD-A05 parity.** `:json` always encodes every top-level key (`nil` as `null`), but the original `:text` encoder omitted `nil` fields entirely — for exactly the events this ticket wires up (`secret_viewed` never has a `reason` or `source_ip`), the two formats would have disagreed about what was recorded. Fixed in `Nucleus.Audit.Format.cast/1`/`encode_text/1` to always print every top-level field, with a comment explaining why and coverage in `test/nucleus/audit/format_test.exs`.

Additionally, one test that claimed to cover the per-event `details` allowlist (`"an unknown field key raises even when nested under :details"`) was actually only exercising the outer `:details`-key rejection, since the event it used (`secret_created`) doesn't support `details` at all. It's now correctly labelled, and a new test (`"an unknown key inside details raises — the per-event details allowlist"`, using `:nomad_var_viewed`, which does declare `details`) exercises the actual inner-key allowlist.

Otherwise the implementation follows the issue's plan as written: the event struct, emitter, sink behaviour, formatting, source extraction, and config wiring all match the proposed shapes, and the eleven-event type union is defined with only the three Secrets events wired.

## Verification

- `mix precommit` passes.
- New tests: `test/nucleus/audit_test.exs`, `test/nucleus/audit/format_test.exs`, `test/nucleus/audit/source_test.exs`, `test/nucleus/audit/sink/device_test.exs`, plus `test/support/audit_sink_raising.ex` for the sink-failure propagation case.
- `docs/adr/0003-audit-emission.md` added, with a matching decision entry (#3) in `.opencode/context/project-intelligence/decisions-log.md`, following the same-PR precedent set by decisions #1 and #2.

Closes #5
