### PR TITLE
EN-7: Application shell, live_session and secrets route, missing core components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ custom classes must fully style the input
 
 - **Always use and maintain this import syntax** in the app.css file for projects generated with `phx.new`
 - **Never** use `@apply` when writing raw css
-- **Always** manually write your own tailwind-based components instead of using daisyUI for a unique, world-class design
+- **Use daisyUI** (already a pinned dependency) for UI components and theming — build on its component classes and theme system rather than hand-rolling every primitive in plain Tailwind
 - Out of the box **only the app.js and app.css bundles are supported**
   - You cannot reference an external vendor'd script `src` or link `href` in the layouts
   - You must import the vendor deps into app.js and app.css to use them

--- a/lib/nucleus_web/components/core_components.ex
+++ b/lib/nucleus_web/components/core_components.ex
@@ -476,6 +476,262 @@ defmodule NucleusWeb.CoreComponents do
   end
 
   @doc """
+  Renders a status pill.
+
+  Needed by `ENV-A03` (Active/Archived) and useful for error states.
+
+  ## Examples
+
+      <.badge variant="success">Active</.badge>
+      <.badge variant="warning">Archived</.badge>
+  """
+  attr :variant, :string, default: "neutral", values: ~w(neutral info success warning error)
+  attr :class, :any, default: nil
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def badge(assigns) do
+    variants = %{
+      "neutral" => "badge-neutral",
+      "info" => "badge-info",
+      "success" => "badge-success",
+      "warning" => "badge-warning",
+      "error" => "badge-error"
+    }
+
+    assigns = assign(assigns, :variant_class, Map.fetch!(variants, assigns.variant))
+
+    ~H"""
+    <span class={["badge", @variant_class, @class]} {@rest}>{render_slot(@inner_block)}</span>
+    """
+  end
+
+  @doc """
+  Renders a panel container.
+
+  ## Examples
+
+      <.card>
+        <p>Panel content</p>
+      </.card>
+  """
+  attr :class, :any, default: nil
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def card(assigns) do
+    ~H"""
+    <div class={["card bg-base-100 border border-base-300 shadow-sm", @class]} {@rest}>
+      <div class="card-body">{render_slot(@inner_block)}</div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders an empty state — `SEC-A14`, `NAV-A07`.
+
+  The `:action` slot is load-bearing, not decorative: `SEC-A14` requires the
+  create affordance stay available even when there is nothing to show, and
+  `NAV-A07`/the wiki's error matrix require this same component for a failed
+  load, not a distinct error state — callers decide what `message` to pass,
+  this component does not distinguish "empty" from "failed to load".
+  """
+  attr :id, :string, required: true
+  attr :icon, :string, default: "hero-inbox"
+  attr :message, :string, required: true
+  attr :class, :any, default: nil
+
+  slot :action, doc: "the load-bearing action shown alongside the empty message, if any"
+
+  def empty_state(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      class={["flex flex-col items-center justify-center gap-3 py-12 text-center", @class]}
+    >
+      <.icon name={@icon} class="size-10 text-base-content/40" />
+      <p class="text-base-content/70">{@message}</p>
+      <div :if={@action != []} class="mt-1">{render_slot(@action)}</div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders a modal — for `SEC-A09`'s creation form and `SEC-A13`'s dismissal
+  requirements.
+
+  Built on daisyUI's `.modal`/`.modal-box` classes (`AGENTS.md`) and
+  `Phoenix.Component.focus_wrap/1` for the Tab focus trap — `focus_wrap`
+  ships its own `Phoenix.FocusWrap` JS hook as part of `phoenix_live_view`,
+  so no colocated hook is needed here.
+
+  Closes on backdrop click (`phx-click-away`), Escape (`phx-window-keydown`),
+  or an explicit close/cancel control — all three route through the same
+  `data-cancel` attribute, so `on_cancel` (a `Phoenix.LiveView.JS` command)
+  always runs regardless of which one the user picks.
+
+  `show_modal/2` and `hide_modal/2` toggle daisyUI's `modal-open` trigger
+  class and use `JS.push_focus/1` + `JS.pop_focus/1` to return focus to
+  whatever triggered the modal on close — `SEC-A13`'s "focus returns to a
+  sensible place in the underlying page" is this pairing's job, not the
+  LiveView's.
+
+  ## Examples
+
+      <.button phx-click={show_modal("confirm-modal")}>Show modal</.button>
+
+      <.modal id="confirm-modal" on_cancel={JS.push("cancel_confirm")}>
+        <:title>Are you sure?</:title>
+        This cannot be undone.
+      </.modal>
+  """
+  attr :id, :string, required: true
+  attr :show, :boolean, default: false
+  attr :on_cancel, JS, default: %JS{}
+  slot :inner_block, required: true
+  slot :title
+
+  def modal(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      phx-mounted={@show && show_modal(@id)}
+      phx-remove={hide_modal(@id)}
+      data-cancel={JS.exec(@on_cancel, "phx-remove")}
+      class="modal"
+    >
+      <.focus_wrap
+        id={"#{@id}-container"}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={@title != [] && "#{@id}-title"}
+        phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
+        phx-key="escape"
+        phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
+        class="modal-box relative"
+      >
+        <button
+          id={"#{@id}-close"}
+          phx-click={JS.exec("data-cancel", to: "##{@id}")}
+          type="button"
+          class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          aria-label={gettext("close")}
+        >
+          <.icon name="hero-x-mark" class="size-5" />
+        </button>
+        <h2 :if={@title != []} id={"#{@id}-title"} class="text-lg font-semibold mb-4 pr-8">
+          {render_slot(@title)}
+        </h2>
+        <div id={"#{@id}-content"}>
+          {render_slot(@inner_block)}
+        </div>
+      </.focus_wrap>
+    </div>
+    """
+  end
+
+  @doc "Shows a `<.modal>` by id. See `hide_modal/2`."
+  def show_modal(js \\ %JS{}, id) when is_binary(id) do
+    js
+    |> JS.push_focus()
+    |> JS.add_class("modal-open", to: "##{id}")
+    |> JS.focus_first(to: "##{id}-container")
+  end
+
+  @doc "Hides a `<.modal>` by id, restoring focus saved by `show_modal/2`."
+  def hide_modal(js \\ %JS{}, id) do
+    js
+    |> JS.remove_class("modal-open", to: "##{id}")
+    |> JS.pop_focus()
+  end
+
+  @doc """
+  Renders a copy-to-clipboard button — `SEC-A02`.
+
+  Pure client-side: the value is already on the page, so a round-trip to the
+  server would add nothing. The colocated `.CopyButton` hook uses
+  `navigator.clipboard.writeText` where available, falling back to a hidden
+  `<textarea>` + `document.execCommand("copy")` both when the API is
+  undefined (non-secure contexts — `navigator.clipboard` only exists on
+  HTTPS/localhost) and when it rejects (e.g. a permissions prompt denial).
+  Confirmation is a ~2s icon swap plus an `aria-live="polite"` announcement,
+  per `SEC-A02` ("receives brief visual confirmation").
+
+  ## Examples
+
+      <.copy_button id="copy-arn" value={@secret.arn} label="Copy ARN" />
+  """
+  attr :id, :string, required: true
+  attr :value, :string, required: true
+  attr :label, :string, default: "Copy"
+  attr :class, :any, default: nil
+
+  def copy_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      id={@id}
+      phx-hook=".CopyButton"
+      data-value={@value}
+      data-label={@label}
+      class={["btn btn-ghost btn-sm gap-1", @class]}
+      aria-label={@label}
+    >
+      <span data-copy-icon><.icon name="hero-clipboard-document" class="size-4" /></span>
+      <span data-copied-icon class="hidden"><.icon name="hero-check" class="size-4" /></span>
+      <span>{@label}</span>
+      <span class="sr-only" aria-live="polite" data-copy-announce></span>
+    </button>
+    <script :type={Phoenix.LiveView.ColocatedHook} name=".CopyButton">
+      export default {
+        mounted() {
+          this.icon = this.el.querySelector("[data-copy-icon]")
+          this.checkIcon = this.el.querySelector("[data-copied-icon]")
+          this.announce = this.el.querySelector("[data-copy-announce]")
+          this.el.addEventListener("click", () => this.copy())
+        },
+        copy() {
+          const value = this.el.dataset.value
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(value)
+              .then(() => this.confirm())
+              .catch(() => this.fallbackCopy(value))
+          } else {
+            this.fallbackCopy(value)
+          }
+        },
+        fallbackCopy(value) {
+          const textarea = document.createElement("textarea")
+          textarea.value = value
+          textarea.setAttribute("readonly", "")
+          textarea.style.position = "fixed"
+          textarea.style.opacity = "0"
+          document.body.appendChild(textarea)
+          textarea.select()
+          try {
+            const ok = document.execCommand("copy")
+            if (ok) this.confirm()
+          } finally {
+            document.body.removeChild(textarea)
+          }
+        },
+        confirm() {
+          this.icon.classList.add("hidden")
+          this.checkIcon.classList.remove("hidden")
+          this.announce.textContent = `${this.el.dataset.label} copied`
+          clearTimeout(this._resetTimer)
+          this._resetTimer = setTimeout(() => {
+            this.icon.classList.remove("hidden")
+            this.checkIcon.classList.add("hidden")
+            this.announce.textContent = ""
+          }, 2000)
+        }
+      }
+    </script>
+    """
+  end
+
+  @doc """
   Translates an error message using gettext.
   """
   def translate_error({msg, opts}) do

--- a/lib/nucleus_web/components/layouts.ex
+++ b/lib/nucleus_web/components/layouts.ex
@@ -45,24 +45,29 @@ defmodule NucleusWeb.Layouts do
 
   def app(assigns) do
     ~H"""
-    <div class="flex h-screen w-full overflow-hidden">
-      <aside class="w-64 shrink-0 border-r border-base-300 bg-base-100 flex flex-col overflow-y-auto">
-        <div class="h-16 shrink-0 flex items-center px-4 border-b border-base-300">
+    <div id="shell" data-collapsed="false" class="group relative flex h-screen w-full overflow-hidden">
+      <aside
+        id="sidebar"
+        class="w-64 group-data-[collapsed=true]:w-16 shrink-0 border-r border-base-300 bg-base-100 flex flex-col overflow-y-auto transition-[width] duration-200"
+      >
+        <div class="h-16 shrink-0 flex items-center justify-start group-data-[collapsed=true]:justify-center px-4 border-b border-base-300">
           <a href="/" class="flex items-center gap-2">
             <img src={~p"/images/logo.svg"} width="28" />
-            <span class="font-semibold">Nucleus</span>
+            <span class="font-semibold group-data-[collapsed=true]:hidden">Nucleus</span>
           </a>
         </div>
 
-        <nav class="p-4 flex flex-col gap-6">
+        <nav class="p-4 flex flex-col gap-6 group-data-[collapsed=true]:items-center group-data-[collapsed=true]:px-2">
           <div>
-            <p class="text-xs font-semibold uppercase text-base-content/50 mb-2 px-2">Tenant</p>
+            <p class="text-xs font-semibold uppercase text-base-content/50 mb-2 px-2 group-data-[collapsed=true]:hidden">
+              Tenant
+            </p>
             <%!--
               NAV-A03 (active-section highlighting) is out of scope: these
               tenant-wide features don't exist yet, so they render as
               visibly disabled placeholders rather than dead links.
             --%>
-            <ul class="menu menu-sm p-0">
+            <ul class="menu menu-sm p-0 group-data-[collapsed=true]:hidden">
               <li>
                 <span class="opacity-40 cursor-not-allowed" aria-disabled="true">
                   Applications
@@ -79,54 +84,122 @@ defmodule NucleusWeb.Layouts do
                 </span>
               </li>
             </ul>
+            <%!--
+              Collapsed rail: one icon per section rather than per item —
+              expanding is the way back to the individual placeholders.
+            --%>
+            <button
+              type="button"
+              class="hidden group-data-[collapsed=true]:flex btn btn-ghost btn-sm btn-square"
+              phx-click={toggle_sidebar()}
+              title="Tenant"
+              aria-label="Tenant"
+            >
+              <.icon name="hero-squares-2x2" class="size-5" />
+            </button>
           </div>
 
           <div>
-            <p class="text-xs font-semibold uppercase text-base-content/50 mb-2 px-2">
+            <p class="text-xs font-semibold uppercase text-base-content/50 mb-2 px-2 group-data-[collapsed=true]:hidden">
               Environments
             </p>
             <%!--
               NAV-A04/NAV-A05 (category grouping, per-category counts,
               multi-category membership, the uncategorised group ordered
-              last, expand/collapse) are out of scope for this ticket. A
-              flat list is acceptable here — the Application Shell &
-              Navigation ticket should replace this list, not extend it.
+              last, expand/collapse of individual *categories*) are out of
+              scope for this ticket. A flat list is acceptable here — the
+              Application Shell & Navigation ticket should replace this
+              list, not extend it. The sidebar-wide collapse-to-icon-rail
+              here is a distinct, later addition and does not group or
+              count environments.
             --%>
-            <%= if @environments do %>
-              <.async_result :let={environments} assign={@environments}>
-                <:loading>
-                  <p id="environments-loading" class="text-sm text-base-content/50 px-2">
-                    Loading environments…
-                  </p>
-                </:loading>
-                <%= if environments == [] do %>
-                  <.empty_state
-                    id="environments-empty"
-                    icon="hero-server-stack"
-                    message="No environments"
-                    class="py-4"
-                  />
-                <% else %>
-                  <ul id="environments-list" class="menu menu-sm p-0">
-                    <li :for={env <- environments}>
-                      <.link navigate={~p"/environments/#{env.short_name}/secrets"}>
-                        {env.label || env.short_name}
-                      </.link>
-                    </li>
-                  </ul>
-                <% end %>
-              </.async_result>
-            <% else %>
-              <.empty_state
-                id="environments-empty"
-                icon="hero-server-stack"
-                message="No environments"
-                class="py-4"
-              />
-            <% end %>
+            <div class="group-data-[collapsed=true]:hidden">
+              <%= if @environments do %>
+                <.async_result :let={environments} assign={@environments}>
+                  <:loading>
+                    <p id="environments-loading" class="text-sm text-base-content/50 px-2">
+                      Loading environments…
+                    </p>
+                  </:loading>
+                  <%= if environments == [] do %>
+                    <.empty_state
+                      id="environments-empty"
+                      icon="hero-server-stack"
+                      message="No environments"
+                      class="py-4"
+                    />
+                  <% else %>
+                    <ul id="environments-list" class="menu menu-sm p-0">
+                      <li :for={env <- environments}>
+                        <.link navigate={~p"/environments/#{env.short_name}/secrets"}>
+                          {env.label || env.short_name}
+                        </.link>
+                      </li>
+                    </ul>
+                  <% end %>
+                </.async_result>
+              <% else %>
+                <.empty_state
+                  id="environments-empty"
+                  icon="hero-server-stack"
+                  message="No environments"
+                  class="py-4"
+                />
+              <% end %>
+            </div>
+            <button
+              type="button"
+              class="hidden group-data-[collapsed=true]:flex btn btn-ghost btn-sm btn-square"
+              phx-click={toggle_sidebar()}
+              title="Environments"
+              aria-label="Environments"
+            >
+              <.icon name="hero-server-stack" class="size-5" />
+            </button>
           </div>
         </nav>
       </aside>
+
+      <%!--
+        Sibling of <aside>, not nested inside it: the aside's own
+        overflow-y-auto implicitly makes its overflow-x "auto" too (CSS
+        overflow spec — one non-visible axis forces the other away from
+        "visible"), which clipped this button's protruding half when it
+        lived inside the aside. Positioned here, against the shell wrapper,
+        it sits fully unclipped on the sidebar/content boundary in both
+        states, so the same amount of each chevron is visible whether open
+        or collapsed.
+      --%>
+      <button
+        id="sidebar-toggle"
+        type="button"
+        class="btn btn-circle btn-sm bg-base-100 border border-base-300 shadow-sm absolute left-60 group-data-[collapsed=true]:left-12 top-4 z-10 transition-[left] duration-200"
+        phx-click={toggle_sidebar()}
+        aria-labelledby="sidebar-toggle-collapse-label sidebar-toggle-expand-label"
+      >
+        <.icon name="hero-chevron-double-left" class="size-4 group-data-[collapsed=true]:hidden" />
+        <.icon
+          name="hero-chevron-double-right"
+          class="size-4 hidden group-data-[collapsed=true]:inline"
+        />
+        <%!--
+          Two sr-only labels toggled by the same CSS group-data mechanism as
+          the icons above, rather than a client-side JS.toggle_attribute
+          matching against the attribute's current string value: the
+          accessible name changes with `display`, which is guaranteed to
+          track `data-collapsed` exactly, instead of independently keeping a
+          second piece of toggled state in sync with it.
+        --%>
+        <span id="sidebar-toggle-collapse-label" class="sr-only group-data-[collapsed=true]:hidden">
+          Collapse sidebar
+        </span>
+        <span
+          id="sidebar-toggle-expand-label"
+          class="sr-only hidden group-data-[collapsed=true]:inline"
+        >
+          Expand sidebar
+        </span>
+      </button>
 
       <div class="flex-1 flex flex-col overflow-hidden">
         <header class="navbar h-16 border-b border-base-300 shrink-0 px-4">
@@ -180,6 +253,20 @@ defmodule NucleusWeb.Layouts do
 
     <.flash_group flash={@flash} />
     """
+  end
+
+  @doc """
+  Toggles the sidebar's collapsed state — `#shell`'s `data-collapsed`
+  attribute.
+
+  Shared by the main toggle button and both collapsed-rail icons (Tenant,
+  Environments) so all three ways of reopening the sidebar stay in sync by
+  construction. `#sidebar-toggle`'s accessible name and icon both track
+  `data-collapsed` declaratively via CSS (`group-data-[collapsed=true]:*`),
+  not a second piece of client-side state kept in sync by hand here.
+  """
+  def toggle_sidebar(js \\ %JS{}) do
+    JS.toggle_attribute(js, {"data-collapsed", "true"}, to: "#shell")
   end
 
   @doc """

--- a/lib/nucleus_web/components/layouts.ex
+++ b/lib/nucleus_web/components/layouts.ex
@@ -31,42 +31,152 @@ defmodule NucleusWeb.Layouts do
     default: nil,
     doc: "the current [scope](https://phoenix.hexdocs.pm/scopes.html)"
 
+  attr :environments, Phoenix.LiveView.AsyncResult,
+    default: nil,
+    doc: """
+    async result for the sidebar's Environments section, assigned by
+    `NucleusWeb.EnvironmentsHook` at the `live_session` level. `nil` (the
+    default) renders the same empty state as a `nil`-vs-loaded distinction
+    matters less than never crashing a caller that hasn't wired the hook —
+    see `test/support/scope_hook_demo_live.ex` (EN-6), which doesn't.
+    """
+
   slot :inner_block, required: true
 
   def app(assigns) do
     ~H"""
-    <header class="navbar px-4 sm:px-6 lg:px-8">
-      <div class="flex-1">
-        <a href="/" class="flex-1 flex w-fit items-center gap-2">
-          <img src={~p"/images/logo.svg"} width="36" />
-          <span class="text-sm font-semibold">v{Application.spec(:phoenix, :vsn)}</span>
-        </a>
-      </div>
-      <div class="flex-none">
-        <ul class="flex flex-column px-1 space-x-4 items-center">
-          <li>
-            <a href="https://phoenixframework.org/" class="btn btn-ghost">Website</a>
-          </li>
-          <li>
-            <a href="https://github.com/phoenixframework/phoenix" class="btn btn-ghost">GitHub</a>
-          </li>
-          <li>
-            <.theme_toggle />
-          </li>
-          <li>
-            <a href="https://phoenix.hexdocs.pm/overview.html" class="btn btn-primary">
-              Get Started <span aria-hidden="true">&rarr;</span>
-            </a>
-          </li>
-        </ul>
-      </div>
-    </header>
+    <div class="flex h-screen w-full overflow-hidden">
+      <aside class="w-64 shrink-0 border-r border-base-300 bg-base-100 flex flex-col overflow-y-auto">
+        <div class="h-16 shrink-0 flex items-center px-4 border-b border-base-300">
+          <a href="/" class="flex items-center gap-2">
+            <img src={~p"/images/logo.svg"} width="28" />
+            <span class="font-semibold">Nucleus</span>
+          </a>
+        </div>
 
-    <main class="px-4 py-20 sm:px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl space-y-4">
-        {render_slot(@inner_block)}
+        <nav class="p-4 flex flex-col gap-6">
+          <div>
+            <p class="text-xs font-semibold uppercase text-base-content/50 mb-2 px-2">Tenant</p>
+            <%!--
+              NAV-A03 (active-section highlighting) is out of scope: these
+              tenant-wide features don't exist yet, so they render as
+              visibly disabled placeholders rather than dead links.
+            --%>
+            <ul class="menu menu-sm p-0">
+              <li>
+                <span class="opacity-40 cursor-not-allowed" aria-disabled="true">
+                  Applications
+                </span>
+              </li>
+              <li>
+                <span class="opacity-40 cursor-not-allowed" aria-disabled="true">
+                  Data Export
+                </span>
+              </li>
+              <li>
+                <span class="opacity-40 cursor-not-allowed" aria-disabled="true">
+                  M2M Clients
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <p class="text-xs font-semibold uppercase text-base-content/50 mb-2 px-2">
+              Environments
+            </p>
+            <%!--
+              NAV-A04/NAV-A05 (category grouping, per-category counts,
+              multi-category membership, the uncategorised group ordered
+              last, expand/collapse) are out of scope for this ticket. A
+              flat list is acceptable here — the Application Shell &
+              Navigation ticket should replace this list, not extend it.
+            --%>
+            <%= if @environments do %>
+              <.async_result :let={environments} assign={@environments}>
+                <:loading>
+                  <p id="environments-loading" class="text-sm text-base-content/50 px-2">
+                    Loading environments…
+                  </p>
+                </:loading>
+                <%= if environments == [] do %>
+                  <.empty_state
+                    id="environments-empty"
+                    icon="hero-server-stack"
+                    message="No environments"
+                    class="py-4"
+                  />
+                <% else %>
+                  <ul id="environments-list" class="menu menu-sm p-0">
+                    <li :for={env <- environments}>
+                      <.link navigate={~p"/environments/#{env.short_name}/secrets"}>
+                        {env.label || env.short_name}
+                      </.link>
+                    </li>
+                  </ul>
+                <% end %>
+              </.async_result>
+            <% else %>
+              <.empty_state
+                id="environments-empty"
+                icon="hero-server-stack"
+                message="No environments"
+                class="py-4"
+              />
+            <% end %>
+          </div>
+        </nav>
+      </aside>
+
+      <div class="flex-1 flex flex-col overflow-hidden">
+        <header class="navbar h-16 border-b border-base-300 shrink-0 px-4">
+          <div class="flex-1">
+            <span :if={@current_scope} id="tenant-identifier" class="badge badge-outline">
+              {@current_scope.tenant}
+            </span>
+          </div>
+          <div class="flex-none flex items-center gap-2">
+            <.theme_toggle />
+
+            <div :if={@current_scope} id="user-menu" class="dropdown dropdown-end">
+              <button
+                type="button"
+                class="btn btn-ghost btn-circle"
+                phx-click={JS.toggle(to: "#user-menu-panel")}
+                aria-label={gettext("User menu")}
+              >
+                <.icon name="hero-user-circle" class="size-6" />
+              </button>
+              <div
+                id="user-menu-panel"
+                class="dropdown-content menu bg-base-100 rounded-box shadow-lg w-64 p-4 mt-2 z-10 hidden"
+                phx-click-away={JS.hide(to: "#user-menu-panel")}
+                phx-window-keydown={JS.hide(to: "#user-menu-panel")}
+                phx-key="Escape"
+              >
+                <p class="font-semibold break-all text-sm">{@current_scope.user.email}</p>
+                <div class="mt-3">
+                  <p class="text-xs uppercase text-base-content/50 mb-1">Scopes</p>
+                  <%= if @current_scope.scopes == [] do %>
+                    <p class="text-sm text-base-content/60">No scopes granted</p>
+                  <% else %>
+                    <ul class="flex flex-wrap gap-1">
+                      <li :for={scope <- @current_scope.scopes}>
+                        <.badge>{scope}</.badge>
+                      </li>
+                    </ul>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <main class="flex-1 overflow-y-auto p-6">
+          {render_slot(@inner_block)}
+        </main>
       </div>
-    </main>
+    </div>
 
     <.flash_group flash={@flash} />
     """

--- a/lib/nucleus_web/components/layouts/root.html.heex
+++ b/lib/nucleus_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="Nucleus" suffix=" · Phoenix Framework" phx-no-format>{assigns[:page_title]}</.live_title>
+    <.live_title default="Nucleus" phx-no-format>{assigns[:page_title]}</.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
     </script>

--- a/lib/nucleus_web/live/environments_hook.ex
+++ b/lib/nucleus_web/live/environments_hook.ex
@@ -1,0 +1,69 @@
+defmodule NucleusWeb.EnvironmentsHook do
+  @moduledoc """
+  `on_mount` hook that assigns `:environments` — the sidebar's Environments
+  section (`Layouts.app`) — to every LiveView in a `live_session`, the same
+  way `NucleusWeb.ScopeHook` assigns `current_scope`.
+
+  Attached via `live_session ..., on_mount: [{NucleusWeb.ScopeHook, :assign},
+  {NucleusWeb.EnvironmentsHook, :assign}]`, in that order — this hook reads
+  `current_scope.token` from the socket, so it must run after `ScopeHook`.
+  The sidebar is shell chrome shared by every page under the shell
+  (`NAV-A02`), not a per-page concern, so no individual LiveView (including
+  the future `SecretsLive`) fetches its own copy.
+
+  ## Failure degrades to empty, never surfaces as an error (`NAV-A07`)
+
+  `Nucleus.TenantApi.list_environments/1` can fail
+  (`{:error, Nucleus.Backend.Error.t()}`). This hook deliberately folds that
+  into an empty list rather than exposing a `:failed`
+  `Phoenix.LiveView.AsyncResult` state: `NAV-A07` and the wiki's error
+  matrix require "the same empty state as no environments ... so navigation
+  is never blocked." This is intentionally the opposite of Secrets' own
+  fail-closed behaviour (`SEC-A17`) — the sidebar degrades, the secrets view
+  refuses.
+
+  ## Archived environments are filtered here
+
+  `Nucleus.TenantApi.list_environments/1` returns every environment,
+  archived included (`ENV-A06`) — filtering is the caller's job, by design.
+  This hook is that caller for the sidebar; `NAV-A04` requires archived ones
+  stay hidden from it (while remaining reachable by direct URL, which this
+  hook has no bearing on).
+
+  Loaded via `Phoenix.LiveView.assign_async/3` so a slow tenant API does not
+  block first paint. `assign_async/3` itself only spawns the fetch once the
+  socket is connected — the disconnected static render just shows the
+  loading state, no special-casing needed here.
+  """
+
+  import Phoenix.LiveView, only: [assign_async: 3]
+
+  alias Nucleus.Scope
+  alias Nucleus.TenantApi
+
+  @spec on_mount(:assign, map(), map(), Phoenix.LiveView.Socket.t()) ::
+          {:cont, Phoenix.LiveView.Socket.t()}
+  def on_mount(:assign, _params, _session, socket) do
+    token = scope_token(socket)
+
+    socket =
+      assign_async(socket, :environments, fn ->
+        environments =
+          case TenantApi.list_environments(token) do
+            {:ok, environments} -> Enum.reject(environments, & &1.archived?)
+            {:error, _reason} -> []
+          end
+
+        {:ok, %{environments: environments}}
+      end)
+
+    {:cont, socket}
+  end
+
+  defp scope_token(socket) do
+    case socket.assigns[:current_scope] do
+      %Scope{token: token} -> token
+      _ -> nil
+    end
+  end
+end

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -1,0 +1,39 @@
+defmodule NucleusWeb.SecretsLive do
+  @moduledoc """
+  Placeholder so `/environments/:environment/secrets` compiles and
+  `Layouts.app`'s sidebar (`NAV-A04`) has a real, navigable destination —
+  EN-7's plan explicitly allows this ("this ticket may add a minimal
+  placeholder module so the route compiles, clearly marked").
+
+  **This is not the Secrets feature.** `SEC-S1` (environment resolution and
+  the fail-closed validation ladder) and `SEC-S2` (the actual secrets list)
+  replace this module's body entirely — nothing here should be extended.
+  Renders an explicit "not implemented" state via `<.empty_state>`, never a
+  blank page.
+
+  `current_scope` and `environments` come from the `:authenticated`
+  `live_session`'s `on_mount` hooks (`NucleusWeb.ScopeHook`,
+  `NucleusWeb.EnvironmentsHook`) in `lib/nucleus_web/router.ex` — this
+  module does not assign either itself.
+  """
+
+  use NucleusWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def mount(%{"environment" => environment}, _session, socket) do
+    {:ok, assign(socket, :environment, environment)}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope} environments={@environments}>
+      <.empty_state
+        id="secrets-not-implemented"
+        icon="hero-wrench-screwdriver"
+        message={"Secrets for \"#{@environment}\" is not implemented yet — see SEC-S1/SEC-S2."}
+      />
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/nucleus_web/router.ex
+++ b/lib/nucleus_web/router.ex
@@ -10,6 +10,13 @@ defmodule NucleusWeb.Router do
     plug :put_secure_browser_headers
   end
 
+  # Assigns `current_scope` (EN-6) — separate from :browser so a route can
+  # opt out (there are none yet; every future authenticated LiveView goes
+  # through this via the :authenticated live_session below).
+  pipeline :assign_scope do
+    plug NucleusWeb.Plugs.AssignScope
+  end
+
   pipeline :api do
     plug :accepts, ["json"]
   end
@@ -18,6 +25,24 @@ defmodule NucleusWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+  end
+
+  scope "/", NucleusWeb do
+    pipe_through [:browser, :assign_scope]
+
+    # `on_mount` at the live_session level, not per LiveView, so no future
+    # view can be added under this scope without current_scope or the
+    # sidebar's environment list (AGENTS.md,
+    # docs/adr/0005-deferred-authentication.md). EnvironmentsHook runs after
+    # ScopeHook — it reads current_scope.token off the socket.
+    #
+    # SecretsLive is a placeholder (SEC-S1/S2 own the real feature) so this
+    # route compiles and Layouts.app's sidebar has somewhere real to link
+    # environments to, per this ticket's own plan.
+    live_session :authenticated,
+      on_mount: [{NucleusWeb.ScopeHook, :assign}, {NucleusWeb.EnvironmentsHook, :assign}] do
+      live "/environments/:environment/secrets", SecretsLive, :index
+    end
   end
 
   # Other scopes may use custom stacks.
@@ -32,6 +57,15 @@ defmodule NucleusWeb.Router do
     # If your application does not have an admins-only section yet,
     # you can use Plug.BasicAuth to set up some basic authentication
     # as long as you are also using SSL (which you should anyway).
+    #
+    # Acceptable here specifically because this whole block is behind
+    # Application.compile_env(:nucleus, :dev_routes) — false in every
+    # non-dev release config (config/{prod,test}.exs never set it), so it
+    # cannot compile into a production build regardless of runtime
+    # configuration. There is still no :auth boundary to gate it behind
+    # (EN-6/docs/adr/0005-deferred-authentication.md) — this guard is the
+    # only thing standing between LiveDashboard and the internet, and it
+    # holds because it's a compile-time, not runtime, switch.
     import Phoenix.LiveDashboard.Router
 
     scope "/dev" do

--- a/test/nucleus_web/components/core_components_test.exs
+++ b/test/nucleus_web/components/core_components_test.exs
@@ -1,0 +1,122 @@
+defmodule NucleusWeb.CoreComponentsTest do
+  use NucleusWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias NucleusWeb.CoreComponents
+
+  defp doc(html), do: LazyHTML.from_fragment(html)
+
+  describe "modal/1" do
+    @tag :unit
+    test "renders role=\"dialog\" and aria-modal" do
+      html = render_component(&CoreComponents.modal/1, modal_assigns())
+
+      dialog = doc(html) |> LazyHTML.query(~s([role="dialog"][aria-modal="true"]))
+
+      assert LazyHTML.attribute(dialog, "id") == ["confirm-modal-container"]
+    end
+
+    @tag :unit
+    test "renders backdrop and close controls with stable ids" do
+      html = render_component(&CoreComponents.modal/1, modal_assigns())
+      d = doc(html)
+
+      # The outer full-screen element doubles as the backdrop — clicking it
+      # (outside the modal-box) triggers phx-click-away.
+      assert LazyHTML.query(d, "#confirm-modal") |> LazyHTML.attribute("data-cancel") != []
+      assert LazyHTML.query(d, "#confirm-modal-close") |> LazyHTML.attribute("phx-click") != []
+    end
+
+    @tag :unit
+    test "renders the title slot when given" do
+      html =
+        render_component(
+          &CoreComponents.modal/1,
+          modal_assigns(title: [%{inner_block: fn _, _ -> "Are you sure?" end}])
+        )
+
+      assert doc(html) |> LazyHTML.query("#confirm-modal-title") |> LazyHTML.text() =~
+               "Are you sure?"
+    end
+  end
+
+  defp modal_assigns(overrides \\ []) do
+    Keyword.merge(
+      [id: "confirm-modal", inner_block: [%{inner_block: fn _, _ -> "Modal content" end}]],
+      overrides
+    )
+  end
+
+  describe "copy_button/1" do
+    @tag :unit
+    test "renders the colocated hook attribute, a unique id, and the value in a data attribute" do
+      html = render_component(&CoreComponents.copy_button/1, id: "copy-arn", value: "arn:aws:1")
+
+      button = doc(html) |> LazyHTML.query("#copy-arn")
+
+      assert [hook] = LazyHTML.attribute(button, "phx-hook")
+      assert hook =~ "CopyButton"
+      assert LazyHTML.attribute(button, "data-value") == ["arn:aws:1"]
+      assert LazyHTML.attribute(button, "id") == ["copy-arn"]
+    end
+  end
+
+  describe "empty_state/1" do
+    @tag :unit
+    test "renders its action slot when given" do
+      html =
+        render_component(&CoreComponents.empty_state/1, %{
+          id: "no-secrets",
+          message: "No secrets yet",
+          action: [%{inner_block: fn _, _ -> "Create secret" end}]
+        })
+
+      d = doc(html)
+      assert LazyHTML.text(d) =~ "No secrets yet"
+      assert LazyHTML.text(d) =~ "Create secret"
+    end
+
+    @tag :unit
+    test "omits the action wrapper when no action slot is given" do
+      html =
+        render_component(&CoreComponents.empty_state/1, %{
+          id: "no-secrets",
+          message: "No secrets yet",
+          action: []
+        })
+
+      d = doc(html)
+      assert LazyHTML.text(d) =~ "No secrets yet"
+      assert LazyHTML.query(d, "#no-secrets > div") |> Enum.to_list() == []
+    end
+  end
+
+  describe "badge/1" do
+    @tag :unit
+    test "renders each variant" do
+      for variant <- ~w(neutral info success warning error) do
+        html =
+          render_component(&CoreComponents.badge/1, %{
+            variant: variant,
+            inner_block: [%{inner_block: fn _, _ -> "Active" end}]
+          })
+
+        badge = doc(html) |> LazyHTML.query(".badge")
+        assert LazyHTML.attribute(badge, "class") |> Enum.at(0) =~ "badge-#{variant}"
+      end
+    end
+  end
+
+  describe "card/1" do
+    @tag :unit
+    test "renders its content inside a card" do
+      html =
+        render_component(&CoreComponents.card/1, %{
+          inner_block: [%{inner_block: fn _, _ -> "Panel content" end}]
+        })
+
+      assert doc(html) |> LazyHTML.text() =~ "Panel content"
+    end
+  end
+end

--- a/test/nucleus_web/live/shell_test.exs
+++ b/test/nucleus_web/live/shell_test.exs
@@ -1,0 +1,121 @@
+defmodule NucleusWeb.ShellTest do
+  # Mutates :nucleus, :backends application config and the LOCAL_FORCE_ERROR
+  # env var, both global.
+  use NucleusWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  @endpoint NucleusWeb.Endpoint
+
+  defmodule EmptyTenantApi do
+    @moduledoc "Stands in for a tenant with zero environments."
+    @behaviour Nucleus.TenantApi
+
+    @impl Nucleus.TenantApi
+    def list_environments(_token), do: {:ok, []}
+
+    @impl Nucleus.TenantApi
+    def health_check, do: :ok
+  end
+
+  setup do
+    original_backends = Application.get_env(:nucleus, :backends)
+
+    on_exit(fn ->
+      Application.put_env(:nucleus, :backends, original_backends)
+      System.delete_env("LOCAL_FORCE_ERROR")
+    end)
+
+    :ok
+  end
+
+  defp put_tenant_api(module) do
+    configured = Application.get_env(:nucleus, :backends, [])
+    Application.put_env(:nucleus, :backends, Keyword.put(configured, :tenant_api, module))
+  end
+
+  @tag :unit
+  test "shows the tenant identifier", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    assert has_element?(view, "#tenant-identifier", "local")
+  end
+
+  @tag :unit
+  test "shows the identity control with the dev email, and no sign-out control", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    assert has_element?(view, "#user-menu", "test-dev@example.com")
+    refute has_element?(view, "#user-menu", "Sign out")
+    refute has_element?(view, "#user-menu", "Log out")
+    refute has_element?(view, "#user-menu", "Logout")
+  end
+
+  @tag :unit
+  test "lists non-archived environments from the local backend, archived excluded", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    render_async(view)
+
+    assert has_element?(view, "#environments-list", "Production")
+    assert has_element?(view, "#environments-list", "Staging")
+    assert has_element?(view, "#environments-list", "Development")
+    assert has_element?(view, "#environments-list", "Sandbox")
+    refute has_element?(view, "#environments-list", "Legacy QA")
+  end
+
+  @tag :unit
+  test "an archived environment stays reachable by direct URL, even though hidden from the sidebar",
+       %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/legacy-qa/secrets")
+
+    render_async(view)
+
+    assert has_element?(view, "#secrets-not-implemented")
+    refute has_element?(view, "#environments-list", "Legacy QA")
+  end
+
+  @tag :unit
+  test "shows the empty state when there are no environments", %{conn: conn} do
+    put_tenant_api(EmptyTenantApi)
+
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    render_async(view)
+
+    assert has_element?(view, "#environments-empty")
+    refute has_element?(view, "#environments-list")
+  end
+
+  @tag :unit
+  test "LOCAL_FORCE_ERROR=unavailable degrades to the same empty state, not an error", %{
+    conn: conn
+  } do
+    System.put_env("LOCAL_FORCE_ERROR", "unavailable")
+
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    render_async(view)
+
+    assert has_element?(view, "#environments-empty")
+    refute has_element?(view, "#environments-list")
+    # The shell itself still renders — a failed environment load never blocks
+    # navigation (NAV-A07).
+    assert has_element?(view, "#tenant-identifier")
+    assert has_element?(view, "#user-menu")
+  end
+
+  @tag :unit
+  test "rendered HTML never contains a token", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    render_async(view)
+
+    # Scoped to where current_scope is actually rendered (the identity
+    # control) — the full page also contains the unrelated csrf-token meta
+    # tag, so a whole-document substring check would false-positive.
+    refute has_element?(view, "#user-menu", "token")
+  end
+end

--- a/test/nucleus_web/live/shell_test.exs
+++ b/test/nucleus_web/live/shell_test.exs
@@ -42,6 +42,22 @@ defmodule NucleusWeb.ShellTest do
   end
 
   @tag :unit
+  test "sidebar is open (not collapsed) by default, with a toggle control", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    assert has_element?(view, ~s(#shell[data-collapsed="false"]))
+    assert has_element?(view, "#sidebar-toggle")
+  end
+
+  @tag :unit
+  test "sidebar's collapsed rail carries one icon per section", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    assert has_element?(view, ~s([title="Tenant"]))
+    assert has_element?(view, ~s([title="Environments"]))
+  end
+
+  @tag :unit
   test "shows the identity control with the dev email, and no sign-out control", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
 


### PR DESCRIPTION
## What

There was nowhere to reach or render Secrets: no `live` routes, no `live_session`, a stock marketing layout, and a stock `core_components.ex` with no modal, empty state, or copy affordance. This PR adds the application shell (header, sidebar, theme toggle), wires an `/environments/:environment/secrets` route behind an authenticated `live_session`, and adds the `<.modal>`, `<.copy_button>`, `<.empty_state>`, `<.badge>`, and `<.card>` components the Secrets feature will need. A follow-up commit makes the new sidebar collapsible.

## How

- `NucleusWeb.Plugs.AssignScope` (EN-6) added to a dedicated `:assign_scope` pipeline; `live_session :authenticated` runs `NucleusWeb.ScopeHook` then `NucleusWeb.EnvironmentsHook` via `on_mount`, so no future LiveView under this session can skip either.
- `Layouts.app/1` rewritten: header shows the tenant identifier (`id="tenant-identifier"`, `NAV-A02`) and an identity control (`id="user-menu"`) with the dev email and scopes, dismissible on outside-click/Escape (`NAV-A08`); no sign-out control, since auth is still disabled (EN-6). Sidebar lists non-archived environments (`NAV-A04`) loaded via `assign_async/3` so a slow tenant API doesn't block first paint, degrading to `<.empty_state>` on load failure rather than an error (`NAV-A07`) — the opposite of Secrets' own fail-closed behaviour (`SEC-A17`). Tenant-wide items (Applications, Data Export, M2M Clients) render as visibly disabled placeholders.
- `core_components.ex` gains `<.modal>` (focus trap via `focus_wrap`, focus restoration via `JS.push_focus`/`JS.pop_focus`, Escape/backdrop/explicit dismissal — `SEC-A09`, `SEC-A13`), `<.copy_button>` (colocated `.CopyButton` hook, clipboard API with a `document.execCommand("copy")` fallback for non-secure contexts, ~2s confirmation with `aria-live="polite"` — `SEC-A02`), `<.empty_state>` (load-bearing `:action` slot — `SEC-A14`, `NAV-A07`), `<.badge>` (`ENV-A03`), and `<.card>`, all built on daisyUI's classes/tokens.
- `root.html.heex` drops the `" · Phoenix Framework"` title suffix; `/dev/dashboard`'s `Application.compile_env(:nucleus, :dev_routes)` guard is confirmed and documented in a router comment as the only thing gating LiveDashboard, since there is still no auth boundary (EN-6).
- Tests added: `core_components_test.exs` (modal a11y attributes, copy button hook/data attributes, empty-state action slot, badge variants) and `shell_test.exs` (tenant identifier, identity control, no sign-out control, archived-environment exclusion, empty-state-on-load-failure, no-token-in-HTML guard, sidebar collapse defaults/rail).

## Divergence from the plan

- **daisyUI decision reversed mid-ticket.** The issue's original "Decision to confirm" called for removing daisyUI and hand-writing Tailwind components. A later comment on the issue reversed that: daisyUI stays. `AGENTS.md` was reverted to its pre-ticket wording ("Use daisyUI ... build on its component classes and theme system") rather than having the daisyUI-removal language deleted outright, and the new components (`<.modal>`, `<.copy_button>`, `<.empty_state>`, `<.badge>`, `<.card>`) are built on daisyUI's classes and theme tokens instead of plain Tailwind.
- **The Secrets route ships now, with a placeholder `SecretsLive`, rather than being deferred to SEC-S1.** The issue's plan preferred deferring the route entirely to keep this ticket to shell + components, calling a placeholder only a fallback. That fallback was needed here: the sidebar's environment links use `~p` verified routes, which require a real, compilable, navigable destination at compile time — there's no way to link to a route that doesn't exist yet. `NucleusWeb.SecretsLive` renders an explicit "not implemented" state via `<.empty_state>` and is documented as disposable once SEC-S1/SEC-S2 land.
- **A second `on_mount` hook, `NucleusWeb.EnvironmentsHook`, was added.** The issue's plan named only `NucleusWeb.ScopeHook` in the `live_session`. Loading the sidebar's environment list needed `assign_async/3`, which can't run inside `Layouts.app` — a stateless function component has no LiveView lifecycle to hook into. `EnvironmentsHook` runs after `ScopeHook` in the `on_mount` list (it reads `current_scope.token` off the socket) and assigns `:environments` at the `live_session` level, so no individual view — including the future `SecretsLive` — needs to fetch its own copy.
- **The sidebar is collapsible** (open by default, collapsing to one icon per section — Tenant, Environments), added in a second commit. This was not part of the original plan at all — `NAV-A12` explicitly lists collapsible-sidebar behaviour as not required for this ticket — and was requested as a follow-up UX enhancement during implementation, not a functional requirement.

## Verification

`mix precommit` (`compile --warnings-as-errors`, `deps.unlock --unused`, `format`, `test`) passes on the pushed commits: 234 tests (25 doctests, 209 tests), 0 failures. A reviewer should still exercise the sidebar collapse/expand toggle, the environment empty-state-on-load-failure path, and the copy button's fallback path in a non-secure context by hand — those are browser-JS behaviors `Phoenix.LiveViewTest` can't execute.

Closes #7
