### PR TITLE
SEC-S2: list secrets for an environment, incl. empty state

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.3 | Updated: 2026-08-14 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.4 | Updated: 2026-08-17 -->
 
 # Business ↔ Tech Bridge
 
@@ -54,11 +54,12 @@ to cite from test names and bug reports.
 sidebar) and `test/nucleus_web/live/shell_test.exs` now exist (EN-7) — a deliberate subset only,
 with no `@tag action:` claimed, so `NAV-A01`–`A12` coverage is still zero until the dedicated
 `NAV-*` ticket lands. `NucleusWeb.SecretsLive` and `test/nucleus_web/live/secrets_live_test.exs`
-also now exist (SEC-S1, issue #9) — but only `SEC-A15`–`A17` are claimed and covered; the module
-validates and resolves the environment and renders three fail-closed states, with no secrets UI
-of its own yet (`SEC-A01` onward is `SEC-S2` and later). Every other row is unimplemented. These
-names are the agreed target so that work lands consistently — treat them as the convention to
-follow, and correct this table if a better structure emerges.
+also now exist (SEC-S1/#9, SEC-S2/#10) — `SEC-A01`, `SEC-A14`–`A17` are claimed and covered; the
+module validates and resolves the environment, lists a `Nucleus.Secrets` boundary's secrets with a
+masked value and reveal placeholder, and renders every fail-closed/empty state (`SEC-A02`–`A13`,
+`A18` are SEC-S3–S7 and later). Every other row is unimplemented. These names are the agreed
+target so that work lands consistently — treat them as the convention to follow, and correct this
+table if a better structure emerges.
 
 ## Tagging Convention
 

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.9 | Updated: 2026-08-14 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.10 | Updated: 2026-08-17 -->
 
 # Decisions Log
 
@@ -27,14 +27,13 @@
 | 7 | Secrets store adapter — cluster/deployment Parameter Store path, `aws` package over `ex_aws`, `:persistent_term` credential cache, no dedicated local `Agent` | 2026-08-12 | Decided | `docs/adr/0007-secrets-store-adapter.md` |
 | 8 | Test strategy — `Phoenix.LiveViewTest` + `PhoenixTest`, no browser driver; `Nucleus.BackendCase`/`AuditCase`/`LiveCase`; `mix nucleus.trace` report-only | 2026-08-14 | Decided | `docs/adr/0008-test-strategy.md` |
 | 9 | Environment validation ladder — allowlist over denylist, strict validate-then-fetch ordering, no cache/no fallback ever, validation errors tagged `boundary: :tenant_api` | 2026-08-14 | Decided | `docs/adr/0009-environment-validation-ladder.md` |
+| 10 | Secrets listing — one context call replaces two, ARN-hashed DOM ids, errors matched on `{kind, boundary}` | 2026-08-17 | Decided | `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md` |
 
-No **"re-platform" decision** exists (fresh start, not a migration) and no **inherited ADRs** —
-the wiki's `ADR-0001`–`ADR-0007` under `docs/requirements/` are reference material only; adopting
-one is a decision made on its own merits in `docs/adr/`, not by citation.
+No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
+`ADR-0007` are reference only; adopting one is a decision made on its own merits.
 
-**Next decision likely needed** (tracked in `living-notes.md`): how a real token gets held and
-refreshed across a long-lived LiveView socket — narrowed by EN-6 to a fixed `token` field on
-`Nucleus.Scope`, still open on *how* it is held.
+**Next decision likely needed** (`living-notes.md`): how a real token is held/refreshed across a
+live socket — narrowed by EN-6 to a fixed `Nucleus.Scope.token` field, open on *how*.
 
 ## Decision Template
 
@@ -51,8 +50,7 @@ Dropped `ecto_sql`/`postgrex`/`Nucleus.Repo` and all database and test-sandbox p
 `ecto` + `phoenix_ecto` for changeset-driven forms. Nothing in scope needed persistence, and the
 stateless constraint is now structurally enforced — adding a datastore back is a reviewable act.
 
-**Related**: Issue #1 (EN-1) · Issue #14 (SEC-S6, the changeset consumer) · Issue #5 (EN-5, where
-audit records actually go)
+**Related**: Issue #1 (EN-1) · Issue #14 (SEC-S6, changeset consumer) · Issue #5 (EN-5, audit destination)
 
 ---
 
@@ -61,12 +59,11 @@ audit records actually go)
 **Date**: 2026-08-07 | **Status**: Decided | **ADR**: `docs/adr/0002-backend-adapter-boundaries.md`
 
 Every external system sits behind a behaviour with `real`/`local` implementations selected **per
-boundary**, never raising — callbacks return `{:error, %Nucleus.Backend.Error{}}` with one of six
-neutral `kind`s, and each declares `health_check/0`. Auth is never swappable. Local implementations
-warn loudly at boot; fault injection (`LOCAL_LATENCY_MS`, `LOCAL_FORCE_ERROR`) is required.
+boundary**, never raising — errors return `{:error, %Nucleus.Backend.Error{}}` with one of six
+neutral `kind`s. Local implementations warn loudly at boot; fault injection is required.
 
-**Related**: Issue #2 (EN-2) · Issues #3 (EN-3), #4 (EN-4) — the concrete boundaries · Issue #6
-(EN-6, auth, deliberately outside the boundary set) · Issue #8 (EN-8, the contract test harness)
+**Related**: Issue #2 (EN-2) · Issues #3/#4 (concrete boundaries) · Issue #6 (auth, outside scope)
+· Issue #8 (contract harness)
 
 ---
 
@@ -79,8 +76,8 @@ One supervised `Agent`, `Nucleus.Backend.Seed` — boundary-neutral, started eve
 original `GenServer`+ETS plan: an `Agent` needs no table for a decoded map, and one shared owner
 lets `:tenant_api` and `:secrets` land in either order.
 
-**Related**: Issue #3 (EN-3, the deciding issue) · Issue #4 (EN-4, next reader of the same seed
-file) · `docs/adr/0002-backend-adapter-boundaries.md` (the real/local split this builds on)
+**Related**: Issue #3 (EN-3, deciding issue) · Issue #4 (EN-4, next reader) · `docs/adr/0002`
+(the real/local split this builds on)
 
 ---
 
@@ -93,9 +90,8 @@ the caller's process, never rescuing a sink failure — a rescued failure would 
 successful record. Every caller-passable field is allowlisted per event, so no key named `value`
 exists for a call site to leak a secret through.
 
-**Related**: Issue #5 (EN-5, the deciding issue) · Issue #8 (EN-8, `AuditCase` depends on
-`Nucleus.Audit.Sink.Test`) · Issues #12/#13/#14 (SEC-S4/S5/S6, wire the three Secrets events) ·
-`docs/adr/0001-no-local-datastore.md` (audit records go to an external log pipeline)
+**Related**: Issue #5 (EN-5, deciding issue) · Issue #8 (`AuditCase`) · Issues #12–14 (SEC-S4–S6,
+wire the 3 events) · `docs/adr/0001` (external log pipeline)
 
 ---
 
@@ -103,14 +99,12 @@ exists for a call site to leak a secret through.
 
 **Date**: 2026-08-11 | **Status**: Decided | **ADR**: `docs/adr/0005-deferred-authentication.md`
 
-`Nucleus.Scope` (`user`, `tenant`, `token`, `scopes`, `source_ip`) is the one shape every reader of
-identity takes it from. `Provider.Disabled` (default) returns a dev identity and never fails,
-`Provider.Cognito` raises, and boot calls whichever is configured so a bad `AUTH_ENABLED` fails at
-boot. `token` is always `nil` — it exists so real passthrough is a substitution, not a refactor.
+`Nucleus.Scope` (`user`, `tenant`, `token`, `scopes`, `source_ip`) is the one identity shape every
+reader takes it from. `Provider.Disabled` (default) never fails; `Provider.Cognito` raises, so a
+bad `AUTH_ENABLED` fails at boot. `token` stays `nil` — populating it later is a substitution.
 
-**Related**: Issue #6 (EN-6, the deciding issue) · Issue #7 (EN-7, wires the plug/hook into the
-router) · Issue #15 (SEC-S7, future consumer of the credential-expiry state `token` exists for) ·
-`docs/adr/0004-audit-emission.md` (`Nucleus.Audit.Source.from_conn/1`, reused for `source_ip`)
+**Related**: Issue #6 (EN-6, deciding issue) · Issue #7 (wires the plug/hook) · Issue #15 (SEC-S7,
+credential-expiry consumer) · `docs/adr/0004` (`source_ip` reuse)
 
 ---
 
@@ -118,15 +112,13 @@ router) · Issue #15 (SEC-S7, future consumer of the credential-expiry state `to
 
 **Date**: 2026-08-11 | **Status**: Decided | **ADR**: `docs/adr/0006-application-shell-and-live-session-composition.md`
 
-Reversed the ticket's own daisyUI-removal recommendation — daisyUI stays; new components build on
-its classes/tokens. `live_session :authenticated` stacks `on_mount: [ScopeHook, EnvironmentsHook]`,
-the second reading the `current_scope.token` the first assigns. The sidebar degrades to an empty
-state on load failure (`NAV-A07`) while Secrets stays fail-closed (`SEC-A17`) — asymmetric by
-design, not by oversight.
+Reversed the ticket's own daisyUI-removal call — daisyUI stays; new components build on its
+classes/tokens. `live_session :authenticated` stacks `on_mount: [ScopeHook, EnvironmentsHook]`. The
+sidebar degrades on load failure (`NAV-A07`) while Secrets stays fail-closed (`SEC-A17`) —
+asymmetric by design.
 
-**Related**: Issue #7 (EN-7, the deciding issue) · `docs/adr/0005-deferred-authentication.md`
-(the `on_mount`-at-`live_session` convention this builds on) · Issues #9/#10 (SEC-S1/S2, replaced
-the `SecretsLive` placeholder wholesale)
+**Related**: Issue #7 (EN-7, deciding issue) · `docs/adr/0005` (on_mount convention this builds on)
+· Issues #9/#10 (SEC-S1/S2, replaced the placeholder)
 
 ---
 
@@ -136,13 +128,11 @@ the `SecretsLive` placeholder wholesale)
 
 Parameter Store path is `/{cluster}/deployments/{deployment}/faas/functions/{environment}/{key}`,
 decoupled from `Nucleus.TenantApi`'s environment list by design. AWS access goes through the `aws`
-hex package over a custom `Req`-backed `AWS.HTTPClient`, chosen over `ex_aws` for SDK-accurate
-request shapes, with credentials cached in `:persistent_term`. Local state reads and mutates EN-3's
-`Nucleus.Backend.Seed` directly, reversing the ticket's dedicated-`Agent` plan.
+package (over `ex_aws`, for SDK-accurate shapes), credentials cached in `:persistent_term`; local
+state reads/mutates EN-3's `Nucleus.Backend.Seed` directly.
 
-**Related**: Issue #4 (EN-4, the deciding issue) · `docs/adr/0003-shared-local-backend-seed.md`
-(`Nucleus.Backend.Seed`, read and mutated here) · Issues #9–#15 (every SEC ticket touching
-secret material, now unblocked)
+**Related**: Issue #4 (EN-4, deciding issue) · `docs/adr/0003` (`Seed`, read/mutated here) ·
+Issues #9–#15 (every SEC ticket touching secret material, now unblocked)
 
 ---
 
@@ -150,14 +140,12 @@ secret material, now unblocked)
 
 **Date**: 2026-08-14 | **Status**: Decided | **ADR**: `docs/adr/0008-test-strategy.md`
 
-`Phoenix.LiveViewTest` plus the new `phoenix_test` dependency replace the wiki's Playwright-driven
-e2e layer — no browser driver yet, so `SEC-A02`/`SEC-A13` are recorded as browser-only gaps,
-asserted for wiring and never claimed as covered. `Nucleus.BackendCase` is `async: false` because
-`Nucleus.Backend.Seed` is a global `Agent` (`docs/adr/0003`); `AuditCase` and `NucleusWeb.LiveCase`
-are async-safe. `mix nucleus.trace` is report-only, not wired into `precommit`.
+`Phoenix.LiveViewTest` + the new `phoenix_test` dep replace the wiki's Playwright e2e layer — no
+browser driver yet, so `SEC-A02`/`SEC-A13` are recorded as browser-only gaps, never claimed
+covered. `BackendCase` is `async: false` (global `Agent` seed); `AuditCase`/`LiveCase` are async-safe.
 
-**Related**: Issue #8 (EN-8, the deciding issue) · Issue #24 (timing-convention reconciliation
-filed during this ticket) · Issues #9–#15 (every SEC ticket, the harness's first consumers)
+**Related**: Issue #8 (EN-8, deciding issue) · Issue #24 (timing reconciliation) · Issues #9–#15
+(every SEC ticket, the harness's first consumers)
 
 ---
 
@@ -166,16 +154,28 @@ filed during this ticket) · Issues #9–#15 (every SEC ticket, the harness's fi
 **Date**: 2026-08-14 | **Status**: Decided | **ADR**: `docs/adr/0009-environment-validation-ladder.md`
 
 `Nucleus.Environments.validate_name/1` rejects any name failing a positive charset allowlist
-(`~r/\A[a-z0-9][a-z0-9-]*\z/`, ≤64 chars) — not a `..`/`/`/`\` denylist, which percent-encoding and
-unicode lookalikes defeat. `fetch/2` runs it first, collapses `:unavailable`/`:not_configured` to
-`:unavailable`, passes `:auth_expired` through untouched, and matches archived environments too,
-with no cache and no fallback ever. `SecretsLive` validates in `handle_params/3`, not `mount/3`, so
-a patch between environments re-validates.
+(`~r/\A[a-z0-9][a-z0-9-]*\z/`, ≤64 chars), not a denylist, which percent-encoding/unicode defeat.
+`fetch/2` validates first, collapses `:unavailable`/`:not_configured`, passes `:auth_expired`
+through, and matches archived environments too, with no cache/fallback ever.
 
-**Related**: Issue #9 (SEC-S1, the deciding issue) · `docs/adr/0006-application-shell-and-live-session-composition.md`
-(the placeholder this ticket replaced) · `docs/adr/0007-secrets-store-adapter.md` (the boundary
-that explicitly deferred this validation here) · Issues #10–#15 (SEC-S2–S7, every one mounts
-through this gate)
+**Related**: Issue #9 (SEC-S1, deciding issue) · `docs/adr/0006` (placeholder replaced) ·
+`docs/adr/0007` (the boundary that deferred validation here) · Issues #10–#15 (SEC-S2–S7, every
+one mounts through this gate)
+
+---
+
+## Decision: Secrets Listing — Gate Collapse, ARN-Hashed DOM IDs, Boundary-Matched Errors
+
+**Date**: 2026-08-17 | **Status**: Decided | **ADR**: `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md`
+
+`Nucleus.Secrets.list/2` collapses `SecretsLive`'s two backend calls into one, gating through
+`Environments.fetch/2` internally — the dead `resolved_environment` assign is gone. Row DOM ids
+hash the ARN, not the key (no sanitiser existed); `data-key` carries the real key. Errors match on
+`{kind, boundary}`, telling the gate's `:unavailable` apart from the store's — also fixing a
+latent `:auth_expired` crash.
+
+**Related**: Issue #10 (SEC-S2) · `docs/adr/0009` (gate called once) · `docs/adr/0007` (`:secrets`
+boundary) · Issues #11–#15 (SEC-S3–S7 build on this DOM-id/error contract)
 
 ---
 
@@ -186,9 +186,9 @@ date, what replaced it, and why.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0009` are binding
-- [ ] Know that new formal ADRs belong in `docs/adr/`, with only a short summary mirrored here,
-      and that the wiki's ADR-0001–0007 are reference only, not adopted
+- [ ] Read the Decision Index above; `adr/0001`–`0010` are binding
+- [ ] New formal ADRs belong in `docs/adr/`, with only a short summary mirrored here — the wiki's
+      ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)
 
 ## Related Files

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.7 | Updated: 2026-08-14 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.8 | Updated: 2026-08-17 -->
 
 # Living Notes
 
@@ -18,6 +18,7 @@
 | LiveDashboard at `/dev/dashboard` unauthenticated | Fine in dev; a leak if ever exposed in prod | Medium | Gate behind auth before any production deploy |
 | Nucleus's own AWS identity (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) is read ambiently by the `aws` package, with no boot-time check or ops-facing doc — unlike `TENANT_ROLE_ARN`/`AWS_REGION`/`CLUSTER_NAME`/`DEPLOYMENT_NAME`, which all raise at boot | A misconfigured deployment fails per-request as `:not_configured` on first `AssumeRole` call, not at boot | Low | `CLUSTER_NAME`/`DEPLOYMENT_NAME` are now correctly documented in the wiki's `Platform-Operations.md` config reference (issue #22). The ambient `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` doc gap remains open — was out of scope for #22 |
 | No browser-driven test coverage for `SEC-A02` (clipboard write confirmation) or `SEC-A13` (Escape dismissal, focus trap, focus restoration) — `navigator.clipboard` and real key/focus events need a browser, which this repo has no driver for | Tests assert wiring only (hook attached, `on_cancel` set), never claim `@tag action:` for these IDs — a real regression would not be caught until a browser harness exists | Medium | Add Wallaby once sign-in exists (deferred, EN-8); see `docs/adr/0008-test-strategy.md` |
+| `LOCAL_FORCE_ERROR` (`Nucleus.Backend.Faults`) is node-global, not per-boundary — a fault set for one boundary is seen by every local implementation's next call | A test targeting the `:secrets` boundary's error path is actually caught by whichever boundary is called first; SEC-S2 found this when `Nucleus.Secrets.list/2`'s `Environments.fetch/2` gate always intercepted the fault before `Store.list_secrets/1` ran | Low | Swap in a real/failing module via `Application.put_env(:nucleus, :backends, ...)` instead of `force_error/2` for a specific-boundary test — see `SecretsLiveTest.FailingSecretsStore` |
 
 ### Technical Debt Details
 
@@ -127,11 +128,12 @@ deploys it.
 Moved here for historical reference.
 
 **`NucleusWeb.SecretsLive` was a placeholder** — *was: Technical Debt, Medium*
-*Resolved*: 2026-08-14 by SEC-S1 (issue #9).
-*Outcome*: Replaced wholesale, as ADR-0006 always intended. Validates the environment in
-`handle_params/3` via `Nucleus.Environments.fetch/2` and renders one of three fail-closed
-states (`SEC-A15`–`A17`); renders no secrets UI of its own yet — that is `SEC-S2` onward.
-*See*: `docs/adr/0009-environment-validation-ladder.md`
+*Resolved*: 2026-08-14 by SEC-S1 (issue #9); listing added 2026-08-17 by SEC-S2 (issue #10).
+*Outcome*: Replaced wholesale, as ADR-0006 always intended. `Nucleus.Secrets.list/2` now gates
+through `Nucleus.Environments.fetch/2` in one call and lists a `Nucleus.Secrets.Store`
+boundary's secrets (`SEC-A01`, `SEC-A14`); every `Nucleus.Backend.Error` kind across both
+boundaries renders without crashing.
+*See*: `docs/adr/0009-environment-validation-ladder.md`, `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md`
 
 **Build `mix nucleus.trace`** — *was: Active Project*
 *Resolved*: 2026-08-14 by EN-8 (issue #8).

--- a/docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md
+++ b/docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md
@@ -1,0 +1,139 @@
+# ADR-0010: Secrets Listing — Context-Layer Gate Collapse, ARN-Hashed DOM IDs, Boundary-Disambiguated Errors
+
+## Status
+
+Accepted — 2026-08-17
+
+Decided on [SEC-S2](https://github.com/dave-bell/nucleus/issues/10). Builds on
+`0009-environment-validation-ladder.md` (the gate this ticket now calls once,
+not twice), `0007-secrets-store-adapter.md` (the `:secrets` boundary this
+ticket lists from), and `0002-backend-adapter-boundaries.md` (the `kind`/
+`boundary` vocabulary this ticket is the first to match on both fields at
+once).
+
+## Context
+
+SEC-S1's plan had `SecretsLive.handle_params/3` call
+`Nucleus.Environments.fetch/2` directly and keep the resolved
+`%Environment{}` in a `resolved_environment` assign that no template ever
+read — because listing (this ticket) was still blocked. With both blockers
+(`#4`, `#9`) closed, three things the original plan left open or got wrong
+needed settling before implementation: how the LiveView calls two backend
+boundaries without duplicating the gate, what a stream row's DOM id should
+be when the natural key (the secret's `key`) can contain unicode and spaces
+the plan never resolved a sanitiser for, and how to tell apart two
+same-`kind`, different-boundary errors (`:unavailable` from the environment
+gate vs. from the secrets store itself) without collapsing them and
+misinforming the user about which system is actually down.
+
+## Decision
+
+### One call to `Nucleus.Secrets.list/2`, not two
+
+`Nucleus.Secrets.list/2` gates through `Environments.fetch/2` internally and
+discards the resolved `%Environment{}` — `SecretsLive` calls only this
+function. The gate is load-bearing, not defensive: `Store.Local.list_secrets/1`
+does `Map.get(buckets, environment, %{})`, so an unvalidated, nonexistent
+environment would otherwise render `SEC-A14`'s empty state indistinguishably
+from a real, seeded-empty one. Collapsing to one call also removes the now
+provably dead `resolved_environment` assign and `scope_token/1` helper —
+the whole `%Nucleus.Scope{}` is passed to the context instead, per Phoenix
+1.8 scope convention.
+
+### Row DOM ids are a hash of the ARN, not the key
+
+`stream_configure(:secrets, dom_id: &dom_id/1)` where `dom_id/1` is
+`"secret-" <> (:crypto.hash(:sha256, ref.arn) |> Base.url_encode64(padding: false))`.
+No convention for hashing an item into a DOM id existed anywhere in this
+codebase before this ticket — `SecretsLive` is the first LiveView here to
+stream a collection at all. The ARN was chosen over the key because it is
+unique, stable across renders, and never needs sanitising (unlike the key,
+which `SEC-S6` permits to contain unicode, spaces, and dots — an
+awkward-for-CSS-selector set with no defined sanitiser in the original
+plan). Every row also carries `data-key={ref.key}` so later tickets select
+on `[data-key="DATABASE_URL"]` rather than the opaque hash.
+
+### Errors are matched on `{kind, boundary}`, not `kind` alone
+
+`fetch_secrets/2`'s `case` distinguishes `kind: :unavailable, boundary:
+:tenant_api` (`#secrets-validation-unavailable`, `SEC-A17`'s concern) from
+`kind: :unavailable, boundary: :secrets` (`#secrets-unavailable`, this
+ticket's own store outage) — both arrive with the same `kind`, and
+collapsing them would tell a user "the environment can't be verified" when
+the real problem is the secrets store, or vice versa. `:auth_expired` is
+matched regardless of boundary and renders a placeholder (`SEC-S7`'s
+concern); every remaining kind (`:already_exists`, `:not_configured`) falls
+back to the `:secrets` rendering rather than being left unmatched — the
+`case` is exhaustive against `Error.kinds/0` today, which also fixes a
+latent bug: SEC-S1's original `case` had no `:auth_expired` clause at all
+and would have crashed the LiveView the first time the store or the tenant
+API returned it.
+
+### Sort: case-fold key, raw key as tiebreak
+
+`Enum.sort_by(refs, &{String.downcase(&1.key), &1.key})`, in the context
+module, not the template. `String.downcase/1` alone is a partial order —
+`API_KEY` and `api_key` collide under it, so a stable sort then inherits
+their relative order from the store's iteration order, which neither
+`Store.Local` (map iteration past 32 keys) nor `Store.Aws`
+(`GetParametersByPath` pagination) guarantees. The raw key breaks every
+remaining tie because keys are unique within an environment.
+
+## Consequences
+
+### Positive
+
+- Exactly one place (`Nucleus.Secrets.list/2`) can bypass the environment
+  gate for a listing request; there is no second call site to audit.
+- `SEC-S3`–`SEC-S6` have a written DOM-id contract (`dom_id`/`data-key`)
+  instead of four tickets independently guessing a key-sanitisation scheme.
+- The `:auth_expired` crash is fixed as a side effect of making the `case`
+  exhaustive, not as a separate patch.
+
+### Negative
+
+- `Nucleus.Backend.Faults`' `LOCAL_FORCE_ERROR` is node-global and checked
+  by both boundaries' local implementations — since the gate always runs
+  first, a global fault is always caught as `boundary: :tenant_api` and the
+  `:secrets`-boundary branch is untestable through it. Both new test files
+  work around this by swapping in a raising/failing `Nucleus.Secrets.Store`
+  implementation instead (the same technique `environments_test.exs` already
+  used for `Nucleus.TenantApi`), rather than fixing the fault mechanism
+  itself, which stays node-global for every other boundary pair too.
+- The row DOM id is opaque (a hash), which is why `data-key` exists — a
+  future ticket that selects on the id directly instead of `data-key` will
+  work today and become a silent liability if the hash function ever
+  changes.
+
+## Alternatives considered
+
+**Keep `Environments.fetch/2` and `Store.list_secrets/1` as two calls in
+`SecretsLive` itself.** Rejected — reintroduces the double round trip and
+the dead `resolved_environment` assign, and pushes the `{kind, boundary}`
+disambiguation into the LiveView instead of the context module owning it
+once.
+
+**DOM id from a sanitised key.** Rejected — the original plan's "sanitise
+the key, or use an index" left the sanitiser undefined, and `SEC-S6`
+permits unicode/spaces/dots in keys with no obvious CSS-safe transform.
+
+**DOM id from list position (index-based).** Rejected — not stable across
+the `stream_insert/3` calls `SEC-S4`/`SEC-S5` perform when one row's reveal
+or edit state changes.
+
+**ARN as the sort tiebreak instead of the raw key.** Rejected — the ARN's
+last path segment is the key itself, so it decides every tie identically to
+using the key directly, over a much longer binary.
+
+## References
+
+- SEC-S2 (issue #10) — the deciding issue, including the "Decisions taken at
+  start of work" comment this ADR formalises
+- `docs/adr/0009-environment-validation-ladder.md` — the gate this ticket
+  now calls exactly once
+- `docs/adr/0007-secrets-store-adapter.md` — the `:secrets` boundary and its
+  `SecretRef` (no `value` field) this ticket lists from
+- `docs/adr/0002-backend-adapter-boundaries.md` — the `kind`/`boundary`
+  vocabulary this ADR is the first to match on both fields together
+- Wiki [Secrets](https://github.com/dave-bell/nucleus/wiki/Secrets)
+  `SEC-A01`, `SEC-A14`

--- a/lib/nucleus/secrets.ex
+++ b/lib/nucleus/secrets.ex
@@ -1,0 +1,74 @@
+defmodule Nucleus.Secrets do
+  @moduledoc """
+  The public context module `NucleusWeb.SecretsLive` talks to.
+
+  Store access always goes through here so the environment gate cannot be
+  bypassed — nothing outside this module should call `Nucleus.Secrets.Store`
+  directly for a request that originated from a caller-supplied environment
+  name.
+
+  ## One call, not a combined result (`SEC-S2` decision 1)
+
+  `list/2` gates internally via `Nucleus.Environments.fetch/2` and discards
+  the resulting `%Nucleus.TenantApi.Environment{}` — the environment response
+  is never merged with the secrets response, because the two backend
+  boundaries stay separate (`:tenant_api` vs `:secrets`, see
+  `Nucleus.Backend.Error.boundary`). The gate is load-bearing, not merely
+  defensive: `Nucleus.Secrets.Store.Local.list_secrets/1` does
+  `Map.get(buckets, environment, %{})`, so a nonexistent environment returns
+  `{:ok, []}` — indistinguishable from a seeded empty environment
+  (`SEC-A14`). `GetParametersByPath` behaves the same way against a path with
+  nothing under it. Without this gate, `/environments/nope/secrets` would
+  render `SEC-A14`'s "no secrets found" plus a create button for an
+  environment that does not exist.
+
+  Callers distinguish the two boundaries' `:unavailable` errors by matching
+  on `error.boundary`, not just `error.kind` — both arrive with
+  `kind: :unavailable`.
+  """
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Environments
+  alias Nucleus.Scope
+  alias Nucleus.Secrets.SecretRef
+  alias Nucleus.Secrets.Store
+
+  @doc """
+  Every secret's metadata for `environment`, re-validating the environment
+  through `scope` before reaching the store.
+
+  Values are never fetched, merged, or prefetched here — `SecretRef` has no
+  `value` field at all (`SEC-A01`), and this function does not call
+  `Store.get_secret/2`.
+
+  Results are sorted by key, ascending, case-insensitive with the raw key as
+  a tiebreak: `Enum.sort_by(refs, &{String.downcase(&1.key), &1.key})`. Keys
+  are unique within an environment, so nothing can tie on both terms — the
+  tiebreak makes the order total, not merely case-folded, so `API_KEY` and
+  `api_key` (which collide under `String.downcase/1` alone) still sort
+  deterministically instead of inheriting the store's iteration order.
+  Neither `Store.Local` (a JSON-decoded map, whose iteration order is not
+  insertion order past 32 keys) nor `Store.Aws` (`GetParametersByPath`
+  pagination, unordered across pages) guarantees a stable order on its own —
+  sorting belongs here, not in the template, so the UI and the tests are not
+  flaky.
+
+  Emits no audit event: the audit catalogue
+  (`Nucleus.Audit.Event.events/0`) has no `secret_listed` entry. Listing
+  exposes no values, so there is nothing sensitive to attribute — unlike
+  Data Export's `nomad_vars_listed`, this is a deliberate omission, not an
+  oversight.
+  """
+  @spec list(environment :: String.t(), scope :: Scope.t()) ::
+          {:ok, [SecretRef.t()]} | {:error, Error.t()}
+  def list(environment, %Scope{token: token}) when is_binary(environment) do
+    with {:ok, _environment} <- Environments.fetch(environment, token),
+         {:ok, refs} <- Store.list_secrets(environment) do
+      {:ok, sort(refs)}
+    end
+  end
+
+  defp sort(refs) do
+    Enum.sort_by(refs, &{String.downcase(&1.key), &1.key})
+  end
+end

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -13,25 +13,72 @@ defmodule NucleusWeb.SecretsLive do
   `mount/3` does not. Putting the check in `mount/3` would let a user patch
   from a valid environment straight into an unvalidated one.
 
-  ## Three distinct, mutually exclusive states
+  ## One call to `Nucleus.Secrets.list/2`, not two
 
-  `Nucleus.Environments.fetch/2` returns one of four outcomes, and each gets
-  its own assign and its own DOM id — collapsing "not found" and
-  "unavailable" into one rendering would misinform the user about a real
-  outage (`SEC-A17`):
+  `SEC-S1`'s original placeholder called `Nucleus.Environments.fetch/2`
+  directly. `SEC-S2` collapsed that into a single call to
+  `Nucleus.Secrets.list/2`, which gates through `Environments.fetch/2`
+  internally — this module no longer calls it, and no longer keeps a
+  `resolved_environment` assign (it was assigned by the placeholder and never
+  read). `current_scope` is passed to the context wholesale, per Phoenix 1.8
+  scope convention.
+
+  ## Every outcome gets its own assign and DOM id
+
+  `Nucleus.Secrets.list/2` can succeed, or fail with any
+  `Nucleus.Backend.Error.kinds/0` value from either boundary it touches
+  (`:tenant_api` via the environment gate, `:secrets` via the store) — this
+  `case` must handle all of them without crashing:
 
   | Outcome | `:environment_status` | DOM id |
   |---|---|---|
-  | `{:ok, environment}` | `:ok` | (list rendering is `SEC-S2`) |
+  | `{:ok, refs}` | `:ok` | `#secrets-table` / `#secrets-empty` |
   | `kind: :invalid` | `:invalid` | `#secrets-invalid-environment` |
   | `kind: :not_found` | `:not_found` | `#secrets-environment-not-found` |
-  | `kind: :unavailable` | `:unavailable` | `#secrets-validation-unavailable` |
+  | `kind: :unavailable, boundary: :tenant_api` | `:validation_unavailable` | `#secrets-validation-unavailable` |
+  | `kind: :unavailable, boundary: :secrets` | `:secrets_unavailable` | `#secrets-unavailable` |
+  | `kind: :auth_expired` (either boundary) | `:auth_expired` | `#secrets-auth-expired` |
+  | anything else (`:already_exists`, `:not_configured`) | `:secrets_unavailable` | `#secrets-unavailable` |
+
+  `:invalid` and `:not_found` only ever arrive with `boundary: :tenant_api` —
+  the store is never reached once the gate rejects a name. The two
+  `:unavailable` outcomes are otherwise identical (`kind: :unavailable`) and
+  are told apart only by `boundary`, which is why this `case` matches on it
+  explicitly rather than collapsing them — collapsing "not found" and
+  "unavailable" would misinform the user about a real outage (`SEC-A17`), and
+  the same reasoning applies to the store's own outage.
+
+  `:auth_expired` is `SEC-S7`'s concern — this module renders a placeholder
+  and does not implement retry semantics for it. Every other, unlisted kind
+  (there are none today, but `kinds/0` could grow one) falls back to the same
+  `:secrets_unavailable` rendering rather than crashing.
 
   Every branch keeps the shell intact (`<Layouts.app>`, `#tenant-identifier`)
   so the user can navigate away — a crashed LiveView is not an acceptable
-  rendering of any of these. No secrets UI (table, create button, reveal
-  control) renders in any error state, and the raw environment name is never
-  echoed unescaped — HEEx's default escaping is not defeated with `raw/1`.
+  rendering of any of these. The raw environment name is never echoed
+  unescaped — HEEx's default escaping is not defeated with `raw/1`.
+
+  ## Values are never in reach, never mind on screen
+
+  `Nucleus.Secrets.list/2` returns `%Nucleus.Secrets.SecretRef{}` structs,
+  which have no `value` field — this module cannot render, prefetch, or leak
+  a value during listing even by accident. The "Value" column renders a
+  fixed-width mask that does not depend on the real value's length (which
+  would leak it). Revealing a value is `SEC-S4`'s `handle_event("reveal", …)`
+  — this module renders the control and a placeholder handler so a click
+  cannot crash the LiveView before that ticket replaces it. Creating a
+  secret is `SEC-S6`'s modal; the same placeholder-handler rule applies to
+  the create button.
+
+  ## Row DOM ids are a hash of the ARN, not the key (`SEC-S2` decision 2)
+
+  The ARN is unique per secret and stable across renders (it encodes the
+  path and key, not the value), so it survives the `stream_insert/3` that
+  `SEC-S4`/`SEC-S5` perform when a row's reveal or edit state changes. An
+  opaque id is worse to select against, so each row also carries
+  `data-key={ref.key}` — later tickets should select on
+  `[data-key="DATABASE_URL"]`, not on the row id, and must not recompute the
+  hash in a test.
 
   `current_scope` and `environments` come from the `:authenticated`
   `live_session`'s `on_mount` hooks (`NucleusWeb.ScopeHook`,
@@ -42,34 +89,71 @@ defmodule NucleusWeb.SecretsLive do
   use NucleusWeb, :live_view
 
   alias Nucleus.Backend.Error
-  alias Nucleus.Environments
-  alias Nucleus.Scope
+  alias Nucleus.Secrets
+  alias Nucleus.Secrets.SecretRef
+
+  @masked_value "••••••••"
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> stream_configure(:secrets, dom_id: &dom_id/1)
+      |> stream(:secrets, [])
+
     {:ok, socket}
   end
 
   @impl Phoenix.LiveView
   def handle_params(%{"environment" => environment}, _uri, socket) do
-    socket = assign(socket, :environment, environment)
-
     socket =
-      case Environments.fetch(environment, scope_token(socket)) do
-        {:ok, resolved} ->
-          assign(socket, environment_status: :ok, resolved_environment: resolved)
-
-        {:error, %Error{kind: :invalid}} ->
-          assign(socket, environment_status: :invalid, resolved_environment: nil)
-
-        {:error, %Error{kind: :not_found}} ->
-          assign(socket, environment_status: :not_found, resolved_environment: nil)
-
-        {:error, %Error{kind: :unavailable}} ->
-          assign(socket, environment_status: :unavailable, resolved_environment: nil)
-      end
+      socket
+      |> assign(:environment, environment)
+      |> fetch_secrets(environment)
 
     {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("reveal", %{"key" => _key}, socket) do
+    {:noreply, put_flash(socket, :info, "Revealing a secret's value is not yet implemented.")}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("create_secret", _params, socket) do
+    {:noreply, put_flash(socket, :info, "Creating a secret is not yet implemented.")}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("retry", _params, socket) do
+    {:noreply, fetch_secrets(socket, socket.assigns.environment)}
+  end
+
+  defp fetch_secrets(socket, environment) do
+    case Secrets.list(environment, socket.assigns.current_scope) do
+      {:ok, refs} ->
+        socket
+        |> assign(environment_status: :ok, secret_count: length(refs))
+        |> stream(:secrets, refs, reset: true)
+
+      {:error, %Error{kind: :invalid, boundary: :tenant_api}} ->
+        assign(socket, environment_status: :invalid, secret_count: 0)
+
+      {:error, %Error{kind: :not_found, boundary: :tenant_api}} ->
+        assign(socket, environment_status: :not_found, secret_count: 0)
+
+      {:error, %Error{kind: :unavailable, boundary: :tenant_api}} ->
+        assign(socket, environment_status: :validation_unavailable, secret_count: 0)
+
+      {:error, %Error{kind: :unavailable, boundary: :secrets}} ->
+        assign(socket, environment_status: :secrets_unavailable, secret_count: 0)
+
+      {:error, %Error{kind: :auth_expired}} ->
+        assign(socket, environment_status: :auth_expired, secret_count: 0)
+
+      {:error, %Error{}} ->
+        assign(socket, environment_status: :secrets_unavailable, secret_count: 0)
+    end
   end
 
   @impl Phoenix.LiveView
@@ -89,19 +173,97 @@ defmodule NucleusWeb.SecretsLive do
         message={"No environment named \"#{@environment}\" was found for this tenant."}
       />
       <.empty_state
-        :if={@environment_status == :unavailable}
+        :if={@environment_status == :validation_unavailable}
         id="secrets-validation-unavailable"
         icon="hero-exclamation-triangle"
         message="Can't verify this environment right now. Try again shortly."
       />
+      <.empty_state
+        :if={@environment_status == :secrets_unavailable}
+        id="secrets-unavailable"
+        icon="hero-exclamation-triangle"
+        message="Can't reach the secrets store right now. Try again shortly."
+      >
+        <:action>
+          <.button phx-click="retry">Retry</.button>
+        </:action>
+      </.empty_state>
+      <.empty_state
+        :if={@environment_status == :auth_expired}
+        id="secrets-auth-expired"
+        icon="hero-lock-closed"
+        message="This environment's secrets can't be reached right now."
+      />
+      <div :if={@environment_status == :ok}>
+        <div class="flex items-center justify-between gap-4 pb-4">
+          <h1 class="text-lg font-semibold">Secrets</h1>
+          <.button id="secrets-create-button" phx-click="create_secret">New secret</.button>
+        </div>
+
+        <.empty_state
+          :if={@secret_count == 0}
+          id="secrets-empty"
+          icon="hero-inbox"
+          message="No secrets found for this environment."
+        />
+
+        <div :if={@secret_count > 0} id="secrets-table">
+          <table class="table table-zebra">
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Path</th>
+                <th>ARN</th>
+                <th>Last modified</th>
+                <th>Value</th>
+                <th><span class="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody id="secrets-table-body" phx-update="stream">
+              <tr :for={{dom_id, ref} <- @streams.secrets} id={dom_id} data-key={ref.key}>
+                <td>{ref.key}</td>
+                <td>
+                  <span class="block max-w-xs truncate" title={ref.path}>{ref.path}</span>
+                </td>
+                <td>
+                  <span class="block max-w-xs truncate" title={ref.arn}>{ref.arn}</span>
+                </td>
+                <td>{format_last_modified(ref.last_modified)}</td>
+                <td>
+                  <span aria-hidden="true">{masked_value()}</span>
+                  <span class="sr-only">value hidden</span>
+                </td>
+                <td>
+                  <button
+                    id={reveal_id(dom_id)}
+                    type="button"
+                    class="btn btn-sm"
+                    phx-click="reveal"
+                    phx-value-key={ref.key}
+                  >
+                    View
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </Layouts.app>
     """
   end
 
-  defp scope_token(socket) do
-    case socket.assigns[:current_scope] do
-      %Scope{token: token} -> token
-      _ -> nil
-    end
+  defp masked_value, do: @masked_value
+
+  defp dom_id(%SecretRef{arn: arn}) do
+    "secret-" <> (:crypto.hash(:sha256, arn) |> Base.url_encode64(padding: false))
+  end
+
+  defp reveal_id("secret-" <> hash), do: "reveal-" <> hash
+
+  defp format_last_modified(nil), do: "—"
+
+  defp format_last_modified(%DateTime{} = datetime) do
+    Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
   end
 end

--- a/test/nucleus/secrets_test.exs
+++ b/test/nucleus/secrets_test.exs
@@ -1,0 +1,134 @@
+defmodule Nucleus.SecretsTest do
+  # `seed_secret/3`/`force_error/2` mutate node-global state
+  # (`Nucleus.Backend.Seed`); composed with `Nucleus.AuditCase` the same way
+  # `NucleusWeb.LiveCase` does, both pinned to `async: false` to match
+  # `Nucleus.BackendCase`'s constraint.
+  use Nucleus.BackendCase, async: false
+  use Nucleus.AuditCase, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Scope
+  alias Nucleus.Secrets
+  alias Nucleus.Secrets.SecretRef
+
+  @scope %Scope{tenant: "acme", user: %{email: "a@b.com", username: nil}}
+
+  defmodule ExplodingSecretsStore do
+    @moduledoc """
+    A `Nucleus.Secrets.Store` implementation that raises if it is ever
+    called — swapped in for the one test that asserts the environment gate
+    holds through the context layer: if `Secrets.list/2` called the store
+    after an invalid name, this module raising is how the test would know.
+    """
+    @behaviour Nucleus.Secrets.Store
+
+    @impl Nucleus.Secrets.Store
+    def list_secrets(_environment), do: raise("list_secrets/1 was called after an invalid name")
+
+    @impl Nucleus.Secrets.Store
+    def get_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def create_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def update_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def locate_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_environments, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_all_secrets, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_exploding_secrets_store do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, ExplodingSecretsStore)
+    )
+  end
+
+  describe "list/2 — SEC-A01 shape" do
+    @tag action: "SEC-A01"
+    test "returns SecretRef structs with key, path, arn populated" do
+      assert {:ok, refs} = Secrets.list("prod", @scope)
+      assert refs != []
+
+      for ref <- refs do
+        assert %SecretRef{} = ref
+        assert is_binary(ref.key) and ref.key != ""
+        assert is_binary(ref.path) and ref.path != ""
+        assert is_binary(ref.arn) and ref.arn != ""
+      end
+    end
+
+    @tag action: "SEC-A01"
+    test "the returned structs have no value key" do
+      assert {:ok, [ref | _]} = Secrets.list("prod", @scope)
+      refute Map.has_key?(ref, :value)
+    end
+  end
+
+  describe "list/2 — SEC-A01 sort order" do
+    @tag action: "SEC-A01"
+    test "results are sorted by key, case-insensitively with a raw-key tiebreak" do
+      seed_secret("prod", "api_key_lower", "one")
+      seed_secret("prod", "API_KEY_LOWER", "two")
+
+      assert {:ok, refs} = Secrets.list("prod", @scope)
+      keys = Enum.map(refs, & &1.key)
+
+      assert keys == Enum.sort_by(keys, &{String.downcase(&1), &1})
+    end
+
+    @tag action: "SEC-A01"
+    test "ordering is stable across two calls" do
+      assert {:ok, first} = Secrets.list("prod", @scope)
+      assert {:ok, second} = Secrets.list("prod", @scope)
+
+      assert Enum.map(first, & &1.key) == Enum.map(second, & &1.key)
+    end
+  end
+
+  describe "list/2 — the environment gate holds through the context layer" do
+    @tag action: "SEC-A01"
+    test "an invalid environment name returns :invalid without calling the store" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} = Secrets.list("..", @scope)
+    end
+  end
+
+  describe "list/2 — SEC-A14 empty state" do
+    @tag action: "SEC-A14"
+    test "the seeded empty sandbox environment returns {:ok, []}, not an error" do
+      assert {:ok, []} = Secrets.list("sandbox", @scope)
+    end
+  end
+
+  describe "list/2 — no audit event" do
+    test "emits none of the three secret audit events" do
+      Secrets.list("prod", @scope)
+
+      assert_no_audit_event(:secret_created)
+      assert_no_audit_event(:secret_viewed)
+      assert_no_audit_event(:secret_updated)
+    end
+
+    test "does not leak a seeded secret's value into the audit trail" do
+      Secrets.list("prod", @scope)
+
+      refute_audit_contains("postgres://app:s3cr3t@prod-db.internal:5432/app")
+    end
+  end
+end

--- a/test/nucleus_web/live/secrets_live_test.exs
+++ b/test/nucleus_web/live/secrets_live_test.exs
@@ -2,6 +2,198 @@ defmodule NucleusWeb.SecretsLiveTest do
   # `force_error/2` (`Nucleus.BackendCase`) mutates node-global state.
   use NucleusWeb.LiveCase, async: false
 
+  alias Nucleus.Backend.Error
+  alias Nucleus.Secrets
+
+  defmodule FailingSecretsStore do
+    @moduledoc """
+    A `Nucleus.Secrets.Store` implementation that always fails `list_secrets/1`
+    with a controllable `Nucleus.Backend.Error`.
+
+    `Nucleus.Backend.Faults`' `LOCAL_FORCE_ERROR` is node-global and checked by
+    `Nucleus.TenantApi.Local` too — since `Nucleus.Secrets.list/2` gates through
+    `Nucleus.Environments.fetch/2` first, a global fault is always caught there
+    (`boundary: :tenant_api`) and the store is never reached. Swapping the
+    `:secrets` boundary's implementation instead, the same technique
+    `test/nucleus/environments_test.exs`'s `ExplodingTenantApi` uses, is the
+    only way to exercise a `boundary: :secrets` failure from this LiveView.
+    """
+    @behaviour Nucleus.Secrets.Store
+
+    @impl Nucleus.Secrets.Store
+    def list_secrets(_environment) do
+      {:error, Error.new(:unavailable, :secrets, "forced for test", %{})}
+    end
+
+    @impl Nucleus.Secrets.Store
+    def get_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def create_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def update_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def locate_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_environments, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_all_secrets, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_failing_secrets_store do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, FailingSecretsStore)
+    )
+  end
+
+  describe "SEC-A01 — list secrets for an environment" do
+    @tag action: "SEC-A01"
+    test "every seeded key under prod has a row", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      assert has_element?(view, "#secrets-table")
+      assert has_element?(view, "[data-key=\"DATABASE_URL\"]")
+      assert has_element?(view, "[data-key=\"STRIPE_API_KEY\"]")
+      assert has_element?(view, "[data-key=\"JWT_SIGNING_KEY\"]")
+    end
+
+    @tag action: "SEC-A01"
+    test "each row contains the full path and the full ARN", %{conn: conn} do
+      assert {:ok, refs} = Secrets.list("prod", %Nucleus.Scope{})
+      assert {:ok, _view, html} = live_secrets(conn, "prod")
+
+      for ref <- refs do
+        assert html =~ ref.path
+        assert html =~ ref.arn
+      end
+    end
+
+    @tag action: "SEC-A01"
+    test "no seeded secret value appears anywhere in the rendered HTML", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Nucleus.Secrets.Store.get_secret("prod", "DATABASE_URL")
+
+      assert {:ok, %{value: stripe_value}} =
+               Nucleus.Secrets.Store.get_secret("prod", "STRIPE_API_KEY")
+
+      assert {:ok, %{value: jwt_value}} =
+               Nucleus.Secrets.Store.get_secret("prod", "JWT_SIGNING_KEY")
+
+      assert {:ok, _view, html} = live_secrets(conn, "prod")
+
+      refute html =~ db_value
+      refute html =~ stripe_value
+      refute html =~ jwt_value
+    end
+
+    @tag action: "SEC-A01"
+    test "the mask is a fixed width regardless of the underlying value's length", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      db_row = view |> element("[data-key=\"DATABASE_URL\"]") |> render()
+      jwt_row = view |> element("[data-key=\"JWT_SIGNING_KEY\"]") |> render()
+
+      mask_regex = ~r/<span aria-hidden="true">(.*?)<\/span>/s
+      assert [_, db_mask] = Regex.run(mask_regex, db_row)
+      assert [_, jwt_mask] = Regex.run(mask_regex, jwt_row)
+
+      assert db_mask == jwt_mask
+      assert String.length(jwt_mask) < 20
+    end
+
+    @tag action: "SEC-A01"
+    test "the reveal control is present per row", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      assert has_element?(view, "button[phx-value-key=\"DATABASE_URL\"]")
+      assert has_element?(view, "button[phx-value-key=\"STRIPE_API_KEY\"]")
+      assert has_element?(view, "button[phx-value-key=\"JWT_SIGNING_KEY\"]")
+    end
+
+    test "ordering is stable across two mounts", %{conn: conn} do
+      assert {:ok, _view1, html1} = live_secrets(conn, "prod")
+      assert {:ok, _view2, html2} = live_secrets(conn, "prod")
+
+      assert {:ok, refs} = Secrets.list("prod", %Nucleus.Scope{})
+      keys = Enum.map(refs, & &1.key)
+
+      positions1 = Enum.map(keys, &key_position(html1, &1))
+      positions2 = Enum.map(keys, &key_position(html2, &1))
+
+      assert positions1 == Enum.sort(positions1)
+      assert positions1 == positions2
+    end
+  end
+
+  describe "SEC-A14 — empty state for an environment with no secrets" do
+    @tag action: "SEC-A14"
+    test "renders #secrets-empty, no #secrets-table", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "sandbox")
+
+      assert has_element?(view, "#secrets-empty")
+      refute has_element?(view, "#secrets-table")
+    end
+
+    @tag action: "SEC-A14"
+    test "#secrets-create-button is present in the empty state", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "sandbox")
+
+      assert has_element?(view, "#secrets-create-button")
+    end
+
+    @tag action: "SEC-A14"
+    test "#secrets-create-button is also present in the populated state", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      assert has_element?(view, "#secrets-table")
+      assert has_element?(view, "#secrets-create-button")
+    end
+  end
+
+  describe "store unavailable (boundary: :secrets)" do
+    test "renders #secrets-unavailable, shell intact, no crash", %{conn: conn} do
+      use_failing_secrets_store()
+
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      assert has_element?(view, "#secrets-unavailable")
+      assert has_element?(view, "#tenant-identifier")
+      refute has_element?(view, "#secrets-table")
+      refute has_element?(view, "#secrets-validation-unavailable")
+    end
+  end
+
+  describe "placeholder handlers do not crash the LiveView" do
+    test "clicking the reveal control does not crash", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view
+      |> element("button[phx-value-key=\"DATABASE_URL\"]")
+      |> render_click()
+
+      assert has_element?(view, "#secrets-table")
+    end
+
+    test "clicking the create button does not crash", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#secrets-create-button") |> render_click()
+
+      assert has_element?(view, "#secrets-table")
+    end
+  end
+
   describe "SEC-A16 — reject a well-formed but unknown environment" do
     @tag action: "SEC-A16"
     test "renders environment-not-found", %{conn: conn} do
@@ -85,5 +277,9 @@ defmodule NucleusWeb.SecretsLiveTest do
 
       assert has_element?(view, "#secrets-environment-not-found")
     end
+  end
+
+  defp key_position(html, key) do
+    :binary.match(html, key) |> elem(0)
   end
 end


### PR DESCRIPTION
## What

`NucleusWeb.SecretsLive`, still a fail-closed shell from SEC-S1, now lists an environment's secrets: every key with its path, full ARN, last-modified time, a fixed-width mask, and a reveal control, plus the `SEC-A14` empty state with a create button that stays present whether or not the environment has any secrets. The new `Nucleus.Secrets` context module is the single place that can reach the secrets store — it re-validates the environment through `Environments.fetch/2` before ever calling `Store.list_secrets/1`, so the store's own "nonexistent environment returns `[]`" behaviour can never be mistaken for a real seeded-empty environment.

## How

- `Nucleus.Secrets.list/2` gates through `Nucleus.Environments.fetch/2` internally and discards the resolved `%Environment{}` — the LiveView makes one context call instead of the two-call plan SEC-S1 left behind. Results are sorted by `{String.downcase(key), key}`, giving a total order even when two keys collide under case-folding (`API_KEY`/`api_key`), since neither backend's native iteration order is guaranteed stable. No audit event is emitted; listing exposes no values, so there's nothing to attribute.
- `SecretsLive` was rewritten to call only `Secrets.list/2`. This removes SEC-S1's double-fetch and its dead `resolved_environment` assign, and passes the whole `%Nucleus.Scope{}` to the context per Phoenix 1.8 convention.
- `fetch_secrets/2`'s `case` now matches on `{kind, boundary}`, not `kind` alone, so the environment gate's `:unavailable` (`boundary: :tenant_api`, renders `#secrets-validation-unavailable`) and the secrets store's own `:unavailable` (`boundary: :secrets`, renders `#secrets-unavailable`) don't collapse into one misleading message. This also makes the `case` exhaustive against `Error.kinds/0`, fixing a latent bug: the prior `case` had no `:auth_expired` clause and would have raised `CaseClauseError` the first time either boundary returned it — it now renders a placeholder `#secrets-auth-expired` state pending SEC-S7.
- Stream rows are keyed by `"secret-" <> base64url(sha256(arn))`, configured once via `stream_configure/3` in `mount/3` — not a sanitised key, because SEC-S6 permits unicode, spaces, and dots in keys and no sanitisation scheme for a DOM id was ever defined. Each row also carries `data-key={ref.key}` for SEC-S3–S6 to select on instead of the row id.
- Path and ARN are visually truncated with CSS and a `title` attribute, but the full string stays in the DOM for SEC-S3 to copy from later. The mask is a fixed 8-character string, independent of the real value's length. `handle_event` placeholders for `"reveal"` and `"create_secret"` flash "not yet implemented" so neither control can crash the LiveView before SEC-S4/SEC-S6 replace them; a `"retry"` handler re-runs the fetch for the store-unavailable state.
- Satisfies `SEC-A01` (list with path/ARN/masked values) and `SEC-A14` (empty state with the create affordance present). `SEC-A02`–`A13`, `A18` remain out of scope per the issue's "Blocks" list (SEC-S3, SEC-S4, SEC-S6, SEC-S7).

## Record

ADR-0010 settles three things together: the context layer, not the LiveView, owns the single call to the environment gate; row DOM ids are hashed from the ARN rather than a sanitised key; and errors are matched on `{kind, boundary}` rather than `kind` alone. `decisions-log.md`, `business-tech-bridge.md` (SecretsLive now claims `SEC-A01`, `SEC-A14`–`A17`, not just `A15`–`A17`), and `living-notes.md` were updated — the latter closes the remaining half of the "SecretsLive was a placeholder" debt item and adds a new row for the `LOCAL_FORCE_ERROR` node-global limitation discovered while writing these tests.

## Divergence from the plan

The issue's own "Decisions taken at start of work" comment amended the plan before implementation started, on five points, and this PR follows that amended plan rather than the original issue body verbatim:

1. One context call, not the plan's separate environment-fetch-then-list — resolves a double-fetch the plan inherited from SEC-S1.
2. Row DOM id is an ARN hash, not `#secret-{key}` as tabulated in the issue body — the plan's key-sanitisation was never defined and would have needed guessing across four downstream tickets.
3. Sort tiebreak added (`{downcase(key), key}`, not just `downcase(key)`) to make the order total rather than merely case-folded.
4. No new seed data needed for the fixed-width-mask test — existing `prod` fixtures already span the needed length range.
5. The `:auth_expired` crash fix is folded into this ticket rather than filed separately, since it's in the same `case` this ticket edits.

One further correction beyond the comment thread: the issue body's DOM-ID table names the create button `#new-secret-button`, but the pre-existing SEC-S1 test suite already asserted `#secrets-create-button` in three tests. This PR keeps `#secrets-create-button` — the id already committed to by shipped tests — rather than renaming to match the ticket body.

## Verification

`mix precommit` passed clean at 376 tests (25 doctests, 351 tests), 0 failures. `test/nucleus/secrets_test.exs` (new) covers the `SecretRef` shape and the structural no-`value`-key guard, sort order and the case-fold tiebreak, the gate holding through the context layer (via a raising `Store` swap, mirroring the technique `environments_test.exs` uses for `TenantApi`), the `SEC-A14` empty result, and no audit event/no value in the audit trail. `test/nucleus_web/live/secrets_live_test.exs` was extended with `SEC-A01`/`SEC-A14` coverage per the issue's test plan, plus store-unavailable and placeholder-handler-doesn't-crash tests; all pre-existing `SEC-A15`–`17` tests still pass unmodified. Both test files work around `LOCAL_FORCE_ERROR` being node-global (see Record) by swapping in a failing `Nucleus.Secrets.Store` implementation directly, since a fault can't otherwise reach the `:secrets`-boundary branch through this LiveView.

Closes #10
