### PR TITLE
docs: correct stale namespace wording for parameter store paths

### DIFF
--- a/.opencode/context/project-intelligence/business-domain.md
+++ b/.opencode/context/project-intelligence/business-domain.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/business | Priority: high | Version: 1.0 | Updated: 2026-08-07 -->
+<!-- Context: project-intelligence/business | Priority: high | Version: 1.1 | Updated: 2026-08-14 -->
 
 # Business Domain
 
@@ -113,7 +113,7 @@ feature work has begun.
 | Term | Meaning |
 |------|---------|
 | **Tenant** | A customer instance, identified by a namespace (e.g. `qa-bb`). One deployment serves one tenant. |
-| **Namespace** | The tenant's identifier. Prefixes Nomad jobs/variables and M2M client names; a path segment for Parameter Store secrets. |
+| **Namespace** | The tenant's identifier. Prefixes Nomad jobs/variables and M2M client names. Not used for Parameter Store paths — see `CLUSTER_NAME`/`DEPLOYMENT_NAME` (`docs/adr/0007-secrets-store-adapter.md`). |
 | **Environment** | A deployment stage within a tenant (e.g. `prod`, `staging`, `dev`). Defined by the tenant's backing API, not by Nucleus. |
 | **M2M client** | A Cognito App Client using the `client_credentials` OAuth flow, for external systems calling tenant APIs without a human user. |
 | **Data Export** | An optional tenant capability, configured via a dedicated Nomad job and matching Nomad Variables. |

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.5 | Updated: 2026-08-14 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.6 | Updated: 2026-08-14 -->
 
 # Living Notes
 
@@ -17,7 +17,7 @@
 | `docs/adr/` had no ADRs while 7 prototype ADRs sit in the wiki | ADR-shaped questions get answered in chat and lost | Medium | Write this project's own ADRs as decisions land — `0001` now exists |
 | LiveDashboard at `/dev/dashboard` unauthenticated | Fine in dev; a leak if ever exposed in prod | Medium | Gate behind auth before any production deploy |
 | `NucleusWeb.SecretsLive` is a placeholder ("not implemented" empty state) so `~p` verified routes compile | Looks like a real view; must not be patched incrementally | Medium | SEC-S1 (#9) replaces the module wholesale — see `docs/adr/0006-application-shell-and-live-session-composition.md` |
-| Nucleus's own AWS identity (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) is read ambiently by the `aws` package, with no boot-time check or ops-facing doc — unlike `TENANT_ROLE_ARN`/`AWS_REGION`/`CLUSTER_NAME`/`DEPLOYMENT_NAME`, which all raise at boot | A misconfigured deployment fails per-request as `:not_configured` on first `AssumeRole` call, not at boot | Low | Document in `OPS-*` config reference when that ticket lands; see `docs/adr/0007-secrets-store-adapter.md` |
+| Nucleus's own AWS identity (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) is read ambiently by the `aws` package, with no boot-time check or ops-facing doc — unlike `TENANT_ROLE_ARN`/`AWS_REGION`/`CLUSTER_NAME`/`DEPLOYMENT_NAME`, which all raise at boot | A misconfigured deployment fails per-request as `:not_configured` on first `AssumeRole` call, not at boot | Low | `CLUSTER_NAME`/`DEPLOYMENT_NAME` are now correctly documented in the wiki's `Platform-Operations.md` config reference (issue #22). The ambient `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` doc gap remains open — was out of scope for #22 |
 | No browser-driven test coverage for `SEC-A02` (clipboard write confirmation) or `SEC-A13` (Escape dismissal, focus trap, focus restoration) — `navigator.clipboard` and real key/focus events need a browser, which this repo has no driver for | Tests assert wiring only (hook attached, `on_cancel` set), never claim `@tag action:` for these IDs — a real regression would not be caught until a browser harness exists | Medium | Add Wallaby once sign-in exists (deferred, EN-8); see `docs/adr/0008-test-strategy.md` |
 
 ### Technical Debt Details


### PR DESCRIPTION
## What

`TENANT_NAMESPACE` was never part of the Parameter Store path — EN-4 Decision 1 (recorded in `docs/adr/0007-secrets-store-adapter.md`) settled that the real pattern is `/{cluster}/deployments/{deployment}/faas/functions/{environment}/{key}`, built from deploy-time `CLUSTER_NAME`/`DEPLOYMENT_NAME` config. Both the project wiki and a local glossary file still claimed the tenant namespace was used as a Parameter Store path segment, a leftover from before that decision landed. This PR brings both back in line with what was actually decided and implemented.

## How

- The substantive content change is a wiki edit, not something this PR's diff shows directly: `docs/requirements` is a submodule pointing at the separate `nucleus.wiki` repo, which has no PR mechanism, so the correction (`Correct stale Namespace wording for Parameter Store paths (EN-4 Decision 1)`, commit `0efab7d`) was committed and pushed straight to that repo. It narrows `Home.md`'s glossary "Namespace" entry to drop the Parameter Store claim, narrows `TENANT_NAMESPACE`'s row in `Platform-Operations.md`'s config table to "Nomad/M2M naming and audit records," corrects `CLUSTER_NAME`'s row and adds the previously-missing `DEPLOYMENT_NAME` row (both required, working together to build the path prefix), and adds a short note to `Secrets.md` stating the actual storage path pattern and its `CLUSTER_NAME`/`DEPLOYMENT_NAME` origin.
- This PR's own diff is almost entirely the submodule pointer bump (`88917a2` → `0efab7d`) plus two local files: `.opencode/context/project-intelligence/business-domain.md`'s glossary "Namespace" entry carried the identical stale claim and is corrected to match the wiki wording, pointing at ADR-0007.
- `.opencode/context/project-intelligence/living-notes.md`'s existing open item about undocumented ambient AWS identity vars is updated to note that `CLUSTER_NAME`/`DEPLOYMENT_NAME` are now correctly documented via this issue, while explicitly flagging that documenting the ambient `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` vars remains a separate, still-open gap.
- Satisfies EN-4 Decision 1 / ADR-0007 by making the documentation match the decision that was already made — no new decision is introduced here, so no new ADR or decision-log entry was written.

## Out of scope

Per the issue body, this PR does not touch anything beyond the "namespace" staleness — the `SSM_REGION`/`AWS_REGION` naming drift the issue flagged as a possible separate follow-up was left alone, and no other wiki wording was revised.

## Verification

No Elixir code changed. `mix precommit` passes — nothing new to compile or test, 338 tests green. This is a documentation-only change; review is by reading the corrected wiki pages (`Home.md`, `Platform-Operations.md`, `Secrets.md` at commit `0efab7d` in `nucleus.wiki`) and the two local context files against `docs/adr/0007-secrets-store-adapter.md`.

Closes #22