### PR TITLE
EN-6: Identity/scope seam with auth disabled by default (no Cognito)

### DIFF
--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.3 | Updated: 2026-08-11 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.4 | Updated: 2026-08-11 -->
 
 # Decisions Log
 
@@ -20,6 +20,7 @@
 | 2 | Backend adapter boundaries — behaviours, tagged-tuple errors, per-boundary real/local selection | 2026-08-07 | Decided | `docs/adr/0002-backend-adapter-boundaries.md` |
 | 3 | Shared local backend seed — one supervised `Agent`, boundary-neutral, started everywhere | 2026-08-11 | Decided | `docs/adr/0003-shared-local-backend-seed.md` |
 | 4 | Audit emission — bypasses `Logger`, synchronous `Sink` behaviour, per-event field allowlist | 2026-08-11 | Decided | `docs/adr/0004-audit-emission.md` |
+| 5 | Deferred authentication — `Nucleus.Scope` seam, disabled-by-default provider, fail-loud `AUTH_ENABLED` | 2026-08-11 | Decided | `docs/adr/0005-deferred-authentication.md` |
 
 Two things this file deliberately does **not** contain:
 
@@ -29,8 +30,9 @@ Two things this file deliberately does **not** contain:
    **reference material only** and carry no status here. Adopting one is a decision made on
    its own merits in `docs/adr/`, not by citation.
 
-**Next decision likely needed** (tracked in `living-notes.md`): how token passthrough works
-across a long-lived LiveView socket.
+**Next decision likely needed** (tracked in `living-notes.md`): how a real token gets held and
+refreshed across a long-lived LiveView socket — narrowed by EN-6 to a fixed `token` field on
+`Nucleus.Scope`, still open on *how* it is held.
 
 ## Decision Template
 
@@ -110,6 +112,28 @@ local option)
 
 ---
 
+## Decision: Deferred Authentication
+
+**Date**: 2026-08-11 | **Status**: Decided | **ADR**: `docs/adr/0005-deferred-authentication.md`
+
+`Nucleus.Scope` (`user`, `tenant`, `token`, `scopes`, `source_ip`) is the one shape every
+LiveView, plug, and future audit call site reads identity from, whether auth is real or not.
+`Nucleus.Scope.Provider.Disabled` (default, `AUTH_ENABLED=false`) never fails and returns a
+single configured dev identity; `Nucleus.Scope.Provider.Cognito` is a stub that raises
+unconditionally. `Nucleus.Scope.verify_provider_at_boot!/0` calls whichever is configured on
+every boot, so `AUTH_ENABLED=true` fails the boot loudly instead of silently keeping the
+disabled provider on the first request. `token` is always `nil` for now — the field exists so
+retrofitting real token passthrough later is a substitution, not a refactor of every call site
+that reads it.
+
+**Related**: Issue #6 (EN-6, the deciding issue) · Issue #7 (EN-7, wires the plug/hook into the
+router) · Issue #15 (SEC-S7, the future consumer of the credential-expiry state this seam's
+`token` field exists for) · `docs/adr/0002-backend-adapter-boundaries.md` (the boot-warning
+pattern this builds on) · `docs/adr/0004-audit-emission.md` (`Nucleus.Audit.Source.from_conn/1`,
+reused here for the plug's `source_ip` capture)
+
+---
+
 ## Deprecated Decisions
 
 Decisions that were later overturned (for historical context):
@@ -120,7 +144,7 @@ Decisions that were later overturned (for historical context):
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0004` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0005` are binding
 - [ ] Know that the wiki's ADR-0001–0007 are reference only, not adopted
 - [ ] Know that new formal ADRs belong in `docs/adr/`, with only a short summary mirrored here
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.1 | Updated: 2026-08-07 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.2 | Updated: 2026-08-11 -->
 
 # Living Notes
 
@@ -45,10 +45,12 @@ expires mid-session. The requirements already anticipate the expiry case in `SEC
 (b) short-lived token in socket state with an explicit refresh path; (c) a per-user
 server-side credential holder process — note (c) is in tension with the stateless constraint.
 *Timeline*: Blocks all three backend integrations; needed before the first feature LiveView.
-*Status*: Open — narrowed by EN-3. `Nucleus.TenantApi.list_environments/1` now takes
-`token :: String.t() | nil` and its `Http` implementation tolerates `nil` (no `Authorization`
-header), so the *boundary-facing* signature is fixed. How that token actually reaches the call
-from a LiveView socket — options (a)/(b)/(c) above — is still open and deferred to EN-6.
+*Status*: Open — narrowed again by EN-6. `Nucleus.Scope` (`lib/nucleus/scope.ex`) now carries
+a `token` field, always `nil` while auth is disabled, and `NucleusWeb.Plugs.AssignScope`
+defensively forces `token` to `nil` before writing the scope into the session regardless of
+what a provider returns — a floor, not an answer. Which of options (a)/(b)/(c) above actually
+holds the token once one is real, and how it survives a socket reconnect, is still open and
+deferred to the real auth ticket. See `docs/adr/0005-deferred-authentication.md`.
 
 **Do the wiki's `AUTH-*` actions still describe the intended flow?**
 *Context*: `Authentication-and-Access.md` defines `AUTH-A01`–`A11`. These were written against
@@ -60,7 +62,10 @@ over a LiveView socket may not match action-for-action. Unlike other pages, wher
 *Options*: Re-verify each of the 11 actions; amend the wiki where LiveView genuinely differs.
 Amend the wiki — do not silently reinterpret, since the wiki is the binding source.
 *Timeline*: Before implementing authentication.
-*Status*: Open
+*Status*: Open — EN-6 built the `Nucleus.Scope`/`Nucleus.Scope.Provider` seam against the
+current eleven actions without re-verifying them, and deliberately implements none of
+`AUTH-A01`–`A11` (no `@tag action:` in its tests) so `mix nucleus.trace` cannot report false
+coverage. Re-verification is still needed before the real auth ticket, not before this one.
 
 ## Known Issues
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -44,6 +44,21 @@ config :nucleus, Nucleus.TenantApi.Http,
   connect_timeout_ms: 5_000,
   receive_timeout_ms: 10_000
 
+# Identity/scope seam (EN-6) — auth is deliberately deferred; see
+# lib/nucleus/scope.ex and docs/adr/0005-deferred-authentication.md.
+#
+# Nucleus.Scope.Provider.Disabled is the default in every environment: it
+# never fails and returns a single configured dev identity. AUTH_ENABLED=true
+# switches `:provider` to Nucleus.Scope.Provider.Cognito in runtime.exs, which
+# raises unconditionally — there is no AUTH_ENABLED default here because
+# "false" and "unset" must behave identically, and the config default already
+# gives that.
+#
+# tenant_namespace has no default host to guess at, so "local" is a
+# deliberately obvious placeholder — runtime.exs fills it from
+# TENANT_NAMESPACE in any environment where the tenant is known.
+config :nucleus, Nucleus.Scope, tenant_namespace: "local"
+
 # Compliance audit trail (SOC2 CC7.2 / HIPAA 164.312(b)) — bypasses Logger and
 # writes synchronously to a dedicated sink, distinct from application logs
 # (AUD-A06/A07). See lib/nucleus/audit.ex and

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -57,6 +57,14 @@ config :nucleus, :backends,
 # differs here, not which events are audited.
 config :nucleus, Nucleus.Audit, format: :text
 
+# Auth is disabled by default (see config/config.exs); this is the dev
+# identity Nucleus.Scope.Provider.Disabled assigns to every session. With
+# AUTH_ENABLED=true this is unused — email and scopes come from the minted
+# JWT instead (EN-6, deferred; see docs/adr/0005-deferred-authentication.md).
+config :nucleus, Nucleus.Scope.Provider.Disabled,
+  email: "dev@example.com",
+  scopes: []
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :default_formatter, format: "[$level] $message\n"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -94,6 +94,37 @@ if audit_device = System.get_env("AUDIT_DEVICE") do
   config :nucleus, Nucleus.Audit, device: device
 end
 
+# Identity/scope seam (EN-6). AUTH_ENABLED selects the scope provider;
+# "false" or unset (the default) keeps Nucleus.Scope.Provider.Disabled.
+# "true" switches to Nucleus.Scope.Provider.Cognito, a stub that raises
+# unconditionally — Nucleus.Scope.verify_provider_at_boot!/0 calls it during
+# Nucleus.Application.start/2, so a misread flag fails the boot rather than
+# silently keeping the disabled provider. Anything else raises here, at boot,
+# rather than being silently treated as "false" — same reasoning as
+# AUDIT_FORMAT above. See docs/adr/0005-deferred-authentication.md.
+case System.get_env("AUTH_ENABLED") do
+  nil ->
+    :ok
+
+  "false" ->
+    :ok
+
+  "true" ->
+    config :nucleus, Nucleus.Scope, provider: Nucleus.Scope.Provider.Cognito
+
+  other ->
+    raise "AUTH_ENABLED must be \"true\" or \"false\", got: #{inspect(other)}"
+end
+
+# The tenant this deployment serves, carried on every Nucleus.Scope (EN-5's
+# audit records and EN-6's identity display both read it). No boot-time
+# presence check, same reasoning as TENANT_API_BASE_URL above — the
+# config.exs default ("local") is a deliberately obvious placeholder, not a
+# host to fail loudly on the absence of.
+if tenant_namespace = System.get_env("TENANT_NAMESPACE") do
+  config :nucleus, Nucleus.Scope, tenant_namespace: tenant_namespace
+end
+
 if config_env() == :dev do
   # Reload browser tabs when matching files change.
   config :nucleus, NucleusWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,6 +20,13 @@ config :nucleus, :backends,
 # registered process, rather than parsing :stderr.
 config :nucleus, Nucleus.Audit, sink: Nucleus.Audit.Sink.Test
 
+# A fixed, deliberately different-from-the-default dev identity, so a test
+# asserting the configured value is not accidentally passing against the
+# same literal used elsewhere.
+config :nucleus, Nucleus.Scope.Provider.Disabled,
+  email: "test-dev@example.com",
+  scopes: ["test-scope"]
+
 # Disable swoosh api client as it is only required for production adapters
 config :swoosh, :api_client, false
 

--- a/docs/adr/0005-deferred-authentication.md
+++ b/docs/adr/0005-deferred-authentication.md
@@ -1,0 +1,245 @@
+# ADR-0005: Deferred Authentication
+
+## Status
+
+Accepted — 2026-08-11
+
+Decided on [EN-6](https://github.com/dave-bell/nucleus/issues/6). Builds on
+`0002-backend-adapter-boundaries.md` (the boot-warning pattern) and
+`0004-audit-emission.md` (the `source_ip`/`X-Forwarded-For` extraction
+algorithm, and the explicit handoff of LiveView-socket source-IP capture to
+this ticket).
+
+**Numbering note**: the issue text names this file
+`0004-deferred-authentication.md`, written before `0004-audit-emission.md`
+(EN-5) landed. `0004` was already taken by the time this ticket started, so
+this ADR is `0005` — a sequencing collision in the ticket text, not a
+decision to revisit.
+
+The wiki's [ADR-0002](https://github.com/dave-bell/nucleus/wiki/ADR-0002-Security-Hardening)
+§6 (audit identity fallback) and §7 (never expose a raw token in logs), under
+`docs/requirements/`, describe the earlier Python prototype and are
+**reference only**. Where this ADR reaches the same conclusion — the
+email-then-username-then-anonymous fallback — it is because that rule was
+re-verified for this stack, not inherited by citation.
+
+## Context
+
+`AGENTS.md` is explicit that Phoenix 1.8 LiveViews require a `current_scope`
+assign, and that omitting it produces its own error class. Every audit record
+(EN-5) needs a `user` and a `tenant`. `SEC-A18` needs somewhere for "your
+session has expired, re-authenticate" to eventually hang off. Secrets
+(SEC-S1 onward) cannot be built against none of this.
+
+At the same time, real authentication is deliberately **not** ready to build.
+The wiki's [Authentication & Access](https://github.com/dave-bell/nucleus/wiki/Authentication-and-Access)
+page defines `AUTH-A01`–`AUTH-A11` — Cognito Hosted UI, federated SSO, PKCE,
+group membership, silent refresh — against an earlier prototype with a React
+SPA. `living-notes.md` records two open questions neither settled by this
+ticket:
+
+1. How does a signed-in user's access token pass through a long-lived
+   LiveView socket, when the original HTTP request that authenticated it is
+   gone?
+2. Do the eleven `AUTH-*` actions still describe the intended flow now that
+   there is no SPA to redirect?
+
+This ADR is the seam that lets Secrets proceed without either question being
+open a blocker: the *shape* of an authenticated request is fixed now, so that
+building the real thing later is a substitution behind that shape, not a
+refactor of every LiveView and every backing-API call site that reads it.
+
+## Decision
+
+### `Nucleus.Scope` is the only shape anything downstream reads
+
+`lib/nucleus/scope.ex` defines `user`, `tenant`, `token`, `scopes`, and
+`source_ip`. No caller — a LiveView, a plug, an audit call site — reads
+identity from anywhere else. Whether that struct was built by a real sign-in
+or (for the whole of this ticket) a single configured dev identity is
+invisible past `Nucleus.Scope.Provider.build/1`.
+
+### `token` exists now and is always `nil`
+
+Retrofitting a `token` field later would touch every backing-API call site
+that needs to pass it through. The field is added now, deliberately unused,
+so that the future auth ticket's job is to populate it, not to invent it and
+thread it through code that has never seen a token-shaped argument. Nothing
+in this ticket fabricates a value for it — a fake token would be worse than a
+missing one, since it would look like passthrough was already solved.
+
+### `audit_user/1`: email, then username, then `"anonymous"`
+
+Re-verified from the wiki's ADR-0002 §6, not inherited: Cognito access tokens
+carry no `email` claim, only ID tokens do, and the access token is what
+`AUTH-A11`'s API contract forwards to backing APIs. An audit emitter reading
+only `email` would silently record `"anonymous"` for every real user once
+auth exists. Encoding the fallback in `Nucleus.Scope.audit_user/1` now, while
+the only caller is `Nucleus.Scope.verify_provider_at_boot!/0`'s warning,
+means EN-5's audit call sites inherit the correct behaviour rather than
+rediscovering it.
+
+### Two providers behind one behaviour, selected by one flag
+
+`Nucleus.Scope.Provider` declares `@callback build(context :: map()) ::
+{:ok, Scope.t()} | {:error, term()}`. `Nucleus.Scope.Provider.Disabled` (the
+default) never fails and returns a scope built from a single configured dev
+identity. `Nucleus.Scope.Provider.Cognito` is a stub that raises
+unconditionally, naming `AUTH-A01..A11`.
+
+`AUTH_ENABLED` (`config/runtime.exs`, default `false`) selects between them.
+Unlike `SECRETS_BACKEND`/`TENANT_API_BACKEND` (`docs/adr/0002`), this is not a
+per-boundary developer convenience — it is the one switch between "no
+authentication exists" and "real authentication, which does not exist yet
+either." An unrecognised value raises at boot, the same defence
+`AUDIT_FORMAT` uses (`docs/adr/0004-audit-emission.md`): a typo here must not
+silently keep the disabled provider.
+
+### The dev identity is compile-time config, not an environment variable
+
+`Nucleus.Scope.Provider.Disabled` reads its assumed email and scopes from
+`config :nucleus, Nucleus.Scope.Provider.Disabled, email: ..., scopes: ...`
+(set in `config/dev.exs`; `config/test.exs` overrides it to a
+distinguishable value). This differs from the issue text's literal
+`DEV_USER_EMAIL`/`DEV_USER_SCOPES` environment variables: with
+`AUTH_ENABLED=true`, the equivalent values come from the minted JWT's claims,
+not from an environment variable — so there is no runtime configuration
+surface for this identity to still occupy once real auth exists, and no
+env-var-vs-JWT precedence question to get wrong later.
+
+`TENANT_NAMESPACE` remains a `config/runtime.exs` environment variable,
+because the tenant a deployment serves is infrastructure configuration, not
+an identity claim — both providers will need it, not just `Disabled`.
+
+### Boot verifies the provider unconditionally — warn or fail loudly
+
+`Nucleus.Scope.verify_provider_at_boot!/0`, called from
+`Nucleus.Application.start/2` alongside `Nucleus.Backend.warn_on_local_backends/0`,
+calls `build/1` on whichever provider is configured, every boot, regardless
+of which one that is:
+
+- `Disabled.build/1` always succeeds, and the boot warning names the
+  assumed identity, tenant, and scopes — the same rationale as EN-2's
+  local-backend warning: make the insecure-but-convenient mode impossible to
+  be in accidentally.
+- `Cognito.build/1` always raises. Calling it at boot means an
+  `AUTH_ENABLED=true` misconfiguration fails the *boot*, not the first
+  request — a loud, early failure rather than a silent fallback to the
+  disabled provider.
+
+No `rescue` wraps this call. A rescued boot check would defeat the entire
+point: the failure must stop the release from serving traffic.
+
+### The plug captures `source_ip`; the LiveView hook carries it forward
+
+`NucleusWeb.Plugs.AssignScope` builds the scope and assigns
+`conn.assigns.current_scope` for the `:browser` pipeline, capturing
+`source_ip` via `Nucleus.Audit.Source.from_conn/1` — the same function EN-5
+built, at the one point a `Plug.Conn` (and so `X-Forwarded-For`) exists for a
+LiveView request. It also puts the scope into the session, with `token`
+forced to `nil` regardless of what the provider returned: the session is a
+signed, not encrypted, cookie, and this is a defensive floor that costs
+nothing today and rules out a future provider leaking a token into it by
+omission.
+
+`NucleusWeb.ScopeHook.on_mount/4` prefers that session-carried scope. When
+there is none — a LiveView mounted outside the `:browser` pipeline, or a
+socket with no prior request — it builds one fresh, reading `source_ip` from
+`get_connect_info(socket, :x_headers)`, re-deriving the same
+first-`X-Forwarded-For`-entry algorithm `Nucleus.Audit.Source` uses for a
+`Plug.Conn`, because that module "deliberately knows nothing about LiveView
+sockets" (`docs/adr/0004-audit-emission.md`) and capturing it here was
+explicitly left to this ticket. `lib/nucleus_web/endpoint.ex`'s LiveView
+socket now declares `:x_headers` in `connect_info` so the value is available
+to read at all.
+
+### Nothing renders an identity control in this ticket
+
+`AUTH-A10` (sign-out) and `AUTH-A11` (identity display) are explicitly out of
+scope. This ticket adds no LiveView and touches no template — the existing
+`Layouts.app` does not render `current_scope` at all yet. EN-7 owns the
+identity control and has already settled (in its own plan) on rendering no
+sign-out control while auth is disabled, rather than a disabled one that does
+nothing.
+
+## Consequences
+
+### Positive
+
+- Every future LiveView and every EN-5 audit call site reads identity from
+  one struct, regardless of whether auth is real yet.
+- `AUTH_ENABLED=true` fails at boot, not on the first authenticated request —
+  the same class of defence as `Nucleus.Backend`'s per-boundary mode
+  validation.
+- Adding real authentication later is bounded to `Nucleus.Scope.Provider.Cognito`
+  and populating `token`; no LiveView, plug, or audit call site changes shape.
+
+### Negative
+
+- **The token-passthrough question is narrowed, not answered.** `token` has
+  a fixed field and a fixed rule (never populate it here), but *how* a real
+  token would be kept out of the session cookie, refreshed, or invalidated
+  mid-socket is still open — see `living-notes.md`. The defensive
+  `%{scope | token: nil}` in `AssignScope` is a floor, not a design for that
+  future state.
+- **The `AUTH-*` re-verification question is untouched.** This ADR reserves
+  a seam shaped by the *current* eleven actions; if those actions turn out
+  not to describe the intended LiveView flow, the seam's shape — not just
+  its implementation — may need to change.
+- **No LiveDashboard gating.** `living-notes.md`'s existing technical debt
+  item (LiveDashboard at `/dev/dashboard` unauthenticated) is unaffected by
+  this ticket; there is still no `:auth` boundary to gate it behind.
+
+## Alternatives considered
+
+**Building a minimal real sign-in flow now, deferring only group
+membership.** Rejected. The issue's own context is explicit: token
+passthrough over a LiveView socket and whether the eleven `AUTH-*` actions
+still apply are both unresolved. A "minimal" real implementation would still
+have to guess at both, and guessing now is more expensive to unwind than
+building the seam and deferring the guess.
+
+**Making `AUTH_ENABLED` per-boundary, like `SECRETS_BACKEND`.** Rejected.
+Backend boundaries are swappable because the *pain* they solve (a
+Terraform-provisioned IAM role) is per boundary. Authentication is the
+security boundary itself — `docs/adr/0002-backend-adapter-boundaries.md`
+already rules out an `:auth` boundary for the same reason.
+
+**Reading the dev identity from `DEV_USER_EMAIL`/`DEV_USER_SCOPES`
+environment variables, as the issue text literally proposes.** Rejected in
+favour of compile-time config in `config/dev.exs`. With `AUTH_ENABLED=true`
+those values come from the JWT, not the environment, so an env-var-based dev
+identity would be a runtime configuration surface with no real-auth
+counterpart to eventually replace it — a dead knob once auth ships, and a
+second source of truth (env var vs. JWT claim) to reconcile in the meantime.
+
+**Storing the whole `Nucleus.Scope` in the session, token included.**
+Rejected. `token` is always `nil` in this ticket, so it is functionally
+identical to forcing it to `nil` — but forcing it costs one line and removes
+a future footgun: a provider change that starts populating `token` would
+otherwise put it straight into a signed-but-unencrypted cookie by omission,
+not by a decision anyone made.
+
+## References
+
+- EN-6 — the deciding issue, including the full implementation and test plan
+- `docs/adr/0002-backend-adapter-boundaries.md` — the boot-warning pattern
+  this ADR's `Nucleus.Scope.verify_provider_at_boot!/0` follows; "Authentication
+  is never swappable"
+- `docs/adr/0004-audit-emission.md` — `Nucleus.Audit.Source.from_conn/1`, and
+  its explicit statement that LiveView-socket source-IP capture is this
+  ticket's job
+- Wiki [Authentication & Access](https://github.com/dave-bell/nucleus/wiki/Authentication-and-Access)
+  (`AUTH-A01`–`A11`, deferred in full);
+  [ADR-0002](https://github.com/dave-bell/nucleus/wiki/ADR-0002-Security-Hardening)
+  §6/§7 — reference only; prior art, not authority
+- `.opencode/context/project-intelligence/living-notes.md` — the
+  token-passthrough and `AUTH-*` re-verification open questions, both
+  narrowed but not closed here
+- `AGENTS.md` — `current_scope` / `Layouts.app` convention; `on_mount` at the
+  `live_session` level, not per-LiveView
+- Issue #7 (EN-7) — wires `AssignScope`/`ScopeHook` into the router and
+  renders the identity control, with no sign-out affordance while auth is
+  disabled
+- Issue #15 (SEC-S7) — the future consumer of the credential-expiry state
+  this seam's `token` field exists for

--- a/lib/nucleus/application.ex
+++ b/lib/nucleus/application.ex
@@ -8,6 +8,7 @@ defmodule Nucleus.Application do
   @impl true
   def start(_type, _args) do
     Nucleus.Backend.warn_on_local_backends()
+    Nucleus.Scope.verify_provider_at_boot!()
 
     children = [
       NucleusWeb.Telemetry,

--- a/lib/nucleus/scope.ex
+++ b/lib/nucleus/scope.ex
@@ -1,0 +1,145 @@
+defmodule Nucleus.Scope do
+  @moduledoc """
+  The current request/session identity — Phoenix 1.8's `current_scope` convention.
+
+  Every authenticated LiveView and every audit record needs a `user` and a
+  `tenant`; `AGENTS.md` is explicit that a missing `current_scope` assign
+  produces its own error class. This struct is the seam: it exists so those
+  call sites have a stable shape to read from, whether the identity behind it
+  came from a real sign-in or (for the whole of EN-6) a single configured dev
+  identity — see `Nucleus.Scope.Provider`.
+
+  ## Fields
+
+  - `user` — `%{email: String.t() | nil, username: String.t() | nil} | nil`.
+    `nil` means unauthenticated; `authenticated?/1` is the read.
+  - `tenant` — the tenant namespace this session is scoped to, from
+    `tenant_namespace/0` (`TENANT_NAMESPACE`).
+  - `token` — the user's access token, for passthrough to backing APIs.
+    **Always `nil` for the whole of EN-6.** The field exists now so that
+    retrofitting it later is a substitution, not a refactor of every
+    backing-API call site — see `docs/adr/0005-deferred-authentication.md`.
+    Never populate this with a fabricated value.
+  - `scopes` — `[String.t()]`, the granted access scopes (`AUTH-A11` /
+    `NAV-A08`). Always `[]` while auth is disabled.
+  - `source_ip` — the caller's source IP, captured once at connect
+    (`Plug.Conn` for a regular request, `get_connect_info/2` for a LiveView
+    socket) because `X-Forwarded-For` is unavailable on later `handle_event`
+    calls. EN-5's audit emitter reads this field, never a `Plug.Conn`.
+
+  ## Never render this struct wholesale
+
+  LiveView diffs *rendered output*, not raw assigns — a token sitting in
+  `socket.assigns.current_scope.token` is never shipped to the client unless
+  something renders it. That is a constraint on template authors, not an
+  ambient guarantee: never write `inspect(@current_scope)` or similar in a
+  debug block, in this ticket or later once `token` is populated.
+  """
+
+  require Logger
+
+  alias Nucleus.Scope.Provider
+
+  defstruct user: nil, tenant: nil, token: nil, scopes: [], source_ip: nil
+
+  @type user :: %{email: String.t() | nil, username: String.t() | nil}
+
+  @type t :: %__MODULE__{
+          user: user() | nil,
+          tenant: String.t() | nil,
+          token: String.t() | nil,
+          scopes: [String.t()],
+          source_ip: String.t() | nil
+        }
+
+  @doc """
+  Whether `scope` carries a signed-in user.
+
+      iex> Nucleus.Scope.authenticated?(%Nucleus.Scope{user: nil})
+      false
+
+      iex> Nucleus.Scope.authenticated?(%Nucleus.Scope{user: %{email: "a@b.com", username: nil}})
+      true
+  """
+  @spec authenticated?(t()) :: boolean()
+  def authenticated?(%__MODULE__{user: nil}), do: false
+  def authenticated?(%__MODULE__{user: %{}}), do: true
+
+  @doc """
+  The identity to record on an audit event, per ADR-0002 §6 (wiki, reference
+  only — re-verified here, not inherited): Cognito access tokens carry no
+  `email` claim, so prefer email, fall back to username, and never leave an
+  audit record with no identity at all.
+
+      iex> Nucleus.Scope.audit_user(%Nucleus.Scope{user: %{email: "a@b.com", username: "auser"}})
+      "a@b.com"
+
+      iex> Nucleus.Scope.audit_user(%Nucleus.Scope{user: %{email: nil, username: "auser"}})
+      "auser"
+
+      iex> Nucleus.Scope.audit_user(%Nucleus.Scope{user: nil})
+      "anonymous"
+  """
+  @spec audit_user(t()) :: String.t()
+  def audit_user(%__MODULE__{user: %{email: email}}) when is_binary(email) and email != "" do
+    email
+  end
+
+  def audit_user(%__MODULE__{user: %{username: username}})
+      when is_binary(username) and username != "" do
+    username
+  end
+
+  def audit_user(%__MODULE__{}), do: "anonymous"
+
+  @doc """
+  The tenant namespace every scope is built against.
+
+  Read from `config :nucleus, Nucleus.Scope, tenant_namespace: ...`, set by
+  `TENANT_NAMESPACE` in `config/runtime.exs`. Defaults to `"local"` so a fresh
+  clone boots with no configuration at all.
+
+      iex> Nucleus.Scope.tenant_namespace()
+      "local"
+  """
+  @spec tenant_namespace() :: String.t()
+  def tenant_namespace do
+    Application.get_env(:nucleus, __MODULE__, [])
+    |> Keyword.get(:tenant_namespace, "local")
+  end
+
+  @doc """
+  Called once from `Nucleus.Application.start/2`.
+
+  Builds a scope through the configured `Nucleus.Scope.Provider` unconditionally,
+  the same way `Nucleus.Backend.warn_on_local_backends/0` verifies backend
+  configuration at boot rather than on first use:
+
+  - `Nucleus.Scope.Provider.Disabled` (default, `AUTH_ENABLED=false`) never
+    fails, so this always succeeds — and logs one prominent warning naming the
+    assumed dev identity and tenant, so the insecure-but-convenient mode is
+    never silently in effect.
+  - `Nucleus.Scope.Provider.Cognito` (`AUTH_ENABLED=true`) raises
+    unconditionally. That raise propagates straight out of `start/2` and fails
+    the boot — a loud failure at the earliest possible point, not a silent
+    fallback to the disabled provider on the first request.
+  """
+  @spec verify_provider_at_boot!() :: :ok
+  def verify_provider_at_boot! do
+    provider = Provider.configured()
+    {:ok, scope} = provider.build(%{})
+
+    if provider == Nucleus.Scope.Provider.Disabled do
+      Logger.warning("""
+      AUTH DISABLED — every session is assigned the dev identity below. This \
+      must never reach a deployed environment; see AUTH_ENABLED and \
+      docs/adr/0005-deferred-authentication.md.
+        * user   -> #{audit_user(scope)}
+        * tenant -> #{scope.tenant}
+        * scopes -> #{inspect(scope.scopes)}
+      """)
+    end
+
+    :ok
+  end
+end

--- a/lib/nucleus/scope/provider.ex
+++ b/lib/nucleus/scope/provider.ex
@@ -1,0 +1,57 @@
+defmodule Nucleus.Scope.Provider do
+  @moduledoc """
+  Behaviour for building a `Nucleus.Scope` — the seam between "how identity is
+  established" and everything downstream that only ever reads a `Scope`.
+
+  Two implementations exist for the whole of EN-6:
+
+  | Module | Role |
+  |---|---|
+  | `Nucleus.Scope.Provider.Disabled` | Default. Never fails; returns a scope built from a single configured dev identity. |
+  | `Nucleus.Scope.Provider.Cognito` | A stub. Raises unconditionally — real authentication does not exist yet. |
+
+  `configured/0` resolves which one is active from
+  `config :nucleus, Nucleus.Scope, provider: ...`, set by `AUTH_ENABLED` in
+  `config/runtime.exs`. There is deliberately no `AUTH_BACKEND`-style
+  per-environment fallback logic here beyond that one switch — see
+  `docs/adr/0005-deferred-authentication.md`.
+  """
+
+  alias Nucleus.Scope
+
+  @doc """
+  Builds a scope from `context` — whatever the caller has available (a
+  captured `source_ip`, and eventually request headers or connect info a real
+  provider would need).
+
+  `Nucleus.Scope.Provider.Disabled` never returns `{:error, _}`.
+  `Nucleus.Scope.Provider.Cognito` never returns at all — it raises.
+  """
+  @callback build(context :: map()) :: {:ok, Scope.t()} | {:error, term()}
+
+  @doc """
+  The provider module selected by application configuration.
+
+  Defaults to `Nucleus.Scope.Provider.Disabled` so a fresh clone boots with
+  auth disabled and no configuration at all.
+  """
+  @spec configured() :: module()
+  def configured do
+    Application.get_env(:nucleus, Scope, [])
+    |> Keyword.get(:provider, Nucleus.Scope.Provider.Disabled)
+  end
+
+  @doc """
+  Builds a scope through the configured provider.
+
+  Raises whenever `configured/0` is `Nucleus.Scope.Provider.Cognito` — that
+  provider raises unconditionally. This is deliberate: an `AUTH_ENABLED=true`
+  misconfiguration fails loudly on the very first scope build (boot, see
+  `Nucleus.Scope.verify_provider_at_boot!/0`), not silently on some later
+  request.
+  """
+  @spec build(map()) :: {:ok, Scope.t()} | {:error, term()}
+  def build(context) when is_map(context) do
+    configured().build(context)
+  end
+end

--- a/lib/nucleus/scope/provider/cognito.ex
+++ b/lib/nucleus/scope/provider/cognito.ex
@@ -1,0 +1,31 @@
+defmodule Nucleus.Scope.Provider.Cognito do
+  @moduledoc """
+  The real authentication provider — a stub.
+
+  None of `AUTH-A01`–`AUTH-A11` are implemented (Cognito Hosted UI, PKCE,
+  token validation, group membership, silent refresh, sign-out, identity
+  display). Selecting this provider (`AUTH_ENABLED=true`) is only meant to
+  fail loudly at boot, via `Nucleus.Scope.verify_provider_at_boot!/0` calling
+  `build/1` unconditionally during `Nucleus.Application.start/2` — booting
+  insecure because a flag was misread is the failure mode this is designed to
+  rule out.
+
+  See `docs/adr/0005-deferred-authentication.md` and the wiki's
+  [Authentication & Access](https://github.com/dave-bell/nucleus/wiki/Authentication-and-Access)
+  page for the deferred design.
+  """
+
+  @behaviour Nucleus.Scope.Provider
+
+  @impl Nucleus.Scope.Provider
+  def build(_context) do
+    raise """
+    Real authentication is not implemented; see AUTH-A01..A11.
+
+    AUTH_ENABLED=true selected Nucleus.Scope.Provider.Cognito, but EN-6 only
+    reserves this seam — it does not implement sign-in, token validation, or
+    group membership (see docs/adr/0005-deferred-authentication.md). Set
+    AUTH_ENABLED=false (or leave it unset) until the auth ticket lands.
+    """
+  end
+end

--- a/lib/nucleus/scope/provider/disabled.ex
+++ b/lib/nucleus/scope/provider/disabled.ex
@@ -1,0 +1,42 @@
+defmodule Nucleus.Scope.Provider.Disabled do
+  @moduledoc """
+  The default scope provider: auth is disabled, identity is a single
+  configured dev user.
+
+  Never fails — there is no external call to fail. The dev identity comes
+  from application configuration (`config/dev.exs`; `config/test.exs`
+  overrides it for tests that need a specific value), not an environment
+  variable: with `AUTH_ENABLED=true`, the equivalent values are sourced from
+  the minted JWT instead, so there is nothing for a `DEV_USER_EMAIL`-style
+  runtime variable to still be doing in a deployed environment.
+
+      config :nucleus, Nucleus.Scope.Provider.Disabled,
+        email: "dev@example.com",
+        scopes: []
+
+  `Nucleus.Scope.verify_provider_at_boot!/0` logs a prominent warning naming
+  this identity on every boot where this provider is selected — see
+  `docs/adr/0005-deferred-authentication.md`.
+  """
+
+  @behaviour Nucleus.Scope.Provider
+
+  alias Nucleus.Scope
+
+  @default_email "dev@example.com"
+
+  @impl Nucleus.Scope.Provider
+  def build(context) when is_map(context) do
+    config = Application.get_env(:nucleus, __MODULE__, [])
+
+    scope = %Scope{
+      user: %{email: Keyword.get(config, :email, @default_email), username: nil},
+      tenant: Scope.tenant_namespace(),
+      token: nil,
+      scopes: Keyword.get(config, :scopes, []),
+      source_ip: Map.get(context, :source_ip)
+    }
+
+    {:ok, scope}
+  end
+end

--- a/lib/nucleus_web/endpoint.ex
+++ b/lib/nucleus_web/endpoint.ex
@@ -11,9 +11,13 @@ defmodule NucleusWeb.Endpoint do
     same_site: "Lax"
   ]
 
+  # :x_headers is declared here (EN-6) so NucleusWeb.ScopeHook can read
+  # X-Forwarded-For via get_connect_info/2 on a connected LiveView socket —
+  # the initial Plug.Conn no longer exists once the socket is live, and this
+  # is the only place the header is still available.
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]],
-    longpoll: [connect_info: [session: @session_options]]
+    websocket: [connect_info: [:x_headers, session: @session_options]],
+    longpoll: [connect_info: [:x_headers, session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/lib/nucleus_web/live/scope_hook.ex
+++ b/lib/nucleus_web/live/scope_hook.ex
@@ -1,0 +1,64 @@
+defmodule NucleusWeb.ScopeHook do
+  @moduledoc """
+  `on_mount` hook that assigns `current_scope` to every LiveView in a
+  `live_session`.
+
+  Attached via `live_session ..., on_mount: {NucleusWeb.ScopeHook, :assign}`
+  (EN-7's router work) so every authenticated LiveView gets it — not
+  per-LiveView, which is how one gets forgotten (`AGENTS.md`).
+
+  Prefers the scope `NucleusWeb.Plugs.AssignScope` already put in the
+  session — the `source_ip` there was captured from the `Plug.Conn` that no
+  longer exists once the socket is live. When the session has no scope (a
+  LiveView mounted outside the `:browser` pipeline, or a socket reconnecting
+  without one), builds one fresh via `Nucleus.Scope.Provider.build/1`, reading
+  `source_ip` from `get_connect_info(socket, :x_headers)` — the only place
+  `X-Forwarded-For` is still available once the initial HTTP request is gone.
+
+  ## Never render `@current_scope` wholesale
+
+  LiveView diffs rendered output, not raw assigns, so a token sitting in
+  `socket.assigns.current_scope.token` is never sent to the client on its
+  own. That is a constraint on template authors, not an ambient guarantee —
+  never write `inspect(@current_scope)`, or any other rendering of the whole
+  struct, in a template. `token` is always `nil` for the whole of EN-6, but
+  the guard needs to exist before it is ever populated — see
+  `docs/adr/0005-deferred-authentication.md`.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+  import Phoenix.LiveView, only: [get_connect_info: 2]
+
+  alias Nucleus.Scope
+
+  @spec on_mount(:assign, map(), map(), Phoenix.LiveView.Socket.t()) ::
+          {:cont, Phoenix.LiveView.Socket.t()}
+  def on_mount(:assign, _params, session, socket) do
+    scope = scope_from_session(session) || build_scope(socket)
+
+    {:cont, assign(socket, :current_scope, scope)}
+  end
+
+  defp scope_from_session(%{"current_scope" => %Scope{} = scope}), do: scope
+  defp scope_from_session(_session), do: nil
+
+  defp build_scope(socket) do
+    {:ok, scope} = Scope.Provider.build(%{source_ip: source_ip_from_connect_info(socket)})
+    scope
+  end
+
+  # Mirrors Nucleus.Audit.Source.from_conn/1's algorithm — first
+  # X-Forwarded-For entry — re-derived for the socket's :x_headers instead of
+  # a Plug.Conn, since that is all that remains once the socket is live.
+  defp source_ip_from_connect_info(socket) do
+    with headers when is_list(headers) <- get_connect_info(socket, :x_headers),
+         {_key, value} <- List.keyfind(headers, "x-forwarded-for", 0),
+         [first | _] <- String.split(value, ","),
+         trimmed <- String.trim(first),
+         true <- trimmed != "" do
+      trimmed
+    else
+      _ -> nil
+    end
+  end
+end

--- a/lib/nucleus_web/plugs/assign_scope.ex
+++ b/lib/nucleus_web/plugs/assign_scope.ex
@@ -1,0 +1,36 @@
+defmodule NucleusWeb.Plugs.AssignScope do
+  @moduledoc """
+  Assigns `conn.assigns.current_scope` on every `:browser` request.
+
+  Builds the scope through `Nucleus.Scope.Provider.build/1`, capturing
+  `source_ip` here — via `Nucleus.Audit.Source.from_conn/1` — because this is
+  the last point at which a `Plug.Conn` (and so `X-Forwarded-For`) exists.
+  `NucleusWeb.ScopeHook` reads the same source IP back out of the session for
+  the LiveView socket that outlives this request.
+
+  The scope is also stored in the session, with `token` forced to `nil`
+  regardless of what the provider returned — the session is a signed, not
+  encrypted, cookie, and this is a defensive floor: it costs nothing today,
+  because EN-6 never populates `token`, and it means a future provider change
+  cannot leak a token into the session by omission.
+  """
+
+  import Plug.Conn
+
+  alias Nucleus.Audit
+  alias Nucleus.Scope
+
+  @spec init(keyword()) :: keyword()
+  def init(opts), do: opts
+
+  @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    source_ip = Audit.Source.from_conn(conn)
+
+    {:ok, scope} = Scope.Provider.build(%{source_ip: source_ip})
+
+    conn
+    |> assign(:current_scope, scope)
+    |> put_session(:current_scope, %{scope | token: nil})
+  end
+end

--- a/test/nucleus/scope/provider/cognito_test.exs
+++ b/test/nucleus/scope/provider/cognito_test.exs
@@ -1,0 +1,18 @@
+defmodule Nucleus.Scope.Provider.CognitoTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.Scope.Provider.Cognito
+
+  @tag :unit
+  test "raises with a message pointing at AUTH-A01..A11" do
+    error = assert_raise RuntimeError, fn -> Cognito.build(%{}) end
+
+    assert error.message =~ "Real authentication is not implemented"
+    assert error.message =~ "AUTH-A01..A11"
+  end
+
+  @tag :unit
+  test "raises regardless of context" do
+    assert_raise RuntimeError, fn -> Cognito.build(%{source_ip: "1.2.3.4", token: "fake"}) end
+  end
+end

--- a/test/nucleus/scope/provider/disabled_test.exs
+++ b/test/nucleus/scope/provider/disabled_test.exs
@@ -1,0 +1,57 @@
+defmodule Nucleus.Scope.Provider.DisabledTest do
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Scope
+  alias Nucleus.Scope.Provider.Disabled
+
+  setup do
+    original_scope = Application.get_env(:nucleus, Scope)
+    original_disabled = Application.get_env(:nucleus, Disabled)
+
+    on_exit(fn ->
+      Application.put_env(:nucleus, Scope, original_scope)
+      Application.put_env(:nucleus, Disabled, original_disabled)
+    end)
+
+    :ok
+  end
+
+  @tag :unit
+  test "builds a scope from the configured dev identity and tenant_namespace" do
+    Application.put_env(:nucleus, Scope, tenant_namespace: "acme")
+    Application.put_env(:nucleus, Disabled, email: "carol@example.com", scopes: ["read"])
+
+    assert {:ok, scope} = Disabled.build(%{source_ip: "1.2.3.4"})
+
+    assert %Scope{
+             user: %{email: "carol@example.com", username: nil},
+             tenant: "acme",
+             scopes: ["read"],
+             source_ip: "1.2.3.4"
+           } = scope
+  end
+
+  @tag :unit
+  test "token is always nil" do
+    assert {:ok, scope} = Disabled.build(%{})
+
+    assert scope.token == nil
+  end
+
+  @tag :unit
+  test "falls back to a default email and empty scopes when unconfigured" do
+    Application.put_env(:nucleus, Disabled, [])
+
+    assert {:ok, scope} = Disabled.build(%{})
+
+    assert scope.user.email == "dev@example.com"
+    assert scope.scopes == []
+  end
+
+  @tag :unit
+  test "never returns an error, regardless of context" do
+    assert {:ok, %Scope{}} = Disabled.build(%{})
+    assert {:ok, %Scope{}} = Disabled.build(%{source_ip: nil})
+    assert {:ok, %Scope{}} = Disabled.build(%{anything: "goes"})
+  end
+end

--- a/test/nucleus/scope_test.exs
+++ b/test/nucleus/scope_test.exs
@@ -1,0 +1,106 @@
+defmodule Nucleus.ScopeTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.Scope
+
+  doctest Nucleus.Scope
+
+  describe "authenticated?/1" do
+    @tag :unit
+    test "false when user is nil" do
+      refute Scope.authenticated?(%Scope{user: nil})
+    end
+
+    @tag :unit
+    test "true when user is present" do
+      assert Scope.authenticated?(%Scope{user: %{email: "a@b.com", username: nil}})
+    end
+  end
+
+  describe "audit_user/1" do
+    @tag :unit
+    test "prefers email when present" do
+      scope = %Scope{user: %{email: "a@b.com", username: "auser"}}
+
+      assert Scope.audit_user(scope) == "a@b.com"
+    end
+
+    @tag :unit
+    test "falls back to username when email is nil" do
+      scope = %Scope{user: %{email: nil, username: "auser"}}
+
+      assert Scope.audit_user(scope) == "auser"
+    end
+
+    @tag :unit
+    test "falls back to username when email is an empty string" do
+      scope = %Scope{user: %{email: "", username: "auser"}}
+
+      assert Scope.audit_user(scope) == "auser"
+    end
+
+    @tag :unit
+    test "falls back to anonymous when there is no user" do
+      assert Scope.audit_user(%Scope{user: nil}) == "anonymous"
+    end
+
+    @tag :unit
+    test "falls back to anonymous when neither email nor username is present" do
+      assert Scope.audit_user(%Scope{user: %{email: nil, username: nil}}) == "anonymous"
+    end
+  end
+
+  describe "tenant_namespace/0" do
+    @tag :unit
+    test "reads config :nucleus, Nucleus.Scope, :tenant_namespace" do
+      original = Application.get_env(:nucleus, Scope)
+      on_exit(fn -> Application.put_env(:nucleus, Scope, original) end)
+
+      Application.put_env(:nucleus, Scope, tenant_namespace: "acme")
+
+      assert Scope.tenant_namespace() == "acme"
+    end
+
+    @tag :unit
+    test "defaults to \"local\" when unset" do
+      original = Application.get_env(:nucleus, Scope)
+      on_exit(fn -> Application.put_env(:nucleus, Scope, original) end)
+
+      Application.put_env(:nucleus, Scope, [])
+
+      assert Scope.tenant_namespace() == "local"
+    end
+  end
+
+  describe "verify_provider_at_boot!/0" do
+    import ExUnit.CaptureLog
+
+    setup do
+      original = Application.get_env(:nucleus, Scope)
+      on_exit(fn -> Application.put_env(:nucleus, Scope, original) end)
+      :ok
+    end
+
+    @tag :unit
+    test "warns and names the dev identity when the Disabled provider is configured" do
+      Application.put_env(:nucleus, Scope,
+        provider: Nucleus.Scope.Provider.Disabled,
+        tenant_namespace: "acme"
+      )
+
+      log = capture_log(fn -> assert Scope.verify_provider_at_boot!() == :ok end)
+
+      assert log =~ "AUTH DISABLED"
+      assert log =~ "tenant -> acme"
+    end
+
+    @tag :unit
+    test "raises rather than warning when the Cognito provider is configured" do
+      Application.put_env(:nucleus, Scope, provider: Nucleus.Scope.Provider.Cognito)
+
+      assert_raise RuntimeError, ~r/AUTH-A01\.\.A11/, fn ->
+        Scope.verify_provider_at_boot!()
+      end
+    end
+  end
+end

--- a/test/nucleus_web/live/scope_hook_test.exs
+++ b/test/nucleus_web/live/scope_hook_test.exs
@@ -1,0 +1,54 @@
+defmodule NucleusWeb.ScopeHookTest do
+  use NucleusWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Nucleus.Scope
+
+  @endpoint NucleusWeb.Endpoint
+
+  setup do
+    original = Application.get_env(:nucleus, Scope)
+    on_exit(fn -> Application.put_env(:nucleus, Scope, original) end)
+    :ok
+  end
+
+  @tag :unit
+  test "assigns current_scope from a scope already in the session", %{conn: conn} do
+    scope = %Scope{user: %{email: "carol@example.com", username: nil}, tenant: "acme"}
+    conn = Plug.Test.init_test_session(conn, %{current_scope: scope})
+
+    {:ok, view, html} = live_isolated(conn, NucleusWeb.ScopeHookDemoLive)
+
+    assert has_element?(view, "#scope-hook-demo-user", "carol@example.com")
+    assert html =~ "carol@example.com"
+  end
+
+  @tag :unit
+  test "builds a fresh scope, with source_ip from x-headers, when the session has none", %{
+    conn: conn
+  } do
+    conn = Plug.Conn.put_req_header(conn, "x-forwarded-for", "9.8.7.6, 10.0.0.1")
+
+    {:ok, view, _html} = live_isolated(conn, NucleusWeb.ScopeHookDemoLive)
+
+    assert has_element?(view, "#scope-hook-demo-source-ip", "9.8.7.6")
+  end
+
+  @tag :unit
+  test "rendered HTML never contains the token, even though the guard is what matters here", %{
+    conn: conn
+  } do
+    scope = %Scope{
+      user: %{email: "carol@example.com", username: nil},
+      tenant: "acme",
+      token: nil
+    }
+
+    conn = Plug.Test.init_test_session(conn, %{current_scope: scope})
+
+    {:ok, _view, html} = live_isolated(conn, NucleusWeb.ScopeHookDemoLive)
+
+    refute html =~ "token"
+  end
+end

--- a/test/nucleus_web/plugs/assign_scope_test.exs
+++ b/test/nucleus_web/plugs/assign_scope_test.exs
@@ -1,0 +1,48 @@
+defmodule NucleusWeb.Plugs.AssignScopeTest do
+  use NucleusWeb.ConnCase, async: false
+
+  alias Nucleus.Scope
+  alias NucleusWeb.Plugs.AssignScope
+
+  setup %{conn: conn} do
+    original = Application.get_env(:nucleus, Scope)
+    on_exit(fn -> Application.put_env(:nucleus, Scope, original) end)
+
+    {:ok, conn: Plug.Test.init_test_session(conn, %{})}
+  end
+
+  @tag :unit
+  test "assigns current_scope", %{conn: conn} do
+    conn = AssignScope.call(conn, [])
+
+    assert %Scope{} = conn.assigns.current_scope
+  end
+
+  @tag :unit
+  test "stores the scope in the session, with token forced to nil", %{conn: conn} do
+    conn = AssignScope.call(conn, [])
+
+    assert %Scope{token: nil} = Plug.Conn.get_session(conn, :current_scope)
+  end
+
+  @tag :unit
+  test "captures source_ip from X-Forwarded-For, first entry", %{conn: conn} do
+    conn =
+      conn
+      |> Plug.Conn.put_req_header("x-forwarded-for", "1.2.3.4, 10.0.0.1")
+      |> AssignScope.call([])
+
+    assert conn.assigns.current_scope.source_ip == "1.2.3.4"
+  end
+
+  @tag :unit
+  test "AUTH_ENABLED=true raises rather than falling back to the disabled provider", %{
+    conn: conn
+  } do
+    Application.put_env(:nucleus, Scope, provider: Nucleus.Scope.Provider.Cognito)
+
+    assert_raise RuntimeError, ~r/AUTH-A01\.\.A11/, fn ->
+      AssignScope.call(conn, [])
+    end
+  end
+end

--- a/test/support/scope_hook_demo_live.ex
+++ b/test/support/scope_hook_demo_live.ex
@@ -1,0 +1,29 @@
+defmodule NucleusWeb.ScopeHookDemoLive do
+  @moduledoc """
+  A minimal LiveView for exercising `NucleusWeb.ScopeHook` in isolation,
+  without depending on EN-7's router `live_session` wiring (not landed yet).
+
+  Declares `on_mount {NucleusWeb.ScopeHook, :assign}` directly on the
+  LiveView module. At mount time this has the same effect as EN-7 attaching
+  the hook via `live_session ..., on_mount: ...` in the router — the hook
+  itself does not know or care which one attached it.
+
+  Renders through `Layouts.app`, the same layout every real page will use,
+  so `test/nucleus_web/live/scope_hook_test.exs` can assert on the actual
+  rendered output rather than on the hook's assign alone.
+  """
+
+  use NucleusWeb, :live_view
+
+  on_mount {NucleusWeb.ScopeHook, :assign}
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope}>
+      <p id="scope-hook-demo-user">{Nucleus.Scope.audit_user(@current_scope)}</p>
+      <p id="scope-hook-demo-source-ip">{@current_scope.source_ip}</p>
+    </Layouts.app>
+    """
+  end
+end


### PR DESCRIPTION
## What

Every LiveView in this app needs a `current_scope` assign, and every audit record (EN-5) needs a `user` and `tenant` — but real authentication (Cognito Hosted UI, PKCE, group membership, silent refresh: `AUTH-A01`–`A11`) isn't ready to design, per two open questions in `living-notes.md` about token passthrough over a LiveView socket and whether those eleven actions still describe the intended flow with no SPA. This PR builds the seam so Secrets and future LiveViews can be built against a stable identity shape now, with a substitution — not a refactor — required when real auth lands.

`Nucleus.Scope` (`user`, `tenant`, `token`, `scopes`, `source_ip`) is the only shape anything downstream reads. Two providers sit behind `Nucleus.Scope.Provider`: `Disabled` (default) never fails and returns a single configured dev identity; `Cognito` is a stub that raises unconditionally. `AUTH_ENABLED` (default `false`) selects between them, checked once at boot via `Nucleus.Scope.verify_provider_at_boot!/0` so a misconfigured flag fails the boot loudly rather than the first request. `token` exists on the struct now and is never populated — deliberately, so the future auth ticket populates it rather than inventing the field and threading it through every backing-API call site for the first time.

## How

- `Nucleus.Scope` — struct plus `authenticated?/1`, `audit_user/1` (email → username → `"anonymous"`, re-verified from the wiki's ADR-0002 §6 rather than inherited by citation, since Cognito access tokens carry no `email` claim), and `tenant_namespace/0`.
- `Nucleus.Scope.Provider` behaviour, `Provider.Disabled` (never fails), `Provider.Cognito` (raises, naming `AUTH-A01..A11`).
- `Nucleus.Scope.verify_provider_at_boot!/0`, wired into `Nucleus.Application.start/2` alongside `Nucleus.Backend.warn_on_local_backends/0` — same boot-time-verification pattern as EN-2, logging a prominent warning naming the assumed dev identity whenever the disabled provider is active.
- `NucleusWeb.Plugs.AssignScope` — assigns `current_scope` on the `:browser` pipeline, captures `source_ip` via EN-5's `Nucleus.Audit.Source.from_conn/1` (the last point a `Plug.Conn` exists), and stores the scope in the session.
- `NucleusWeb.ScopeHook.on_mount/4` — prefers the session-carried scope; otherwise builds one fresh, reading `source_ip` from the socket's connect info using the same first-`X-Forwarded-For`-entry algorithm as `Audit.Source`, since that module deliberately knows nothing about LiveView sockets.
- `docs/adr/0005-deferred-authentication.md` records the full rationale; `living-notes.md` and `decisions-log.md` updated accordingly.
- This ticket implements none of `AUTH-A01`–`AUTH-A11` by design, and no test carries an `action:` tag for them — claiming coverage here would make `mix nucleus.trace` (EN-8) report a false positive.

## Divergence from the plan

- **ADR number.** The issue names `docs/adr/0004-deferred-authentication.md`; this PR ships `0005-deferred-authentication.md`. `0004` was already taken by EN-5's `docs/adr/0004-audit-emission.md`, which merged first — a sequencing collision in the ticket text, not a reconsideration.
- **Dev identity is compile-time config, not env vars.** The plan's `DEV_USER_EMAIL`/`DEV_USER_SCOPES` environment variables are not implemented. Per explicit direction during implementation, `Provider.Disabled`'s email and scopes come from `config :nucleus, Nucleus.Scope.Provider.Disabled, email: ..., scopes: ...` in `config/dev.exs` (overridden to a distinguishable value in `config/test.exs`). With `AUTH_ENABLED=true` those same values would come from the minted JWT's claims instead of an environment variable, so an env-var-based dev identity would be a runtime knob with no counterpart once real auth ships.
- **`TENANT_NAMESPACE` is unaffected by the above** — it remains a `config/runtime.exs` environment variable as originally planned, because the tenant a deployment serves is infrastructure configuration both providers need, not an identity claim.
- **`endpoint.ex` connect_info gained `:x_headers`**, not explicitly called out in the plan. Without declaring it on the LiveView socket, `get_connect_info(socket, :x_headers)` always returns `nil`, which would have silently broken `ScopeHook`'s source-IP capture for every LiveView.
- **No router/`live_session` wiring in this PR** — that's EN-7 (#7), not this ticket. To exercise `ScopeHook`'s `on_mount` (including the "no token in rendered HTML" guard) ahead of EN-7's wiring, `test/support/scope_hook_demo_live.ex` declares `on_mount {NucleusWeb.ScopeHook, :assign}` directly on a test-only LiveView — equivalent at mount time to EN-7 attaching it via `live_session ..., on_mount: ...`.
- **Session storage forces `token: nil`** in `AssignScope` regardless of what the provider returns. This is a defensive floor against the session cookie being signed-but-unencrypted, not a decision about the eventual token-passthrough shape — that question remains open per the ADR's Negative consequences.

## Verification

`mix precommit` was run and passed: 217 tests (25 doctests, 192 tests) passed, 4 excluded as `:external`, compiled with `--warnings-as-errors`, and `mix format` found nothing to reformat. New tests cover `Nucleus.Scope`, both providers, `AssignScope`, and `ScopeHook` (including the demo LiveView's rendered output containing no token). No further manual exercise was performed.

Closes #6
