### PR TITLE
SEC-S1: environment resolution and fail-closed validation ladder

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.2 | Updated: 2026-08-14 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.3 | Updated: 2026-08-14 -->
 
 # Business ↔ Tech Bridge
 
@@ -53,9 +53,12 @@ to cite from test names and bug reports.
 **Most "Planned" columns are still unimplemented.** `NucleusWeb.Layouts` (app shell, header,
 sidebar) and `test/nucleus_web/live/shell_test.exs` now exist (EN-7) — a deliberate subset only,
 with no `@tag action:` claimed, so `NAV-A01`–`A12` coverage is still zero until the dedicated
-`NAV-*` ticket lands. Every other row is unimplemented. These names are the agreed target so
-that work lands consistently — treat them as the convention to follow, and correct this table
-if a better structure emerges.
+`NAV-*` ticket lands. `NucleusWeb.SecretsLive` and `test/nucleus_web/live/secrets_live_test.exs`
+also now exist (SEC-S1, issue #9) — but only `SEC-A15`–`A17` are claimed and covered; the module
+validates and resolves the environment and renders three fail-closed states, with no secrets UI
+of its own yet (`SEC-A01` onward is `SEC-S2` and later). Every other row is unimplemented. These
+names are the agreed target so that work lands consistently — treat them as the convention to
+follow, and correct this table if a better structure emerges.
 
 ## Tagging Convention
 

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.7 | Updated: 2026-08-14 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.8 | Updated: 2026-08-14 -->
 
 # Decisions Log
 
@@ -24,6 +24,7 @@
 | 6 | Application shell & live session composition — daisyUI retained, stacked `on_mount` hooks, placeholder `SecretsLive` ships now | 2026-08-11 | Decided | `docs/adr/0006-application-shell-and-live-session-composition.md` |
 | 7 | Secrets store adapter — cluster/deployment Parameter Store path, `aws` package over `ex_aws`, `:persistent_term` credential cache, no dedicated local `Agent` | 2026-08-12 | Decided | `docs/adr/0007-secrets-store-adapter.md` |
 | 8 | Test strategy — `Phoenix.LiveViewTest` + `PhoenixTest`, no browser driver; `Nucleus.BackendCase`/`AuditCase`/`LiveCase`; `mix nucleus.trace` report-only | 2026-08-14 | Decided | `docs/adr/0008-test-strategy.md` |
+| 9 | Environment validation ladder — allowlist over denylist, strict validate-then-fetch ordering, no cache/no fallback ever, validation errors tagged `boundary: :tenant_api` | 2026-08-14 | Decided | `docs/adr/0009-environment-validation-ladder.md` |
 
 This file deliberately contains **no "re-platform" decision** (fresh start, not a migration —
 nothing to supersede) and **no inherited ADRs** (the wiki's `ADR-0001`–`ADR-0007` under
@@ -175,6 +176,25 @@ filed during this ticket) · Issues #9–#15 (every SEC ticket, the harness's fi
 
 ---
 
+## Decision: Environment Validation Ladder
+
+**Date**: 2026-08-14 | **Status**: Decided | **ADR**: `docs/adr/0009-environment-validation-ladder.md`
+
+`Nucleus.Environments.validate_name/1` rejects any environment name failing a positive charset
+allowlist (`~r/\A[a-z0-9][a-z0-9-]*\z/`, ≤64 chars) — not a `..`/`/`/`\` denylist, which percent-
+encoding and unicode lookalikes defeat. `fetch/2` runs it first, calls `TenantApi.list_environments/1`
+only if it passes, collapses `:unavailable`/`:not_configured` to `:unavailable`, passes
+`:auth_expired` through untouched, and matches archived environments too — with no cache and no
+fallback list, ever. `NucleusWeb.SecretsLive` replaced its EN-7 placeholder wholesale, validating
+in `handle_params/3` (not `mount/3`) so a patch between environments re-validates.
+
+**Related**: Issue #9 (SEC-S1, the deciding issue) · `docs/adr/0006-application-shell-and-live-session-composition.md`
+(the placeholder this ticket replaced) · `docs/adr/0007-secrets-store-adapter.md` (the boundary
+that explicitly deferred this validation here) · Issues #10–#15 (SEC-S2–S7, every one mounts
+through this gate)
+
+---
+
 ## Deprecated Decisions
 
 Decisions that were later overturned (for historical context):
@@ -185,7 +205,7 @@ Decisions that were later overturned (for historical context):
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0008` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0009` are binding
 - [ ] Know that the wiki's ADR-0001–0007 are reference only, not adopted
 - [ ] Know that new formal ADRs belong in `docs/adr/`, with only a short summary mirrored here
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.6 | Updated: 2026-08-14 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.7 | Updated: 2026-08-14 -->
 
 # Living Notes
 
@@ -16,7 +16,6 @@
 |------|--------|----------|------------|
 | `docs/adr/` had no ADRs while 7 prototype ADRs sit in the wiki | ADR-shaped questions get answered in chat and lost | Medium | Write this project's own ADRs as decisions land — `0001` now exists |
 | LiveDashboard at `/dev/dashboard` unauthenticated | Fine in dev; a leak if ever exposed in prod | Medium | Gate behind auth before any production deploy |
-| `NucleusWeb.SecretsLive` is a placeholder ("not implemented" empty state) so `~p` verified routes compile | Looks like a real view; must not be patched incrementally | Medium | SEC-S1 (#9) replaces the module wholesale — see `docs/adr/0006-application-shell-and-live-session-composition.md` |
 | Nucleus's own AWS identity (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) is read ambiently by the `aws` package, with no boot-time check or ops-facing doc — unlike `TENANT_ROLE_ARN`/`AWS_REGION`/`CLUSTER_NAME`/`DEPLOYMENT_NAME`, which all raise at boot | A misconfigured deployment fails per-request as `:not_configured` on first `AssumeRole` call, not at boot | Low | `CLUSTER_NAME`/`DEPLOYMENT_NAME` are now correctly documented in the wiki's `Platform-Operations.md` config reference (issue #22). The ambient `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` doc gap remains open — was out of scope for #22 |
 | No browser-driven test coverage for `SEC-A02` (clipboard write confirmation) or `SEC-A13` (Escape dismissal, focus trap, focus restoration) — `navigator.clipboard` and real key/focus events need a browser, which this repo has no driver for | Tests assert wiring only (hook attached, `on_cancel` set), never claim `@tag action:` for these IDs — a real regression would not be caught until a browser harness exists | Medium | Add Wallaby once sign-in exists (deferred, EN-8); see `docs/adr/0008-test-strategy.md` |
 
@@ -126,6 +125,13 @@ deploys it.
 ## Archive (Resolved Items)
 
 Moved here for historical reference.
+
+**`NucleusWeb.SecretsLive` was a placeholder** — *was: Technical Debt, Medium*
+*Resolved*: 2026-08-14 by SEC-S1 (issue #9).
+*Outcome*: Replaced wholesale, as ADR-0006 always intended. Validates the environment in
+`handle_params/3` via `Nucleus.Environments.fetch/2` and renders one of three fail-closed
+states (`SEC-A15`–`A17`); renders no secrets UI of its own yet — that is `SEC-S2` onward.
+*See*: `docs/adr/0009-environment-validation-ladder.md`
 
 **Build `mix nucleus.trace`** — *was: Active Project*
 *Resolved*: 2026-08-14 by EN-8 (issue #8).

--- a/docs/adr/0009-environment-validation-ladder.md
+++ b/docs/adr/0009-environment-validation-ladder.md
@@ -1,0 +1,173 @@
+# ADR-0009: Environment Resolution and Fail-Closed Validation Ladder
+
+## Status
+
+Accepted — 2026-08-14
+
+Decided on [SEC-S1](https://github.com/dave-bell/nucleus/issues/9). Builds on
+`0002-backend-adapter-boundaries.md` (behaviour/real-local shape, neutral
+error kinds) and `0006-application-shell-and-live-session-composition.md`
+(the placeholder `SecretsLive` this ticket replaces). Confirms the boundary
+line `0007-secrets-store-adapter.md` drew: `Nucleus.Secrets.Store` does not
+validate `{environment}` against `Nucleus.TenantApi`, so this ladder is the
+only place that validation happens.
+
+## Context
+
+Every Secrets action's precondition is "a valid environment for this
+tenant" (`SEC-A01` onward), and a caller-supplied environment name reaches
+`Nucleus.Secrets.Path.build/2` — which does no sanitisation of its own — the
+moment any of those actions run. `SEC-A15`–`A17` are the gate: reject a
+path-traversal name before any lookup, reject a well-formed but unknown
+name clearly, and fail closed rather than open when the tenant's own API
+(the authority on environments) cannot currently be reached. Issue #9's own
+plan resolved most of the design up front — the allowlist regex, the exact
+ordering, the "no cache, ever" rule — leaving one decision genuinely open at
+implementation time: what `boundary` atom a purely local validation failure
+should be tagged with, given `Nucleus.Backend`'s registry has no
+`:environments` entry.
+
+## Decision
+
+### Allowlist, not denylist, for the environment short name
+
+`Nucleus.Environments.validate_name/1` rejects anything that is not a
+binary, is empty, contains `..`, `/`, `\`, or a null byte, exceeds 64
+characters, or fails `~r/\A[a-z0-9][a-z0-9-]*\z/`. The regex is the actual
+gate; the explicit checks preceding it exist for clearer error context, not
+because the regex would let any of them through. A three-sequence denylist
+(`..`, `/`, `\`) — all the wiki's error matrix names — passes through
+percent-encoded traversal (`%252e`, which decodes once to `%2e` by the time
+Phoenix hands it to `handle_params/3`, not twice to `..`), unicode
+lookalikes (a fullwidth solidus), and control characters. An allowlist
+cannot, by construction, and `PRX-A04` already establishes this project's
+stance that percent-encoded traversal must be blocked for the same class of
+input.
+
+### `fetch/2`'s ordering is the whole of `SEC-A15`'s contract
+
+`validate_name/1` runs as `fetch/2`'s first statement, with `with :ok <-
+validate_name(name) do ... end` making an early return the only path an
+invalid name can take — no adapter call, no path construction reachable
+from that branch. `TenantApi.list_environments/1`'s `:unavailable` and
+`:not_configured` both collapse to `:unavailable` (`SEC-A17` — a
+misconfigured deployment must fail closed, not open, exactly like an
+unreachable one); `:auth_expired` passes through untouched, left for
+`SEC-S7`. Resolution matches by `short_name` against every environment
+returned, archived included (`ENV-A06`) — filtering archived environments
+out of navigation is `NucleusWeb.EnvironmentsHook`'s job, a different
+question asked by a different caller.
+
+### No cache, no fallback list — structurally, not just by omission
+
+`fetch/2` calls `TenantApi.list_environments/1` fresh on every call and
+never stores the result anywhere between calls. `SEC-A17`'s precondition —
+"unreachable, and no cached list is available" — is otherwise the only
+branch that would ever execute, given the stateless constraint
+(`0001-no-local-datastore.md`) means no cache could exist here without
+deliberately building one. Not building one keeps the fail-closed guarantee
+single-path and untested-second-path-free, per the ticket's own explicit
+instruction.
+
+### Validation errors are tagged `boundary: :tenant_api`
+
+The one decision the ticket left open. `Nucleus.Backend.Error.new/4` takes
+an arbitrary atom for `boundary`, and no `:environments` boundary is
+registered in `Nucleus.Backend`'s `@impls` map — introducing one purely for
+error attribution would create an atom that exists nowhere else in the
+selection/registry system this project already has for boundaries.
+`validate_name/1` is pure and performs no I/O of its own, but it exists
+entirely to gate the `:tenant_api` boundary before a call reaches it — the
+same relationship `Nucleus.Backend.Faults.maybe_fault/1` already has when a
+local implementation tags an injected fault with the boundary it was called
+for. Tagging validation failures `:tenant_api` keeps every error this
+module returns attributable to the one boundary a reader would actually
+look at.
+
+### Validated in `handle_params/3`, not `mount/3`
+
+`NucleusWeb.SecretsLive` re-validates on every params change, not only on
+initial mount. A `<.link patch={...}>` between two environments does not
+remount the LiveView, so a check placed in `mount/3` would let a user patch
+from a validated environment straight into an unvalidated one — silently
+defeating `SEC-A15`–`A17` for every navigation after the first.
+
+### Three states reuse `<.empty_state>`; no bespoke error component
+
+No three-distinct-state error pattern existed anywhere in this codebase
+before this ticket. `<.empty_state id icon message>`'s own moduledoc already
+frames it as message-agnostic — "callers decide what message to pass, this
+component does not distinguish empty from failed" — so three calls with
+distinct `id`s, icons, and copy satisfy the requirement's "three **distinct**
+states with distinct DOM IDs and distinct copy" without introducing a second
+component that would duplicate the same markup for no behavioural gain.
+
+## Consequences
+
+### Positive
+
+- `Nucleus.Environments` is the single place a raw environment name is ever
+  validated; `Nucleus.Secrets.Path.build/2`'s existing "assumes pre-validated
+  input" doc note is now backed by exactly one caller that keeps that
+  promise.
+- The zero-adapter-call guarantee is checked structurally, not inferred: the
+  test swaps in a `Nucleus.TenantApi` implementation that raises if called
+  at all, so a future refactor that accidentally reordered `fetch/2` would
+  fail loudly rather than passing for the wrong reason.
+- `SEC-S2`–`SEC-S7` all mount through `handle_params/3`'s resolved
+  `:environment_status`/`:resolved_environment` assigns without re-deriving
+  any of this ladder themselves.
+
+### Negative
+
+- No telemetry event or call counter was added to the local `TenantApi`
+  implementation, which the ticket's plan named as something to "consider."
+  The raising-fake test achieves the same proof for this ticket without it;
+  if a later ticket needs to assert call counts against the *real* HTTP
+  implementation too, that instrumentation still does not exist.
+- Replacing `NucleusWeb.SecretsLive` wholesale broke two pre-existing tests
+  (`shell_test.exs`, `secrets_flow_test.exs`) that asserted against the
+  placeholder's `#secrets-not-implemented` id. Both were updated in this
+  ticket's own commit rather than left for a follow-up, since ADR-0006 and
+  the placeholder's own moduledoc already told every reader this breakage
+  was coming.
+
+## Alternatives considered
+
+**A three-character denylist (`..`, `/`, `\`), matching the wiki's error
+matrix literally.** Rejected — see "Allowlist, not denylist" above; it is a
+strictly weaker check than the allowlist for the same three characters plus
+everything else in scope for `SEC-A15`.
+
+**A new `:environments` boundary atom for validation errors.** Rejected.
+`Nucleus.Backend`'s boundary registry (`:secrets`, `:tenant_api`) is meant to
+be exhaustive and swappable-implementation-backed; a boundary atom that maps
+to no registered implementation would be a name that exists only for error
+tagging, not a boundary in the sense the rest of the codebase uses the word.
+
+**Caching `list_environments/1`'s result for the lifetime of a socket, to
+avoid a network round trip on every patch.** Rejected outright by the
+ticket and reaffirmed here: `SEC-A17`'s fail-closed guarantee depends on
+"unreachable and no cache" being the only state that exists, and a cache
+would additionally mean a `fetch/2` that starts returning stale answers
+after an environment is added or archived upstream, with no invalidation
+signal to know when.
+
+## References
+
+- SEC-S1 (issue #9) — the deciding issue, including the accepted
+  implementation plan this ADR mostly confirms rather than overturns
+- `docs/adr/0002-backend-adapter-boundaries.md` — the `Nucleus.Backend.Error`
+  kind vocabulary (`:invalid`, `:not_found`, `:unavailable`,
+  `:not_configured`, `:auth_expired`) this module maps onto
+- `docs/adr/0006-application-shell-and-live-session-composition.md` — the
+  placeholder `SecretsLive` this ticket replaces wholesale, and the
+  sidebar-degrades-vs-Secrets-fails-closed asymmetry this ADR's ordering
+  decision preserves rather than reconciles
+- `docs/adr/0007-secrets-store-adapter.md` — "`SEC-S1` cannot lean on this
+  boundary for that validation and must do it independently," which this
+  ADR is the independent answer to
+- Wiki [Secrets](https://github.com/dave-bell/nucleus/wiki/Secrets)
+  `SEC-A15`–`A17`; [Environments](https://github.com/dave-bell/nucleus/wiki/Environments)
+  `ENV-A06`; wiki [ADR-0002](https://github.com/dave-bell/nucleus/wiki/ADR-0002-Security-Hardening)
+  §4, the source of the fail-closed rule

--- a/lib/nucleus/environments.ex
+++ b/lib/nucleus/environments.ex
@@ -1,0 +1,168 @@
+defmodule Nucleus.Environments do
+  @moduledoc """
+  The fail-closed validation ladder every Secrets action mounts through
+  (`SEC-A15`, `SEC-A16`, `SEC-A17`).
+
+  Nucleus is not authoritative for environments — `Nucleus.TenantApi` is —
+  but a raw, caller-supplied environment name reaches this module before it
+  reaches anything that builds a Parameter Store path
+  (`Nucleus.Secrets.Path.build/2` assumes it never sees an unvalidated one).
+  This module is the only gate.
+
+  Two functions, deliberately separated:
+
+  - `validate_name/1` is pure. No I/O, cannot be skipped by a network fault,
+    and is cheap enough to run before anything else — `SEC-A15` requires a
+    path-traversal name be rejected "before any lookup is attempted".
+  - `fetch/2` is the whole ladder: validate, then call out to
+    `Nucleus.TenantApi.list_environments/1`, then resolve. `validate_name/1`
+    is called as `fetch/2`'s first statement so an invalid name causes zero
+    adapter calls — this is asserted directly in
+    `test/nucleus/environments_test.exs`, not merely inferred from behaviour.
+
+  ## Allowlist, not denylist
+
+  The wiki's error matrix only names `..`, `/`, `\\` as deny cases, but a
+  three-sequence denylist lets percent-encoded traversal, unicode
+  lookalikes, and control characters through — the same class of problem
+  `PRX-A04` calls out for the proxy allowlist. `validate_name/1` rejects
+  anything that fails a positive charset check
+  (`~r/\\A[a-z0-9][a-z0-9-]*\\z/`) rather than trying to enumerate what to
+  reject.
+
+  Phoenix has already percent-decoded a path segment by the time it reaches
+  `handle_params/3`, so `%2e%2e` arrives as `..` and would be caught by a
+  denylist too — but `%252e` (double-encoded) arrives as `%2e`, which the
+  denylist would miss and this allowlist rejects outright, since `%` is not
+  in the allowed charset.
+
+  ## No cache, no fallback — ever
+
+  `SEC-A17`'s precondition is "the backing API is unreachable, **and no
+  cached list is available**". With the stateless constraint (EN-1), that is
+  the only state that ever exists — `fetch/2` never caches
+  `list_environments/1`'s result and never falls back to a stale list on
+  failure. Adding either would create an untested second path and weaken the
+  fail-closed guarantee this module exists to provide.
+
+  ## Archived environments resolve too
+
+  `ENV-A06` requires an archived environment stay reachable by direct URL and
+  usable for secrets management. `fetch/2` matches against every environment
+  `list_environments/1` returns, archived included — filtering archived ones
+  out of navigation is `NucleusWeb.EnvironmentsHook`'s job, not this one's.
+  """
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.TenantApi
+  alias Nucleus.TenantApi.Environment
+
+  @boundary :tenant_api
+  @max_length 64
+  @allowed_name ~r/\A[a-z0-9][a-z0-9-]*\z/
+
+  @doc """
+  Validates `name` as a well-formed environment short name.
+
+  Pure — performs no I/O and calls no adapter. Returns `:ok` or
+  `{:error, %Nucleus.Backend.Error{kind: :invalid}}`.
+
+  Rejects: anything that is not a binary, an empty string, a name containing
+  `..` anywhere, a name containing `/` or `\\`, a name containing a null
+  byte, a name longer than #{@max_length} characters, and anything that
+  fails the positive charset allowlist (lowercase letters, digits, and
+  internal hyphens; must start with a letter or digit).
+
+      iex> Nucleus.Environments.validate_name("prod")
+      :ok
+
+      iex> {:error, error} = Nucleus.Environments.validate_name("..")
+      iex> error.kind
+      :invalid
+
+      iex> {:error, error} = Nucleus.Environments.validate_name(nil)
+      iex> error.kind
+      :invalid
+  """
+  @spec validate_name(term()) :: :ok | {:error, Error.t()}
+  def validate_name(name) when is_binary(name) do
+    cond do
+      name == "" ->
+        invalid(name)
+
+      String.contains?(name, "..") ->
+        invalid(name)
+
+      String.contains?(name, "/") or String.contains?(name, "\\") ->
+        invalid(name)
+
+      String.contains?(name, <<0>>) ->
+        invalid(name)
+
+      String.length(name) > @max_length ->
+        invalid(name)
+
+      not Regex.match?(@allowed_name, name) ->
+        invalid(name)
+
+      true ->
+        :ok
+    end
+  end
+
+  def validate_name(name), do: invalid(name)
+
+  @doc """
+  Validates, fetches, and resolves `name` to the tenant's environment.
+
+  Strict order, which is the substance of `SEC-A15`:
+
+  1. `validate_name/1` — on error, returns immediately. No adapter call, no
+     path construction.
+  2. `Nucleus.TenantApi.list_environments/1` — an `:unavailable` or
+     `:not_configured` error is returned as `:unavailable` (`SEC-A17`);
+     an `:auth_expired` error passes through unchanged, untouched by this
+     module (`SEC-S7`'s concern).
+  3. Resolves by exact `short_name` match, archived environments included
+     (`ENV-A06`). No match is `{:error, kind: :not_found}` (`SEC-A16`).
+
+  Never caches the list and never falls back to a stale one — see the
+  module doc.
+  """
+  @spec fetch(term(), String.t() | nil) :: {:ok, Environment.t()} | {:error, Error.t()}
+  def fetch(name, token) do
+    with :ok <- validate_name(name) do
+      resolve(TenantApi.list_environments(token), name)
+    end
+  end
+
+  defp resolve({:ok, environments}, name) do
+    case Enum.find(environments, &(&1.short_name == name)) do
+      nil ->
+        {:error,
+         Error.new(:not_found, @boundary, "no such environment: #{inspect(name)}", %{
+           environment: name
+         })}
+
+      environment ->
+        {:ok, environment}
+    end
+  end
+
+  defp resolve({:error, %Error{kind: kind} = error}, _name)
+       when kind in [:unavailable, :not_configured] do
+    {:error,
+     Error.new(:unavailable, @boundary, "environment validation is unavailable", %{
+       reason: error.message
+     })}
+  end
+
+  defp resolve({:error, %Error{} = error}, _name), do: {:error, error}
+
+  defp invalid(name) do
+    {:error,
+     Error.new(:invalid, @boundary, "invalid environment name", %{
+       environment: inspect(name)
+     })}
+  end
+end

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -1,27 +1,75 @@
 defmodule NucleusWeb.SecretsLive do
   @moduledoc """
-  Placeholder so `/environments/:environment/secrets` compiles and
-  `Layouts.app`'s sidebar (`NAV-A04`) has a real, navigable destination —
-  EN-7's plan explicitly allows this ("this ticket may add a minimal
-  placeholder module so the route compiles, clearly marked").
+  The Secrets view for one environment — the gate every other Secrets action
+  (`SEC-A01` onward) mounts through.
 
-  **This is not the Secrets feature.** `SEC-S1` (environment resolution and
-  the fail-closed validation ladder) and `SEC-S2` (the actual secrets list)
-  replace this module's body entirely — nothing here should be extended.
-  Renders an explicit "not implemented" state via `<.empty_state>`, never a
-  blank page.
+  Replaces the `SEC-S1`-marked placeholder wholesale (see ADR-0006 §"the
+  disposable placeholder"), not incrementally.
+
+  ## Validated in `handle_params/3`, not `mount/3`
+
+  The environment name comes from the URL, and a `<.link patch={...}>` can
+  change it without a remount — `handle_params/3` runs on every patch,
+  `mount/3` does not. Putting the check in `mount/3` would let a user patch
+  from a valid environment straight into an unvalidated one.
+
+  ## Three distinct, mutually exclusive states
+
+  `Nucleus.Environments.fetch/2` returns one of four outcomes, and each gets
+  its own assign and its own DOM id — collapsing "not found" and
+  "unavailable" into one rendering would misinform the user about a real
+  outage (`SEC-A17`):
+
+  | Outcome | `:environment_status` | DOM id |
+  |---|---|---|
+  | `{:ok, environment}` | `:ok` | (list rendering is `SEC-S2`) |
+  | `kind: :invalid` | `:invalid` | `#secrets-invalid-environment` |
+  | `kind: :not_found` | `:not_found` | `#secrets-environment-not-found` |
+  | `kind: :unavailable` | `:unavailable` | `#secrets-validation-unavailable` |
+
+  Every branch keeps the shell intact (`<Layouts.app>`, `#tenant-identifier`)
+  so the user can navigate away — a crashed LiveView is not an acceptable
+  rendering of any of these. No secrets UI (table, create button, reveal
+  control) renders in any error state, and the raw environment name is never
+  echoed unescaped — HEEx's default escaping is not defeated with `raw/1`.
 
   `current_scope` and `environments` come from the `:authenticated`
   `live_session`'s `on_mount` hooks (`NucleusWeb.ScopeHook`,
-  `NucleusWeb.EnvironmentsHook`) in `lib/nucleus_web/router.ex` — this
-  module does not assign either itself.
+  `NucleusWeb.EnvironmentsHook`) — this module does not assign either
+  itself.
   """
 
   use NucleusWeb, :live_view
 
+  alias Nucleus.Backend.Error
+  alias Nucleus.Environments
+  alias Nucleus.Scope
+
   @impl Phoenix.LiveView
-  def mount(%{"environment" => environment}, _session, socket) do
-    {:ok, assign(socket, :environment, environment)}
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(%{"environment" => environment}, _uri, socket) do
+    socket = assign(socket, :environment, environment)
+
+    socket =
+      case Environments.fetch(environment, scope_token(socket)) do
+        {:ok, resolved} ->
+          assign(socket, environment_status: :ok, resolved_environment: resolved)
+
+        {:error, %Error{kind: :invalid}} ->
+          assign(socket, environment_status: :invalid, resolved_environment: nil)
+
+        {:error, %Error{kind: :not_found}} ->
+          assign(socket, environment_status: :not_found, resolved_environment: nil)
+
+        {:error, %Error{kind: :unavailable}} ->
+          assign(socket, environment_status: :unavailable, resolved_environment: nil)
+      end
+
+    {:noreply, socket}
   end
 
   @impl Phoenix.LiveView
@@ -29,11 +77,31 @@ defmodule NucleusWeb.SecretsLive do
     ~H"""
     <Layouts.app flash={@flash} current_scope={@current_scope} environments={@environments}>
       <.empty_state
-        id="secrets-not-implemented"
-        icon="hero-wrench-screwdriver"
-        message={"Secrets for \"#{@environment}\" is not implemented yet — see SEC-S1/SEC-S2."}
+        :if={@environment_status == :invalid}
+        id="secrets-invalid-environment"
+        icon="hero-shield-exclamation"
+        message="This is not a valid environment name."
+      />
+      <.empty_state
+        :if={@environment_status == :not_found}
+        id="secrets-environment-not-found"
+        icon="hero-question-mark-circle"
+        message={"No environment named \"#{@environment}\" was found for this tenant."}
+      />
+      <.empty_state
+        :if={@environment_status == :unavailable}
+        id="secrets-validation-unavailable"
+        icon="hero-exclamation-triangle"
+        message="Can't verify this environment right now. Try again shortly."
       />
     </Layouts.app>
     """
+  end
+
+  defp scope_token(socket) do
+    case socket.assigns[:current_scope] do
+      %Scope{token: token} -> token
+      _ -> nil
+    end
   end
 end

--- a/test/nucleus/environments_test.exs
+++ b/test/nucleus/environments_test.exs
@@ -1,0 +1,151 @@
+defmodule Nucleus.EnvironmentsTest do
+  # `force_error/2` and the backend swap in the "zero adapter calls" test both
+  # mutate node-global state (`LOCAL_FORCE_ERROR`, `:nucleus, :backends`).
+  use Nucleus.BackendCase, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Environments
+
+  defmodule ExplodingTenantApi do
+    @moduledoc """
+    A `Nucleus.TenantApi` implementation that raises if it is ever called.
+
+    Swapped in for the one test that asserts `SEC-A15`'s "zero adapter calls"
+    guarantee: if `Environments.fetch/2` called `list_environments/1` after an
+    invalid name, this module raising is how the test would know.
+    """
+    @behaviour Nucleus.TenantApi
+
+    @impl Nucleus.TenantApi
+    def list_environments(_token) do
+      raise "list_environments/1 was called — SEC-A15 requires zero adapter calls for an invalid name"
+    end
+
+    @impl Nucleus.TenantApi
+    def health_check, do: :ok
+  end
+
+  defp use_exploding_tenant_api do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :tenant_api, ExplodingTenantApi)
+    )
+  end
+
+  describe "validate_name/1 — SEC-A15" do
+    @tag action: "SEC-A15"
+    @tag :unit
+    test "rejects path-traversal and malformed names" do
+      invalid = [
+        "..",
+        "../other",
+        "prod/..",
+        "prod/sub",
+        "prod\\sub",
+        "pro\0d",
+        "",
+        nil,
+        :prod,
+        String.duplicate("a", 65),
+        "%2e%2e",
+        "PROD",
+        "-prod",
+        "prod ",
+        "prod\uFF0Fsub"
+      ]
+
+      for name <- invalid do
+        assert {:error, %Error{kind: :invalid}} = Environments.validate_name(name),
+               "expected #{inspect(name)} to be rejected"
+      end
+    end
+
+    @tag action: "SEC-A15"
+    @tag :unit
+    test "accepts well-formed short names" do
+      valid = ["prod", "staging", "dev", "legacy-qa", "sandbox"]
+
+      for name <- valid do
+        assert Environments.validate_name(name) == :ok,
+               "expected #{inspect(name)} to be accepted"
+      end
+    end
+
+    @tag action: "SEC-A15"
+    @tag :unit
+    test "the double-encoded traversal case specifically" do
+      # Phoenix has already percent-decoded once by the time a path segment
+      # reaches `handle_params/3`, so `%2e%2e` arrives as literal text and is
+      # caught by the charset allowlist (no denylist needed). `%252e` is the
+      # case a denylist of `..`/`/`/`\` would miss: it decodes only once, to
+      # `%2e`, which still fails the allowlist because `%` is not permitted.
+      assert {:error, %Error{kind: :invalid}} = Environments.validate_name("%252e%252e")
+    end
+  end
+
+  describe "fetch/2 — SEC-A15 zero adapter calls" do
+    @tag action: "SEC-A15"
+    @tag :unit
+    test "an invalid name never reaches TenantApi.list_environments/1" do
+      use_exploding_tenant_api()
+
+      assert {:error, %Error{kind: :invalid}} = Environments.fetch("..", nil)
+    end
+  end
+
+  describe "fetch/2 — SEC-A16 reject a well-formed but unknown environment" do
+    @tag action: "SEC-A16"
+    @tag :unit
+    test "a well-formed unknown name resolves to :not_found" do
+      assert {:error, %Error{kind: :not_found}} = Environments.fetch("nope", nil)
+    end
+  end
+
+  describe "fetch/2 — SEC-A17 fail closed when validation is unavailable" do
+    @tag action: "SEC-A17"
+    @tag :unit
+    test "an unavailable tenant API resolves to :unavailable" do
+      force_error(:tenant_api, :unavailable)
+
+      assert {:error, %Error{kind: :unavailable}} = Environments.fetch("prod", nil)
+    end
+
+    @tag action: "SEC-A17"
+    @tag :unit
+    test "a not_configured tenant API also fails closed as :unavailable" do
+      force_error(:tenant_api, :not_configured)
+
+      assert {:error, %Error{kind: :unavailable}} = Environments.fetch("prod", nil)
+    end
+  end
+
+  describe "fetch/2 — auth_expired passes through untouched" do
+    @tag :unit
+    test "does not get rewritten to :unavailable" do
+      force_error(:tenant_api, :auth_expired)
+
+      assert {:error, %Error{kind: :auth_expired}} = Environments.fetch("prod", nil)
+    end
+  end
+
+  describe "fetch/2 — ENV-A06 archived environments resolve" do
+    @tag :unit
+    test "an archived environment is found, not treated as not_found" do
+      assert {:ok, environment} = Environments.fetch("legacy-qa", nil)
+      assert environment.short_name == "legacy-qa"
+      assert environment.archived? == true
+    end
+  end
+
+  describe "fetch/2 — happy path" do
+    @tag :unit
+    test "resolves a known, active environment" do
+      assert {:ok, environment} = Environments.fetch("prod", nil)
+      assert environment.short_name == "prod"
+    end
+  end
+end

--- a/test/nucleus_web/live/secrets_flow_test.exs
+++ b/test/nucleus_web/live/secrets_flow_test.exs
@@ -2,8 +2,9 @@ defmodule NucleusWeb.SecretsFlowTest do
   @moduledoc """
   Demonstrates `PhoenixTest` (EN-8's acceptance criteria: "added and
   demonstrated by at least one flow test") against the one real flow that
-  exists today — `NucleusWeb.SecretsLive` is still a placeholder
-  (`SEC-S1`/`SEC-S2` replace it), but the shell's environment-picker
+  exists today — `NucleusWeb.SecretsLive` now resolves the environment
+  through `Nucleus.Environments` (`SEC-S1`), but renders no secrets UI of
+  its own yet (`SEC-S2` builds the list). The shell's environment-picker
   navigation is real (EN-7) and worth exercising end to end: load one
   environment's secrets page, then follow a sidebar link to another.
 
@@ -33,11 +34,11 @@ defmodule NucleusWeb.SecretsFlowTest do
   } do
     conn
     |> visit(~p"/environments/prod/secrets")
-    |> assert_has("#secrets-not-implemented", text: "prod")
+    |> assert_has("#tenant-identifier")
     |> assert_has("#environments-list", text: "Staging", timeout: 100)
     |> click_link("Staging")
     |> assert_path(~p"/environments/staging/secrets")
-    |> assert_has("#secrets-not-implemented", text: "staging")
+    |> assert_has("#tenant-identifier")
   end
 
   @tag :unit
@@ -45,7 +46,7 @@ defmodule NucleusWeb.SecretsFlowTest do
        %{conn: conn} do
     conn
     |> visit(~p"/environments/legacy-qa/secrets")
-    |> assert_has("#secrets-not-implemented", text: "legacy-qa")
+    |> assert_has("#tenant-identifier")
     # Wait for the async environments list to actually resolve (proven by a
     # real, non-archived entry appearing) before asserting an absence —
     # otherwise this would vacuously pass while #environments-list hasn't

--- a/test/nucleus_web/live/secrets_live_test.exs
+++ b/test/nucleus_web/live/secrets_live_test.exs
@@ -1,0 +1,89 @@
+defmodule NucleusWeb.SecretsLiveTest do
+  # `force_error/2` (`Nucleus.BackendCase`) mutates node-global state.
+  use NucleusWeb.LiveCase, async: false
+
+  describe "SEC-A16 — reject a well-formed but unknown environment" do
+    @tag action: "SEC-A16"
+    test "renders environment-not-found", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "nope")
+
+      assert has_element?(view, "#secrets-environment-not-found")
+      refute has_element?(view, "#secrets-table")
+    end
+  end
+
+  describe "SEC-A15 — reject an invalid environment name" do
+    @tag action: "SEC-A15"
+    test "renders invalid-environment for path-traversal characters", %{conn: conn} do
+      assert {:ok, view, _html} = live(conn, "/environments/..%2f..%2fetc/secrets")
+
+      assert has_element?(view, "#secrets-invalid-environment")
+      refute has_element?(view, "#secrets-table")
+    end
+  end
+
+  describe "SEC-A17 — fail closed when environment validation is unavailable" do
+    @tag action: "SEC-A17"
+    test "renders validation-unavailable, distinct from not-found", %{conn: conn} do
+      force_error(:tenant_api, :unavailable)
+
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      assert has_element?(view, "#secrets-validation-unavailable")
+      refute has_element?(view, "#secrets-environment-not-found")
+      refute has_element?(view, "#secrets-table")
+    end
+  end
+
+  describe "all three states keep the shell intact" do
+    test "invalid name still renders the shell and no secrets controls", %{conn: conn} do
+      assert {:ok, view, _html} = live(conn, "/environments/..%2f..%2fetc/secrets")
+
+      assert has_element?(view, "#tenant-identifier")
+      refute has_element?(view, "#secrets-table")
+      refute has_element?(view, "#secrets-create-button")
+    end
+
+    test "not-found still renders the shell and no secrets controls", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "nope")
+
+      assert has_element?(view, "#tenant-identifier")
+      refute has_element?(view, "#secrets-table")
+      refute has_element?(view, "#secrets-create-button")
+    end
+
+    test "unavailable still renders the shell and no secrets controls", %{conn: conn} do
+      force_error(:tenant_api, :unavailable)
+
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      assert has_element?(view, "#tenant-identifier")
+      refute has_element?(view, "#secrets-table")
+      refute has_element?(view, "#secrets-create-button")
+    end
+  end
+
+  describe "patching between environments re-validates" do
+    test "patching from a valid environment to an invalid one re-renders as invalid", %{
+      conn: conn
+    } do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      refute has_element?(view, "#secrets-invalid-environment")
+
+      html = render_patch(view, "/environments/..%2f..%2fetc/secrets")
+
+      assert html =~ ~s(id="secrets-invalid-environment")
+      assert has_element?(view, "#secrets-invalid-environment")
+    end
+
+    test "patching from a valid environment to an unknown one re-renders as not-found", %{
+      conn: conn
+    } do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      render_patch(view, "/environments/nope/secrets")
+
+      assert has_element?(view, "#secrets-environment-not-found")
+    end
+  end
+end

--- a/test/nucleus_web/live/shell_test.exs
+++ b/test/nucleus_web/live/shell_test.exs
@@ -89,7 +89,10 @@ defmodule NucleusWeb.ShellTest do
 
     render_async(view)
 
-    assert has_element?(view, "#secrets-not-implemented")
+    # SEC-S1's validation ladder resolves it (ENV-A06), not treated as an error.
+    refute has_element?(view, "#secrets-environment-not-found")
+    refute has_element?(view, "#secrets-invalid-environment")
+    refute has_element?(view, "#secrets-validation-unavailable")
     refute has_element?(view, "#environments-list", "Legacy QA")
   end
 


### PR DESCRIPTION
## What

Every Secrets action's precondition is "a valid environment for this tenant", and this PR builds the one gate all of them will mount through. `Nucleus.Environments` adds a pure, allowlist-based `validate_name/1` and a `fetch/2` that runs it before ever calling `Nucleus.TenantApi.list_environments/1` — rejecting a path-traversal name outright, rejecting a well-formed but unknown one clearly, and failing closed (rather than open) when the tenant API is unreachable or misconfigured. `NucleusWeb.SecretsLive` is replaced wholesale to validate in `handle_params/3` on every mount and patch, rendering one of three distinct, shell-intact error states with no secrets UI ever leaking through.

## How

- `Nucleus.Environments.validate_name/1` is pure (no I/O), rejecting non-binaries, empty strings, `..`, `/`, `\`, null bytes, names over 64 chars, and anything failing a positive charset allowlist (`~r/\A[a-z0-9][a-z0-9-]*\z/`) — chosen over a denylist because a three-sequence denylist lets percent-encoded traversal (`%252e`), unicode lookalikes, and control characters through.
- `fetch/2` uses `with :ok <- validate_name(name)` so an invalid name has no path to the adapter call; on success it calls `TenantApi.list_environments/1`, collapses `:unavailable`/`:not_configured` to `:unavailable` (SEC-A17), passes `:auth_expired` through untouched (left for SEC-S7), and resolves by `short_name` against every environment returned — archived included, guarding against a regression of ENV-A06. No caching, no fallback list, by design: the fail-closed branch must stay the only branch that can execute when the API is down.
- `NucleusWeb.SecretsLive` validates in `handle_params/3`, not `mount/3`, since a `<.link patch={...}>` between environments doesn't remount — putting the check in `mount/3` would let a patch slip past validation. Three mutually exclusive states (`#secrets-invalid-environment`, `#secrets-environment-not-found`, `#secrets-validation-unavailable`) each keep the shell intact and render no secrets controls.
- Satisfies SEC-A15, SEC-A16, and SEC-A17; also guards against a regression of ENV-A06 (archived environments must still resolve, not read as "not found").

## Record

`docs/adr/0009-environment-validation-ladder.md` settles the allowlist-over-denylist choice, the validate-then-fetch ordering, the no-cache/no-fallback rule, and — the one decision the ticket left open — that pure validation failures are tagged `boundary: :tenant_api` rather than introducing an unregistered `:environments` boundary atom. `decisions-log.md` gained decision #9 and its full entry, `business-tech-bridge.md`'s Secrets row now shows SEC-A15–A17 as implemented and covered (SEC-A01 onward still pending SEC-S2+), and `living-notes.md` moved the "`SecretsLive` is a placeholder" tech-debt item to Archive as resolved.

## Divergence from the plan

- The plan said to "consider a telemetry event or a counter on the local backend" so the zero-adapter-call test could assert call count directly. That instrumentation was not added. Instead, the test swaps in an `ExplodingTenantApi` fake (`@behaviour Nucleus.TenantApi`) whose `list_environments/1` raises unconditionally — if `fetch/2` ever called it after an invalid name, the test would fail loudly. This proves the same "zero adapter calls" guarantee structurally, without adding production instrumentation that has no other consumer yet. ADR-0009 notes the tradeoff: a future ticket that needs call counts against the *real* HTTP implementation would still need to build that.
- Replacing `NucleusWeb.SecretsLive` wholesale broke two pre-existing tests that asserted against the old placeholder's `#secrets-not-implemented` DOM id — `test/nucleus_web/live/shell_test.exs` and `test/nucleus_web/live/secrets_flow_test.exs`. Both were fixed in the same commit (updated to assert `#tenant-identifier` and the absence of the three new error-state ids) rather than deferred, since ADR-0006 already flagged this breakage as expected when the placeholder shipped.
- The `boundary:` atom used on `Nucleus.Backend.Error` for pure validation failures (`:tenant_api`) wasn't specified by the ticket — `Nucleus.Backend` has no `:environments` boundary registered — and was a judgment call made during implementation. ADR-0009 explains the reasoning: `validate_name/1` exists entirely to gate the `:tenant_api` boundary, so tagging its failures with that boundary keeps every error attributable to a boundary a reader would actually recognize, rather than inventing an atom that maps to no registered implementation.

## Verification

`mix nucleus.trace --feature SEC` shows exactly SEC-A15/16/17 covered. `mix precommit` passes: 356 tests, 25 doctests, 0 failures. New coverage includes `test/nucleus/environments_test.exs` (table-driven validation cases, including the double-encoded-traversal case and the zero-adapter-call guarantee) and `test/nucleus_web/live/secrets_live_test.exs` (all three error states, shell-intact assertions, and re-validation on patch).

Closes #9
