### PR TITLE
docs: move the durable record into the ticket's own PR; make the worktree-isolation stop structural

### DIFF
--- a/.opencode/agents/pr-author.md
+++ b/.opencode/agents/pr-author.md
@@ -72,7 +72,13 @@ You are given a ticket ID (e.g. `EN-3`) and optionally a base ref. If the base i
 4. **Check traceability.** If the issue references requirement IDs (`SEC-A09`, `EN-*`), confirm
    the diff actually addresses them and name them in the body.
 
-5. **Return the body** in the format below.
+5. **Account for the durable record.** Ticket PRs carry their own ADR and context-file updates
+   (`docs/adr/`, `decisions-log.md`, `business-tech-bridge.md`, `living-notes.md`) as a separate
+   commit — they are part of the change under review, not paperwork to ignore. Name the ADR and
+   summarise what it settles in one line. If the diff contains none and the ticket clearly
+   settled an architectural choice, flag that as a gap rather than staying silent.
+
+6. **Return the body** in the format below.
 
 ## Output Format
 
@@ -87,6 +93,12 @@ change, not the file list.
 - The substantive decisions — modules introduced, boundaries drawn, patterns followed.
 - One bullet per idea, not per file.
 - Name the requirement IDs satisfied, where the issue references them.
+
+## Record
+
+The ADR added and what it settles, in one line, plus which context files were updated. Omit the
+heading if the ticket settled nothing architectural and shipped no record — but say so in `What`
+rather than leaving it unexplained.
 
 ## Divergence from the plan
 

--- a/.opencode/commands/land.md
+++ b/.opencode/commands/land.md
@@ -1,5 +1,5 @@
 ---
-description: Land a merged ticket — merge the PR, tear down the worktree and branch, then write the ADR and decision-log entries that are authored at implementation time.
+description: Land a reviewed ticket — confirm the durable record shipped in the PR, merge it, then tear down the worktree and branch.
 agent: build
 ---
 
@@ -7,9 +7,11 @@ agent: build
 
 Ticket: $ARGUMENTS
 
-Complete a ticket after review. This command both merges **and** writes the durable record —
-per `ticket-decisions.md`, the ADR and decision-log entries are authored at implementation time,
-not decision time. Skipping step 5 is how the reasoning gets lost.
+Complete a ticket after review: merge, tear down, propagate.
+
+This command **does not write the ADR or the decision log.** Those ship inside the ticket's own
+PR, written by the `durable-record` skill during `/pr`. Step 1 checks they are there; if they are
+not, the fix is to add them to the PR before merging, not to write them here afterwards.
 
 ## 1. Resolve and check
 
@@ -22,6 +24,20 @@ gh pr checks <pr>
 
 Stop and report if the PR is not mergeable, or if checks are failing or still running.
 
+Then confirm the durable record is in the PR:
+
+```sh
+gh pr diff <pr> --name-only
+```
+
+If the ticket settled an architectural choice and no `docs/adr/` or
+`project-intelligence/decisions-log.md` change appears, **stop.** Report it, and offer to write
+the record onto the ticket branch via the `durable-record` skill so it merges with the code. Do
+not merge first and paper over it after — that is the pattern this convention exists to end.
+
+A ticket that genuinely settled nothing architectural is allowed to carry no record. Say so
+explicitly rather than leaving it unmentioned.
+
 ## 2. Merge
 
 Confirm with the user before merging — this is irreversible.
@@ -31,7 +47,9 @@ gh pr merge <pr> --squash --delete-branch
 ```
 
 Squash matches the existing history: one commit per ticket, sentence-style subject, lower-case,
-trailing full stop. Verify `Closes #<n>` did its job:
+trailing full stop. The implementation commits and the record commit collapse into that one
+commit — the split existed for the reviewer, not for `main`'s history. Verify `Closes #<n>` did
+its job:
 
 ```sh
 gh issue view <n> --json state --jq .state
@@ -67,26 +85,9 @@ mix precommit
 ```
 
 On `main`, post-merge. A wave of individually-green tickets can still produce a red `main`.
-If it fails, say so immediately — that is more urgent than the paperwork below.
+If it fails, say so immediately.
 
-## 5. Write the durable record
-
-Now, and only now:
-
-1. **ADR** — if the ticket settled an architectural choice, add `docs/adr/NNNN-<slug>.md`
-   following the structure of the existing ADRs in that directory. Read one first; match it.
-   Number sequentially. If the ticket settled nothing architectural, skip this and say so.
-2. **Decision log** — mirror it into
-   `.opencode/context/project-intelligence/decisions-log.md`.
-3. **Traceability** — if the requirement mapping changed, update
-   `.opencode/context/project-intelligence/business-tech-bridge.md`.
-4. **Living notes** — if the work opened or closed a question, update
-   `.opencode/context/project-intelligence/living-notes.md`.
-
-Respect the MVI size limits on those context files. If an entry would push a file over, load the
-`context-manager` skill and compact rather than letting it sprawl.
-
-## 6. Propagate
+## 5. Propagate
 
 If any open ticket's plan branched on this outcome, add the one-line back-reference described in
 `ticket-decisions.md`, or the decision is invisible from the ticket that depends on it:
@@ -97,7 +98,7 @@ Resolved by #3: tenant API adapter landed, use Nucleus.TenantApi behaviour.
 
 Also remove the `blocked` label from any ticket this unblocked.
 
-## 7. Report
+## 6. Report
 
-Merge commit, issue state, worktree/branch teardown result, `mix precommit` on `main`, files
-written in step 5, and tickets updated in step 6.
+Merge commit, issue state, worktree/branch teardown result, `mix precommit` on `main`, the record
+artifacts step 1 confirmed were in the PR, and tickets updated in step 5.

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -1,5 +1,5 @@
 ---
-description: Open a pull request for the current ticket branch — verify the precommit gate, delegate the body to the pr-author subagent, then create it.
+description: Open a pull request for the current ticket branch — write the durable record, verify the precommit gate, delegate the body to the pr-author subagent, then create it.
 agent: build
 ---
 
@@ -24,7 +24,20 @@ Stop and report if:
 If `$ARGUMENTS` is empty, infer the ticket ID from the branch name (`en-3-...` → `EN-3`) and
 state the inference you made.
 
-## 2. Verify the gate
+## 2. Write the durable record
+
+Load the `durable-record` skill and follow it. The ADR, `decisions-log.md`,
+`business-tech-bridge.md`, and `living-notes.md` are part of **this** PR — they ship as their own
+commit on top of the implementation, and are reviewed with the code that justifies them.
+
+The skill decides which of the four artifacts actually apply and may legitimately conclude that
+none do. Carry what it reports — files written, ADR number, anything skipped and why — into
+step 5.
+
+Do not skip this step because the ticket body did not spell it out, and do not defer it to
+`/land`; `/land` no longer writes anything.
+
+## 3. Verify the gate
 
 Run `mix precommit` in this worktree. It is `compile --warnings-as-errors`,
 `deps.unlock --unused`, `format`, `test`.
@@ -33,27 +46,33 @@ Run `mix precommit` in this worktree. It is `compile --warnings-as-errors`,
 
 If `mix format` or `deps.unlock` modified files, commit those changes before continuing.
 
-## 3. Push
+## 4. Push
 
 ```sh
 git push -u origin HEAD
 ```
 
-## 4. Delegate the body
+## 5. Delegate the body
 
 Invoke the `pr-author` subagent with the ticket ID and base ref. It reads the diff and the issue
 in an isolated context and returns markdown only — this keeps a large diff out of this session.
 
+The record commit from step 2 is in that diff, so `pr-author` will describe it. Pass along what
+the skill reported, including anything it skipped, so the body can state it rather than leaving
+the reviewer to infer it from the file list.
+
 Do not write the body yourself unless `pr-author` is unavailable.
 
-## 5. Create the PR
+## 6. Create the PR
 
 Review what came back before using it. Check specifically that:
 
 - `Closes #<number>` is present and the number matches the issue you resolved by **title**.
 - Any `## Divergence from the plan` section is accurate — this is the highest-value part for a
   reviewer, and the easiest to get wrong.
-- No claim is made about tests passing beyond what step 2 actually showed.
+- No claim is made about tests passing beyond what step 3 actually showed.
+- The record is described, or its absence is explained. A PR that silently ships no ADR reads
+  identically to one that forgot.
 
 Then:
 
@@ -63,7 +82,8 @@ gh pr create --base <default-branch> --title "<ID>: <short description>" --body-
 
 Pass the body on stdin. Do not use `--fill`.
 
-## 6. Report
+## 7. Report
 
-Return the PR URL, the issue it closes, and the `mix precommit` result. If you amended anything
-`pr-author` produced, say what and why.
+Return the PR URL, the issue it closes, the record artifacts written in step 2 (and any skipped,
+with the reason), and the `mix precommit` result. If you amended anything `pr-author` produced,
+say what and why.

--- a/.opencode/commands/start.md
+++ b/.opencode/commands/start.md
@@ -45,10 +45,17 @@ Choose the slug to describe **the work**, not the ticket title, and propose it t
 before running. Precedent: `en-1-no-local-datastore` for a ticket titled *"Resolve
 Postgres-vs-stateless — drop ecto_sql/postgrex"*.
 
-If `bin/wt` creates a new worktree, this session cannot move into it. Report the printed launch
-line and stop.
+The skill tracks its own `isolation_status` and stops with a boxed `STOP` at the point a new
+worktree is created — follow that stop. Do not treat step 4 below as automatically next; its
+heading below repeats the same precondition so there is nothing to read past.
 
 ## 4. Load context
+
+**Precondition — only if `isolation_status` came back `already-isolated` or `declined`.** If the
+skill just created a new worktree, you already stopped inside it. This session ends at that
+`STOP` box: it reports the launch line and nothing else. Do not run the steps below in that
+session; they get redone from scratch by the fresh session that runs `/start` again inside the
+new worktree.
 
 Once isolation is settled and you are in the right directory:
 

--- a/.opencode/context/workflows/guides/ticket-decisions.md
+++ b/.opencode/context/workflows/guides/ticket-decisions.md
@@ -1,4 +1,4 @@
-<!-- Context: workflows/guides | Priority: high | Version: 1.0 | Updated: 2026-08-07 -->
+<!-- Context: workflows/guides | Priority: high | Version: 1.1 | Updated: 2026-08-14 -->
 
 # Answering Questions & Decisions on a Ticket
 
@@ -23,9 +23,9 @@ gh issue comment <n> --body-file -   # 1. post the decision
 gh issue edit <n> --remove-label needs-decision   # 2. clear the signal
 ```
 
-The comment is the durable record. The label is the machine-readable "still blocked on Dave"
-flag that `gh issue list --label needs-decision` scans. **If the label survives the answer, the
-agent will re-ask.** Clearing it is not optional bookkeeping.
+The comment is the permanent record of the decision. The label is the machine-readable "still
+blocked on Dave" flag that `gh issue list --label needs-decision` scans. **If the label survives
+the answer, the agent will re-ask.** Clearing it is not optional bookkeeping.
 
 ## Comment Template
 
@@ -69,11 +69,16 @@ Resolved by #1: ecto retained, use embedded_schema.
 | Artifact | Answers | Written |
 |----------|---------|---------|
 | Issue comment | *when and why we chose* | at decision time |
-| `docs/adr/` | *what we do now* | at implementation time |
-| `project-intelligence/decisions-log.md` | in-repo mirror of the decision | at implementation time |
+| `docs/adr/` | *what we do now* | at implementation time, **in the ticket's own PR** |
+| `project-intelligence/decisions-log.md` | in-repo mirror of the decision | at implementation time, **in the ticket's own PR** |
 
-Do **not** write the ADR or log entry when the decision is made — only when the work lands.
+Do **not** write the ADR or log entry when the decision is made — only when the work is built.
 Otherwise the reasoning is duplicated in three places ahead of any code.
+
+"At implementation time" means **before the pull request opens, as a commit in that PR** — not
+after `/land` merges it. The `durable-record` skill does this, and `/pr` invokes it. A ticket body
+that lists ADR or context-file updates in its plan or acceptance criteria is therefore read
+literally: those files belong in that ticket's diff.
 
 ## Non-Decision Questions
 
@@ -92,6 +97,7 @@ Fix: `gh auth refresh -s project`
 
 ## Related Files
 
+- **Writing the ADR / decision log for a ticket** → `durable-record` skill
 - **Decision log** → `../../project-intelligence/decisions-log.md`
 - **Open questions / debt** → `../../project-intelligence/living-notes.md`
 - **Requirement traceability** → `../../project-intelligence/business-tech-bridge.md`

--- a/.opencode/context/workflows/guides/ticket-delivery.md
+++ b/.opencode/context/workflows/guides/ticket-delivery.md
@@ -1,4 +1,4 @@
-<!-- Context: workflows/guides | Priority: high | Version: 1.0 | Updated: 2026-08-07 -->
+<!-- Context: workflows/guides | Priority: high | Version: 1.1 | Updated: 2026-08-14 -->
 
 # Delivering a Ticket
 
@@ -70,27 +70,43 @@ Do not put ticket IDs in commit subjects. The PR carries the link.
 
 ## Before Opening a PR
 
-`mix precommit` is the required gate — `compile --warnings-as-errors`, `deps.unlock --unused`,
-`format`, `test`. Run it **inside the worktree**. Never open a PR on a red gate.
+Two required steps, in this order.
+
+**1. Write the durable record.** Load the `durable-record` skill. If the ticket settled an
+architectural choice, `docs/adr/NNNN-<slug>.md` and the `decisions-log.md` entry are part of
+**this ticket's PR** — plus `business-tech-bridge.md` where traceability changed and
+`living-notes.md` where a question opened or closed. They go in as their own commit on top of the
+implementation, so a reviewer sees the reasoning next to the code.
+
+This means a ticket body listing doc updates in its plan or acceptance criteria is read
+**literally**: those files belong in that ticket's diff. `EN-1`/`EN-3`/`EN-5`/`EN-6`/`EN-7`/`EN-8`
+each landed their record as a follow-up commit *after* merge under the previous convention — that
+is history, not a pattern to copy.
+
+**2. Run the gate.** `mix precommit` — `compile --warnings-as-errors`, `deps.unlock --unused`,
+`format`, `test`. Run it **inside the worktree**, after the record commit. Never open a PR on a
+red gate.
 
 ## Pull Request
 
-`/pr` delegates the body to the `pr-author` subagent, then creates it. The body must:
+`/pr` writes the record, verifies the gate, delegates the body to the `pr-author` subagent, then
+creates it. The body must:
 
 - Open with what changed and why, in prose — not a bullet dump of the diff.
 - Carry `Closes #<number>` so the merge closes the issue automatically.
 - Call out any divergence from the plan in the issue body, and why.
 - Name the requirement IDs (`SEC-A09`, …) the change satisfies, where relevant.
+- Describe the record that shipped with it, or explain why the ticket earned none.
 
 ## After Merge
 
-`/land` squash-merges, deletes the branch, and removes the worktree. Then, and **only** then,
-write the durable record — per `ticket-decisions.md`, these are authored at implementation
-time, not decision time:
+`/land` squash-merges, deletes the branch, and removes the worktree. The record already merged
+with the code, so there is no documentation step left — squashing collapses the implementation
+commits and the record commit into the single ticket commit on the default branch.
 
-1. `docs/adr/NNNN-<slug>.md` — what we do now, if the ticket settled an architectural choice.
-2. `project-intelligence/decisions-log.md` — the in-repo mirror.
-3. `project-intelligence/business-tech-bridge.md` — if requirement traceability changed.
+What does remain: verify `Closes #<n>` actually closed the issue, run `mix precommit` on the
+default branch (a wave of individually-green tickets can still produce a red `main`), and
+propagate the outcome to any ticket whose plan branched on it, per `ticket-decisions.md`.
 
 ## Worktree Teardown
 
@@ -101,6 +117,7 @@ uncommitted changes, untracked files, and unpushed commits before forcing.
 ## Related Files
 
 - **Answering a question/decision on a ticket** → `ticket-decisions.md`
+- **Writing the ADR / decision log for a ticket** → `durable-record` skill
 - **Running several tickets at once** → `parallel-dispatch.md`
 - **Code standards** → `AGENTS.md` at the project root
 - **Decision log** → `../../project-intelligence/decisions-log.md`

--- a/.opencode/context/workflows/navigation.md
+++ b/.opencode/context/workflows/navigation.md
@@ -1,4 +1,4 @@
-<!-- Context: workflows/nav | Priority: high | Version: 1.1 | Updated: 2026-08-07 -->
+<!-- Context: workflows/nav | Priority: high | Version: 1.2 | Updated: 2026-08-14 -->
 
 # Workflows
 
@@ -21,7 +21,7 @@
 | File | Description | Priority |
 |------|-------------|----------|
 | `guides/ticket-decisions.md` | Answering a question or confirming a decision on a GitHub issue: the comment-then-unlabel loop, comment template, when to edit the issue body, ADR timing | high |
-| `guides/ticket-delivery.md` | Implementing a ticket end to end: readiness gate, worktree isolation via `bin/wt`, branch naming, commit style, `mix precommit` gate, opening a pull request, merging, cleanup | high |
+| `guides/ticket-delivery.md` | Implementing a ticket end to end: readiness gate, worktree isolation via `bin/wt`, branch naming, commit style, writing the durable record, `mix precommit` gate, opening a pull request, merging, cleanup | high |
 | `guides/parallel-dispatch.md` | Working several tickets simultaneously: computing dependency-safe waves, one worktree per ticket, headless `opencode run` trade-offs, merge/rebase reconciliation order | medium |
 
 ## Loading Strategy
@@ -41,8 +41,10 @@
 2. Then `guides/ticket-delivery.md` for the per-ticket mechanics
 
 **Recording a decision that has already been implemented**:
-1. Load `guides/ticket-decisions.md` (Timing section — issue vs ADR vs log)
-2. Then `../project-intelligence/decisions-log.md`
+1. Load the `durable-record` skill — it writes the ADR, `decisions-log.md`,
+   `business-tech-bridge.md`, and `living-notes.md`, and is invoked by `/pr` before the PR opens
+2. `guides/ticket-decisions.md` (Timing section) for why those artifacts are not written at
+   decision time
 
 ## Tooling
 
@@ -50,7 +52,8 @@
   IDs by issue **title**, branches from `origin/HEAD`, initialises submodules, runs
   `mix deps.get`. Run `bin/wt --help`.
 - Commands: `/start`, `/dispatch`, `/pr`, `/land` in `.opencode/commands/`.
-- Skill: `workspace-isolation` checks for worktree isolation before implementation begins.
+- Skills: `workspace-isolation` checks for worktree isolation before implementation begins;
+  `durable-record` writes the ADR and context-file updates into the ticket's PR.
 
 ## Maintenance
 

--- a/.opencode/skills/durable-record/SKILL.md
+++ b/.opencode/skills/durable-record/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: durable-record
+description: Use when a ticket's implementation is committed and its durable record must be written — the ADR under docs/adr/ plus decisions-log.md, business-tech-bridge.md, and living-notes.md. Triggers on "write the ADR", "record the decision", "update decisions-log", "update living notes", "update the bridge", and runs as part of /pr before the pull request opens.
+---
+
+# Writing the Durable Record
+
+Turn a ticket's settled decisions into the artifacts a future reader will actually find, and
+commit them **into the ticket's own branch, as part of its pull request**.
+
+**Announce at start:** "Writing the durable record before the PR."
+
+## Timing — This Is the Rule
+
+The record ships **inside the ticket's PR**, as its own commit on top of the implementation
+commits. It is reviewed alongside the code that justifies it.
+
+Three consequences to hold on to:
+
+1. A ticket body that lists `docs/adr/…`, `living-notes.md`, or `business-tech-bridge.md` in its
+   plan or acceptance criteria means exactly what it says — those files are deliverables of that
+   ticket's PR. Read them literally.
+2. `/land` no longer writes anything. If you reach `/land` and the record is missing, the PR was
+   incomplete; see "If You Are Already Past the Merge" below.
+3. `EN-1`/`EN-3`/`EN-5`/`EN-6`/`EN-7`/`EN-8` landed their records as follow-up commits *after*
+   merge, under the previous convention. That history is a record of how it used to work, not a
+   pattern to copy. Do not reproduce it.
+
+Because `/land` squash-merges, the record and the implementation collapse into one commit on the
+default branch. That is intended — the split exists for reviewability, not for history.
+
+## Step 0: Preconditions
+
+Do not start until all three hold:
+
+| Check | Why |
+|-------|-----|
+| Implementation work is **committed**, working tree clean | The record describes what the code does; `git status` must be quiet so the record lands as its own commit |
+| You are inside the ticket's worktree, not the main checkout | See the `workspace-isolation` skill |
+| The issue is resolved by **title** and you have read it, with comments | `EN-n`/`SEC-Sn` IDs are not GitHub numbers; the comment thread carries decisions that amended the plan |
+
+```sh
+gh issue view <n> --comments
+```
+
+## Step 1: Decide What Applies
+
+Not every ticket earns every artifact. Decide deliberately, and **say which you skipped and
+why** — silence reads as an oversight.
+
+| Artifact | Write it when | Skip it when |
+|----------|---------------|--------------|
+| `docs/adr/NNNN-<slug>.md` | The ticket settled an architectural choice, or reversed one | Pure mechanics with no choice in it — a rename, a dependency bump |
+| `.opencode/context/project-intelligence/decisions-log.md` | An ADR was written | No ADR — the log is that file's index, never a standalone entry |
+| `.opencode/context/project-intelligence/business-tech-bridge.md` | Requirement traceability changed — new action IDs covered, test paths now real | The change touches no requirement mapping |
+| `.opencode/context/project-intelligence/living-notes.md` | The work opened, closed, or narrowed an open question, or retired an active project | Nothing on that file's lists moved |
+
+If **nothing** applies, stop and report that. An empty record commit is noise.
+
+## Step 2: The ADR
+
+1. **Number from the directory, not the ticket body.** `ls docs/adr/` and take the highest
+   number plus one. Ticket bodies name a number when they are written, and drift — EN-8's body
+   asked for `0005-test-strategy.md` when `0005-deferred-authentication.md` already existed. The
+   directory is the truth; if the body disagrees, follow the directory and note the divergence
+   for the PR body.
+2. **Read a neighbour first and match it.** `docs/adr/0007-secrets-store-adapter.md` is a good
+   model. Structure: `# ADR-NNNN: Title`, `## Status`, `## Context`, `## Decision` (subsections
+   per choice settled), `## Consequences`.
+3. **Status is `Accepted — YYYY-MM-DD`, with the deciding issue linked.** Not `Proposed`.
+   Merging the PR is the acceptance; a `Proposed` status would need flipping later, which is
+   precisely the dangling follow-up step this convention removes.
+4. **Never write that the ADR "is not yet live"** or otherwise hedge on its own status. It ships
+   with the code it describes.
+5. Cover what the previous convention's after-merge write-ups were good at: the alternatives
+   rejected, and any correction that implementation surfaced which the plan could not have
+   anticipated. Those are the parts nobody can reconstruct later.
+
+## Step 3: `decisions-log.md`
+
+Two edits, both required — the file is an index *and* a summary:
+
+1. Add a row to the **Decision Index** table.
+2. Add an entry below it, following the **Decision Template** documented in that file: title,
+   the `**Date** | **Status** | **ADR**` line, two to four sentences, then `**Related**` with
+   issue links.
+
+Summarise; do not restate the ADR. Rationale, alternatives, and consequences live in the ADR and
+belong in exactly one place.
+
+## Step 4: `business-tech-bridge.md` and `living-notes.md`
+
+Only where step 1 said they apply. Edit in place, following each file's existing entry shape —
+`living-notes.md` in particular distinguishes Active Projects from its Archive, and closing an
+item means moving it, not deleting it.
+
+## Step 5: Context-File Hygiene
+
+- Bump `Version:` and `Updated:` in the `<!-- Context: … -->` header comment of every context
+  file you touched.
+- Respect the MVI size limits. If an entry would push a file over, load the `context-manager`
+  skill and compact — do not let it sprawl.
+
+## Step 6: Commit
+
+One commit, separate from the implementation, sentence-style and lower-case with a trailing full
+stop, naming the artifacts written:
+
+```
+record the secrets store adapter decision: adr-0007, decisions-log, living-notes.
+```
+
+No ticket ID in the subject — the PR carries the link.
+
+## Step 7: Hand Back
+
+Report the files written, the ADR number assigned, anything you skipped and why, and any place
+the ticket body disagreed with what you found. `/pr` folds that into the PR body, so the
+reviewer sees the record and the code together.
+
+## If You Are Already Past the Merge
+
+A ticket that merged without its record is not a reason to leave the record unwritten. Write it
+on the default branch as a standalone commit, and say plainly that it is a repair of a missed
+step, not the normal flow.
+
+## Related
+
+- **Delivery mechanics, PR conventions** → `.opencode/context/workflows/guides/ticket-delivery.md`
+- **Decision-time vs implementation-time artifacts** → `.opencode/context/workflows/guides/ticket-decisions.md`
+- **Compacting an oversized context file** → `context-manager` skill

--- a/.opencode/skills/workspace-isolation/SKILL.md
+++ b/.opencode/skills/workspace-isolation/SKILL.md
@@ -26,13 +26,14 @@ git rev-parse --show-superproject-working-tree 2>/dev/null
 If that prints a path, you are in a submodule, **not** a worktree. Treat it as a normal
 checkout, and note that editing files there commits to `nucleus.wiki`, not this repo.
 
-Decide:
+Decide, and set `isolation_status` to one of the three values in the right column — every later
+step in this skill is gated on that value, not on remembering the prose below:
 
-| Condition | Meaning | Action |
+| Condition | Meaning | `isolation_status` |
 |-----------|---------|--------|
-| Output above is non-empty | Inside the `docs/requirements` submodule | Stop. You are almost certainly in the wrong place — confirm with the user. |
-| `GIT_DIR != GIT_COMMON` | Already in a linked worktree | Report path + branch, skip to Step 2 |
-| `GIT_DIR == GIT_COMMON` | Main checkout | Go to Step 1 |
+| Output above is non-empty | Inside the `docs/requirements` submodule | `submodule` — stop, confirm with the user, do not set any other value |
+| `GIT_DIR != GIT_COMMON` | Already in a linked worktree | `already-isolated` — report path + branch, go to **Step 2** |
+| `GIT_DIR == GIT_COMMON` | Main checkout | unset — go to **Step 1** |
 
 Report as: "Already isolated at `.worktrees/en-3` on branch `en-3-tenant-api-adapter`."
 
@@ -44,7 +45,8 @@ honour it silently. Otherwise **ask before creating anything**:
 > "You're in the main checkout on `main`. Set up an isolated worktree for this ticket? It keeps
 > `main` clean and lets other tickets run in parallel."
 
-If they decline, work in place and skip to Step 2. Do not re-ask later in the session.
+If they decline: `isolation_status = declined`. Work in place and go to **Step 2**. Do not
+re-ask later in the session.
 
 If they accept, use `bin/wt` — never raw `git worktree add`:
 
@@ -56,19 +58,31 @@ bin/wt EN-3 tenant-api-adapter
 `mix deps.get`. Doing it by hand skips all three and produces a worktree with empty
 requirements and a wrong base. Run `bin/wt --help` for options.
 
-**The new worktree is a different directory, and this session cannot move into it.** Report the
-printed launch line and stop:
+`isolation_status = new-worktree-created`.
 
-```
-cd .worktrees/en-3 && opencode      # then: /start EN-3
-```
-
-Do not attempt to edit files inside `.worktrees/` from this session.
+> [!STOP]
+> **This session cannot move into the new worktree.** It is a different directory on disk; `cd`
+> from this process does not change what this session can edit. Output the launch line below,
+> then **end your turn. Do not call another tool. Do not read Step 2.**
+>
+> ```
+> cd .worktrees/en-3 && opencode      # then: /start EN-3
+> ```
+>
+> Loading `ticket-delivery.md`, running `context-indexer`, or reading the issue further in *this*
+> session is not "getting a head start" — it is wasted work. A fresh session inside the new
+> worktree runs `/start` again and reloads everything from the correct location. That session
+> does not inherit anything you do here after this point.
 
 ## Step 2: Proceed
 
+**Precondition — do not enter this step unless `isolation_status` is `already-isolated` or
+`declined`.** If `isolation_status` is `new-worktree-created`, you already stopped at the STOP
+box in Step 1; there is nothing here for that session to do.
+
 Isolation is settled. Load `.opencode/context/workflows/guides/ticket-delivery.md` for branch
-naming, commit style, the `mix precommit` gate, and PR conventions, then begin the work.
+naming, commit style, the durable-record timing, the `mix precommit` gate, and PR conventions,
+then begin the work.
 
 ## Related
 

--- a/docs/adr/0008-test-strategy.md
+++ b/docs/adr/0008-test-strategy.md
@@ -110,16 +110,23 @@ count would miss. Supports `--feature PREFIX` and `--exitcode`. Not added to
 tickets remain open would block every commit before any of them lands. See
 `living-notes.md`.
 
-### Context-file updates land after merge, not in the PR
+### Context-file updates landed after merge — a convention issue #24 has since replaced
 
-`test/README.md` documents the layer table, tag vocabulary, and
-traceability convention inline, and explicitly notes at review time that
-this ADR is not yet live. Per `ticket-delivery.md`'s "After Merge"
-convention — and matching how EN-1/EN-3/EN-5/EN-6/EN-7 actually shipped —
-this ADR, `living-notes.md`, and `business-tech-bridge.md` are updated in
-the landing commit, not the PR. Issue #24 was filed during this ticket to
-reconcile the ticket-body-vs-workflow-guide timing inconsistency that made
-this ambiguous going forward.
+`test/README.md` documents the layer table, tag vocabulary, and traceability convention inline,
+and noted at review time that this ADR was not yet live. That was correct under the convention
+in force when this ticket landed: per `ticket-delivery.md`'s then-current "After Merge" section —
+matching how EN-1/EN-3/EN-5/EN-6/EN-7 actually shipped — this ADR, `living-notes.md`, and
+`business-tech-bridge.md` were written in the landing commit, after the harness PR merged, not in
+the PR itself. That history is not being rewritten here.
+
+This ticket's own plan and acceptance-criteria checklist listed those same updates as PR-scope
+deliverables, contradicting the guide it was implemented under — an inconsistency this ticket's
+own kickoff surfaced and filed as issue #24. That issue's resolution changed the convention
+**going forward**: `docs/adr/`, `decisions-log.md`, `business-tech-bridge.md`, and
+`living-notes.md` updates now ship inside a ticket's own PR, as a dedicated commit written by the
+`durable-record` skill and invoked by `/pr` — not as a follow-up `/land` commit. `/land` no longer
+writes any of them. See `ticket-delivery.md`'s "Before Opening a PR" section and
+`ticket-decisions.md`'s "Timing" table, both updated by issue #24.
 
 ## Consequences
 
@@ -188,6 +195,8 @@ Secrets is complete, per `living-notes.md`.
   convention, in the form a developer reads day to day
 - `.opencode/context/project-intelligence/business-tech-bridge.md` — the
   `action:` tagging convention this task enforces
-- Issue #24 — files the ticket-body-vs-workflow-guide timing reconciliation
-  this ticket's own orientation surfaced
+- Issue #24 — filed during this ticket's own kickoff over the ticket-body-vs-workflow-guide
+  timing inconsistency; resolved by moving doc updates into the ticket's own PR going forward
+- `.opencode/skills/durable-record/SKILL.md` — the skill issue #24 introduced to write this
+  record inside a ticket's PR, for tickets after this one
 - Issues #9–#15 (every SEC ticket) — the harness's first consumers


### PR DESCRIPTION
## What

This reconciles a contradiction between two workflow guides and a ticket's own acceptance criteria: `ticket-delivery.md` and `ticket-decisions.md` said the ADR/`decisions-log.md`/`business-tech-bridge.md` update for a ticket is written as a follow-up commit *after* `/land` merges the PR, while EN-8's issue body listed those same updates as PR-scope acceptance criteria. Per explicit direction, the fix moves that work out of `/land` and into `/pr`, via a new `durable-record` skill that `/pr` invokes before the gate runs. A second, related bug found live during this ticket's own kickoff — `workspace-isolation`'s "stop after creating a worktree" instruction being prose-only with no structural gate — is fixed in the same PR.

## How

- Added `.opencode/skills/durable-record/SKILL.md`: decides which of the four artifacts (ADR, `decisions-log.md`, `business-tech-bridge.md`, `living-notes.md`) apply to a given ticket, numbers ADRs from the `docs/adr/` directory rather than the ticket body (calling out EN-8's stale `0005` collision as the kind of drift this prevents), and writes them as a dedicated commit on top of the implementation.
- Rewired `/land` (`land.md`) to stop writing anything: it now checks the merged PR's diff for the expected record and refuses to merge silently if an architectural ticket shipped none, instead of writing the record itself post-merge.
- Rewired `/pr` (`pr.md`) to invoke `durable-record` as its new step 2, before the `mix precommit` gate, and to carry what the skill reports (files written, ADR number, anything skipped) into the PR body via `pr-author`.
- Updated `pr-author.md` with a new "Account for the durable record" instruction and a `## Record` section in its output format, so every PR body states what shipped or explicitly says nothing architectural was settled.
- Updated `ticket-decisions.md` and `ticket-delivery.md` to state the new timing explicitly ("at implementation time" now means "in the ticket's own PR," not after `/land`), and updated `navigation.md` to point at the new skill.
- Updated `docs/adr/0008-test-strategy.md`'s own retrospective note, since it had documented the *old* after-merge convention as still current; it now records that issue #24 changed the convention going forward and that ADR-0008 itself is history, not a pattern to copy.
- Made `workspace-isolation/SKILL.md`'s stop structural per the issue's option 4: introduced an `isolation_status` variable (`submodule` / `already-isolated` / `declined` / `new-worktree-created`) set explicitly at the decision point, a boxed `STOP` callout immediately after worktree creation instructing the agent to end its turn without reading further, and an explicit precondition on Step 2's heading gating it on `isolation_status`. `start.md` got the matching precondition on its "Load context" step.

## Divergence from the plan

The issue offered four non-exclusive options for the ADR/decisions-log timing question and left the choice open. The implementation took option 1 in spirit (fix the template/guides) but went further than any single listed option: rather than just adding a caveat note to future ticket bodies, it introduced a new `durable-record` skill as the enforcement mechanism, per explicit direction to move the durable record into the ticket's own PR using a third skill invoked by `/pr`. This is a stronger structural fix than the issue's options described, not a smaller one.

For the second bug (workspace-isolation), the issue's option 4 was implemented as described — a boxed `STOP` plus preconditions on the downstream headings — with no divergence.

## Record

This PR carries no ADR and no `decisions-log.md` entry, and that absence is correct rather than an omission: the change is entirely to `.opencode/` workflow tooling (skills, commands, guides) and does not settle an architectural choice about the Nucleus application itself. The one `docs/adr/` file touched (`0008-test-strategy.md`) is an edit to an *existing* ADR's retrospective note, correcting it to reflect the new convention this ticket introduces — not a new decision recorded here.

## Verification

`mix precommit` (`compile --warnings-as-errors`, `deps.unlock --unused`, `format`, `test`) run in this worktree: 338 tests passed (25 doctests, 313 tests), 10 excluded, no failures, no files modified by `format`/`deps.unlock`. No new tests were added — this change is entirely to `.opencode/` prose (skills, commands, guides), which has no automated coverage in this repo. A reviewer should read the `durable-record` skill and the updated `/pr`/`/land` commands directly, and ideally exercise `/pr` end to end on a small follow-up ticket to confirm the skill invocation and `/land`'s diff-check behave as described.

Closes #24
