### PR TITLE
SEC-S4: reveal, hide, and handle a failed reveal

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -54,14 +54,19 @@ to cite from test names and bug reports.
 sidebar) and `test/nucleus_web/live/shell_test.exs` now exist (EN-7) — a deliberate subset only,
 with no `@tag action:` claimed, so `NAV-A01`–`A12` coverage is still zero until the dedicated
 `NAV-*` ticket lands. `NucleusWeb.SecretsLive` and `test/nucleus_web/live/secrets_live_test.exs`
-also now exist (SEC-S1/#9, SEC-S2/#10, SEC-S3/#11) — `SEC-A01`, `SEC-A02`, `SEC-A14`–`A17` are
-claimed and covered; the module validates and resolves the environment, lists a
-`Nucleus.Secrets` boundary's secrets with a masked value and reveal placeholder, copies a row's
-path/ARN to the clipboard (`SEC-A02` — wiring only; the clipboard write itself is a recorded
-browser gap, `docs/adr/0008-test-strategy.md`), and renders every fail-closed/empty state
-(`SEC-A03`–`A13`, `A18` are SEC-S4–S7 and later). Every other row is unimplemented. These names
-are the agreed target so that work lands consistently — treat them as the convention to follow,
-and correct this table if a better structure emerges.
+**Most "Planned" columns are still unimplemented.** `NucleusWeb.Layouts` (app shell, header,
+sidebar) and `test/nucleus_web/live/shell_test.exs` now exist (EN-7) — a deliberate subset only,
+with no `@tag action:` claimed, so `NAV-A01`–`A12` coverage is still zero until the dedicated
+`NAV-*` ticket lands. `NucleusWeb.SecretsLive` and `test/nucleus_web/live/secrets_live_test.exs`
+also now exist (SEC-S1/#9, SEC-S2/#10, SEC-S3/#11, SEC-S4/#12) — `SEC-A01`–`A05`, `SEC-A14`–`A17`
+are claimed and covered; the module validates and resolves the environment, lists a
+`Nucleus.Secrets` boundary's secrets with a masked value, copies a row's path/ARN to the
+clipboard (`SEC-A02` — wiring only; the clipboard write itself is a recorded browser gap,
+`docs/adr/0008-test-strategy.md`), reveals/hides a value per row with a fresh audited fetch on
+every reveal, and renders every fail-closed/empty/failed-reveal state (`SEC-A06`–`A13`, `A18`
+are SEC-S5–S7 and later). Every other row is unimplemented. These names are the agreed target
+so that work lands consistently — treat them as the convention to follow, and correct this
+table if a better structure emerges.
 
 ## Tagging Convention
 

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.11 | Updated: 2026-08-17 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.12 | Updated: 2026-08-18 -->
 
 # Decisions Log
 
@@ -35,6 +35,7 @@ job and the row should point rather than paraphrase.
 | 8 | Test strategy — `Phoenix.LiveViewTest` + `PhoenixTest`, no browser driver (`SEC-A02`/`SEC-A13` left as recorded browser-only gaps); `BackendCase`/`AuditCase`/`LiveCase`; `mix nucleus.trace` report-only | 2026-08-14 | Decided | `docs/adr/0008-test-strategy.md` |
 | 9 | Environment validation ladder — allowlist over denylist, strict validate-then-fetch ordering, no cache/no fallback ever, validation errors tagged `boundary: :tenant_api` | 2026-08-14 | Decided | `docs/adr/0009-environment-validation-ladder.md` |
 | 10 | Secrets listing — one context call replaces two, ARN-hashed DOM ids with `data-key` carrying the real key, errors matched on `{kind, boundary}` | 2026-08-17 | Decided | `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md` |
+| 11 | Secret reveal — re-stream a converted `SecretRef` (never the value-bearing `Secret`), audit `user:` via `Scope.audit_user/1`, `Nucleus.Audit.Sink.Test` falls back to `$callers` for LiveView-emitted audit events | 2026-08-18 | Decided | `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -50,7 +51,7 @@ being edited in place, so the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0010` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0011` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -19,6 +19,7 @@
 | Nucleus's own AWS identity (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) is read ambiently by the `aws` package, with no boot-time check or ops-facing doc — unlike `TENANT_ROLE_ARN`/`AWS_REGION`/`CLUSTER_NAME`/`DEPLOYMENT_NAME`, which all raise at boot | A misconfigured deployment fails per-request as `:not_configured` on first `AssumeRole` call, not at boot | Low | `CLUSTER_NAME`/`DEPLOYMENT_NAME` are now correctly documented in the wiki's `Platform-Operations.md` config reference (issue #22). The ambient `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` doc gap remains open — was out of scope for #22 |
 | No browser-driven test coverage for `SEC-A02` (the `navigator.clipboard.writeText` call itself, the confirmation icon swap/revert, the non-secure-context `execCommand` fallback, and the failure indication) or `SEC-A13` (Escape dismissal, focus trap, focus restoration) — `navigator.clipboard` and real key/focus events need a browser, which this repo has no driver for | Tests assert wiring only (hook attached, `data-value` full/untruncated, `phx-update="ignore"` present, `on_cancel` set), never claim `@tag action:` for these IDs — a real regression would not be caught until a browser harness exists | Medium | Add Wallaby once sign-in exists (deferred, EN-8); see `docs/adr/0008-test-strategy.md`. `SEC-S3`'s four gaps are also a skipped `:browser`-tagged placeholder module in `secrets_live_test.exs` |
 | `LOCAL_FORCE_ERROR` (`Nucleus.Backend.Faults`) is node-global, not per-boundary — a fault set for one boundary is seen by every local implementation's next call | A test targeting the `:secrets` boundary's error path is actually caught by whichever boundary is called first; SEC-S2 found this when `Nucleus.Secrets.list/2`'s `Environments.fetch/2` gate always intercepted the fault before `Store.list_secrets/1` ran | Low | Swap in a real/failing module via `Application.put_env(:nucleus, :backends, ...)` instead of `force_error/2` for a specific-boundary test — see `SecretsLiveTest.FailingSecretsStore` |
+| `Nucleus.Secrets.reveal/3`'s key validator is a second, weaker copy of `Environments.validate_name/1`'s deny-list (`..`, `/`, `\`, null byte only — no charset allowlist, no length cap) | A forged key using percent-double-encoding or a control character other than a null byte could still reach `Store.get_secret/2`/`Path.build/2`; cross-environment traversal is still blocked since `/`, `..`, `\` are denied | Low | `SEC-S6` (issue #14, `needs-decision`) should replace this with one shared validator, not add a third — see `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` |
 
 ### Technical Debt Details
 
@@ -110,6 +111,11 @@ deploys it.
   assign depends on another's (`EnvironmentsHook` reads `current_scope.token` after
   `ScopeHook` assigns it) — see `docs/adr/0006-application-shell-and-live-session-composition.md`.
   Keeps every view under the session correct without each one opting in individually.
+- `Nucleus.Audit.Sink.Test` falls back to `Process.get(:"$callers")` when the writing process
+  has no direct `register/1` call — reaches a test's own `AuditCase` registration from inside a
+  mounted LiveView, using the same ancestry chain Ecto's SQL Sandbox relies on. Any test
+  asserting on an audit event emitted from a `handle_event/3` gets this for free; no per-ticket
+  sink workaround needed. See `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`.
 
 ### Gotchas for Maintainers
 - **Requirements are a submodule.** Fresh clones need

--- a/docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md
+++ b/docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md
@@ -1,0 +1,178 @@
+# ADR-0011: Secret Reveal — Stream Re-Insertion, Audit Identity, and the Test Sink's `$callers` Fallback
+
+## Status
+
+Accepted — 2026-08-18
+
+Decided on [SEC-S4](https://github.com/dave-bell/nucleus/issues/12). Builds on
+`0010-secrets-listing-gate-collapse-and-dom-ids.md` (the ARN-hashed DOM id
+this ticket re-streams against) and `0004-audit-emission.md` (the sink and
+per-event allowlist this ticket is the first to actually wire to a call
+site).
+
+## Context
+
+SEC-S4 implements `SEC-A03`–`A05`: reveal a secret's plaintext value, hide it
+again, and handle a failed reveal without an unexplained blank state. Three
+things the plan left open needed settling during implementation:
+
+1. `Nucleus.Secrets.list/2` returns `SecretRef` (no `value` field);
+   `reveal/3` is the first function to call `Store.get_secret/2` and produce
+   a `Secret` (which has one). `SecretsLive` streams `SecretRef` structs —
+   what does a reveal or hide actually re-stream, and does the plaintext
+   ever touch the stream's own state?
+2. This is the first real call site for `Nucleus.Audit.emit/2` — EN-5 built
+   the emitter and its allowlist, but nothing before this ticket actually
+   called it from application code. What identity does `user:` carry, and
+   does it hold up once a signed-in user's Cognito token has no `email`
+   claim (a case `Nucleus.Scope.audit_user/1` already exists to handle)?
+3. `Nucleus.Audit.Sink.Test` delivers a record to whichever process called
+   `register/1` — by design, since every prior audit-emitting call ran
+   directly in the test process. `reveal/3` is now called from inside a
+   `handle_event/3` in a *mounted LiveView*, a distinct GenServer process a
+   test never calls `register/1` from. Testing "hiding emits no audit
+   event" and "reveal → hide → reveal emits two events" — both explicitly
+   asked for in the ticket's test plan — requires the sink to reach the test
+   process from inside that spawned view.
+4. `SEC-A05` requires `:auth_expired` be handled without crashing, but
+   `SEC-S7` (the ticket that owns that failure mode's shared retry handler)
+   is still open. What does `reveal/3`'s failure path show in the meantime?
+
+## Decision
+
+### Re-stream a converted `SecretRef`, never the `Secret`
+
+`handle_event("reveal"/"hide", ...)` converts the `Secret` back to a
+`SecretRef` (`key`, `path`, `arn`, `last_modified` — dropping `value`) before
+`stream_insert/3`. The stream itself never carries a struct with a `value`
+field, on either branch — the plaintext lives only in a new `:revealed`
+assign (`%{key => Secret.t()}`), read directly in the template. This means
+an accidental `inspect(@streams.secrets)` in a future debugging session, or
+a LiveView introspection tool that dumps stream state, still cannot leak a
+value; only `@revealed` can, and only for keys the user actually revealed.
+
+Re-streaming (rather than only updating `:revealed`) is required by
+`AGENTS.md`'s rule that an assign changing content *inside* a streamed item
+must re-insert that item — `:revealed` is not itself part of the stream
+item, so without this the row would not re-render on reveal or hide at all.
+The DOM id is unaffected: `dom_id/1` now matches on both `SecretRef` and
+`Secret` (same ARN, same hash), so a reveal or hide never changes which row
+it targets.
+
+### Audit `user:` is `Nucleus.Scope.audit_user/1`, not a raw `email` read
+
+`reveal/3` emits `user: Scope.audit_user(scope)`, not `scope.user &&
+scope.user.email`. `audit_user/1` already existed (built with EN-6's
+`Nucleus.Scope`) for exactly this: Cognito access tokens can carry no
+`email` claim, so it falls back to `username`, then `"anonymous"`, and
+guards against a blank-but-non-nil `email` being recorded as the audit
+user. `Nucleus.Audit.emit/2`'s own `nil`-to-`"anonymous"` fallback only
+covers an absent field — it does not know about `username` or reject `""` —
+so calling it with a raw `email` read would have silently misattributed a
+real Cognito user to `"anonymous"` the first time `email` was absent,
+undetectable in this ticket's own tests since the dev scope fixture always
+populates `email`. Every future `Audit.emit/2` call site (`SEC-S6`'s
+`secret_created`, `SEC-S5`'s `secret_updated`) should call `audit_user/1`
+for the same reason, not repeat the raw read.
+
+### `Nucleus.Audit.Sink.Test` falls back to `Process.get(:"$callers")`
+
+`write/1` now checks the writing process's own registration first (existing
+behaviour, unchanged for every context-level test that emits directly), and
+falls back to the first pid in `$callers` when none is set. Empirically,
+`Phoenix.LiveViewTest` sets `$callers` on a mounted view's process to the
+test process that called `live/2` — the same ancestry chain Ecto's SQL
+Sandbox relies on for its own process-allowance mechanism, already present
+in this stack's dependencies with no additional wiring needed. This reaches
+exactly the process that already called `Nucleus.Audit.Sink.Test.register/1`
+in `AuditCase`'s `setup`, with no LiveView code aware that a test is
+watching, and no change to `register/1`'s existing per-process contract.
+
+### `:auth_expired` gets local, honest copy — not a borrowed handler
+
+The ticket's plan called for delegating to "the shared handler `SEC-S7`
+introduces." `SEC-S7` (issue #15) is still open, so `reveal/3`'s failure
+`case` renders its own flash text for `:auth_expired`
+("This environment's secrets can't be reached right now.") rather than
+inventing a cross-cutting handler function prematurely — `SEC-S7`'s own
+plan says the handler must end up in exactly one place, and building it
+here first would mean `SEC-S7` either keeping this copy as-is or rewriting
+a call site outside its own ticket. This is a divergence from the plan as
+written, tracked so `SEC-S7` replaces it deliberately rather than
+discovering it by accident.
+
+### Key validation stays a minimal, explicitly weaker deny list
+
+`reveal/3` rejects `..`, `/`, `\`, and a null byte in `key` before calling
+`Store.get_secret/2` — the minimum needed to stop a forged `phx-value-key`
+from reaching `Path.build/2` and resolving into another environment's
+bucket. This is deliberately **not** as strong as
+`Environments.validate_name/1`, which layers a positive charset allowlist
+and a length cap on the same denylist, for the reason that module's own doc
+gives: a denylist alone lets percent-encoded traversal and unicode
+lookalikes through. `SEC-S6` (issue #14, still `needs-decision`) owns the
+authoritative key rules for secret creation; this validator is provisional
+pending that ticket's consolidation, not a claim of equivalent strength.
+
+## Consequences
+
+### Positive
+
+- No path from a reveal or hide to a value leaking into stream state,
+  independent of what leaks into `:revealed` — two different failure modes
+  would have to both go wrong for a value to reach the DOM outside the
+  template's own `@revealed` read.
+- `Nucleus.Audit.Sink.Test`'s `$callers` fallback is generic — `SEC-S5`
+  (`secret_updated`) and `SEC-S6` (`secret_created`) get audit-assertion
+  support in their own LiveView tests for free, with no per-ticket sink
+  workaround to invent.
+- `audit_user/1` is now proven at a real call site, not just defined and
+  doctested.
+
+### Negative
+
+- The `:auth_expired` flash copy written here is throwaway the moment
+  `SEC-S7` lands — a deliberate, tracked cost, not an oversight.
+- The key validator's deny list is a second, slightly different copy of
+  logic that already exists once in `Environments.validate_name/1`. `SEC-S6`
+  inherits an explicit obligation to consolidate rather than leave two
+  slightly-different validators live.
+
+## Alternatives considered
+
+**Keep streaming `Secret` structs directly, relying on the template to
+never render `.value` for an unrevealed row.** Rejected — this is exactly
+the "single struct, optional value, one forgotten branch away from a leak"
+shape `Nucleus.Secrets.Secret`'s own moduledoc was written to make
+impossible. Converting back to `SecretRef` before `stream_insert/3` keeps
+that guarantee intact through this ticket's own change.
+
+**Register the mounted view's pid explicitly from each test, via some new
+test helper, instead of extending the sink.** Rejected — there is no public
+API to execute code inside an already-running LiveView process from a test
+process; `register/1` stores its argument in the *calling* process's own
+dictionary, so calling it with `view.pid` from the test process would only
+overwrite the test process's own entry, not reach the view. The `$callers`
+fallback is the only mechanism available that runs inside the view process
+itself without adding test-awareness to `NucleusWeb.SecretsLive`.
+
+**Build `SEC-S7`'s shared `:auth_expired` handler now, since this ticket
+needs the copy anyway.** Rejected — pulls a not-yet-decided ticket's design
+forward under time pressure from an unrelated one; `SEC-S7`'s plan expects
+to consolidate every `:auth_expired` branch in the codebase, not just this
+one, into a single function.
+
+## References
+
+- SEC-S4 (issue #12) — the deciding issue
+- `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md` — the
+  ARN-hashed DOM id this ticket's re-streaming preserves
+- `docs/adr/0004-audit-emission.md` — the sink and per-event allowlist this
+  ticket is the first to call from application code
+- `docs/adr/0009-environment-validation-ladder.md` — the denylist-vs-allowlist
+  reasoning this ticket's key validator is explicitly weaker than
+- `AGENTS.md` — the stream re-insertion rule this ticket's reveal/hide
+  handlers follow
+- Wiki [Secrets](https://github.com/dave-bell/nucleus/wiki/Secrets)
+  `SEC-A03`–`A05`; [Audit & Compliance](https://github.com/dave-bell/nucleus/wiki/Audit-and-Compliance)
+  `AUD-A01`, `AUD-A02`

--- a/lib/nucleus/audit/sink/test.ex
+++ b/lib/nucleus/audit/sink/test.ex
@@ -10,6 +10,22 @@ defmodule Nucleus.Audit.Sink.Test do
 
   EN-8's `AuditCase` and its `refute_audit_contains/1` helper are built on
   this module.
+
+  ## Falling back to `$callers` (`SEC-S4`)
+
+  Every audit call before `SEC-S4` ran directly in the test process (a
+  context function called straight from a `test` block), so `register/1`
+  having been called there was always enough. `SEC-S4` is the first ticket
+  to emit from *inside* a mounted LiveView — a distinct GenServer process a
+  test never calls `register/1` from directly. Rather than have every such
+  test reach into the view process to register itself (there is no public
+  API to run code there), `write/1` falls back to `Process.get(:"$callers")`
+  when the writing process has no direct registration of its own.
+  `Phoenix.LiveViewTest` sets `$callers` on the spawned view process to the
+  test process that mounted it — the same ancestry Ecto's SQL Sandbox relies
+  on for its own process-allowance mechanism — so the fallback reaches
+  exactly the process that already called `register/1` in its `AuditCase`
+  `setup`, with no LiveView code aware that a test is watching.
   """
 
   @behaviour Nucleus.Audit.Sink
@@ -28,7 +44,7 @@ defmodule Nucleus.Audit.Sink.Test do
 
   @impl Nucleus.Audit.Sink
   def write(iodata) do
-    case Process.get(@key) do
+    case receiver() do
       nil ->
         raise "Nucleus.Audit.Sink.Test has no registered process — call " <>
                 "Nucleus.Audit.Sink.Test.register/1 before emitting an audit event in a test"
@@ -36,6 +52,19 @@ defmodule Nucleus.Audit.Sink.Test do
       pid ->
         send(pid, {:audit, IO.iodata_to_binary(iodata)})
         :ok
+    end
+  end
+
+  defp receiver do
+    case Process.get(@key) do
+      nil ->
+        case Process.get(:"$callers") do
+          [pid | _] -> pid
+          _no_callers -> nil
+        end
+
+      pid ->
+        pid
     end
   end
 end

--- a/lib/nucleus/secrets.ex
+++ b/lib/nucleus/secrets.ex
@@ -25,11 +25,21 @@ defmodule Nucleus.Secrets do
   Callers distinguish the two boundaries' `:unavailable` errors by matching
   on `error.boundary`, not just `error.kind` — both arrive with
   `kind: :unavailable`.
+
+  ## `reveal/3` owns the one plaintext fetch (`SEC-S4`)
+
+  `list/2` deliberately never calls `Store.get_secret/2` — see its own doc.
+  `reveal/3` is the only function in this module that does, and the only one
+  that emits `:secret_viewed`. Keeping the two separate means `SEC-A01`'s
+  "never included in the listing response" is not something a future change
+  to `list/2` could quietly break by merging in a value.
   """
 
+  alias Nucleus.Audit
   alias Nucleus.Backend.Error
   alias Nucleus.Environments
   alias Nucleus.Scope
+  alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
   alias Nucleus.Secrets.Store
 
@@ -68,7 +78,99 @@ defmodule Nucleus.Secrets do
     end
   end
 
+  @doc """
+  Reveals `key`'s plaintext value in `environment`, re-validating both
+  before either reaches the store or a path is built (`SEC-A03`).
+
+  Strict order:
+
+  1. `Nucleus.Environments.fetch/2` — re-validate the environment, the same
+     gate `list/2` uses. Never trust an environment name arriving from a
+     client-originated event.
+  2. The **key** shape, validated here. `key` comes from `phx-value-key`,
+     which a client can forge — an attacker-supplied key such as
+     `"../../other-env/secret"` must never reach
+     `Nucleus.Secrets.Path.build/2`, which concatenates its arguments
+     verbatim. `SEC-S6` (key creation) owns the authoritative key rules;
+     until it lands, this rejects only `..`, `/`, `\`, and a null byte as
+     `{:error, kind: :invalid}`, **before** the store is ever called. This
+     is deliberately **not** as strong as
+     `Nucleus.Environments.validate_name/1`, which layers a positive
+     charset allowlist and a length cap on top of the same denylist for
+     exactly the reason its own moduledoc gives — a denylist alone lets
+     percent-encoded traversal, unicode lookalikes, and other control
+     characters through. Blocking `/`, `..`, and `\` is enough to stop a
+     forged key from reaching another environment's Parameter Store path,
+     which is the concrete risk this function guards against, but `SEC-S6`
+     should not assume this validator is a drop-in replacement for
+     `validate_name/1`'s stronger guarantee when it consolidates the two.
+  3. `Nucleus.Secrets.Store.get_secret/2` — the one place in this module a
+     value is fetched.
+
+  On success **only**, emits `secret_viewed` with `resource` set to the
+  full parameter path (`secret.path`, built by `Nucleus.Secrets.Path.build/2`
+  inside the store) — never the bare key. Emitting before the fetch would
+  record views that never happened; emitting on failure would too, so a
+  failed reveal is not a view and produces no audit record at all. `source_ip`
+  is not part of `secret_viewed`'s catalogue entry (see
+  `Nucleus.Audit.Event.spec/1`) and must not be passed. `user` comes from
+  `Nucleus.Scope.audit_user/1`, not a raw `scope.user.email` read — Cognito
+  access tokens carry no `email` claim for some users, and `audit_user/1`
+  falls back to `username`, then `"anonymous"`, so a signed-in reveal is
+  never misattributed to "anonymous" just because `email` happened to be
+  `nil` or blank.
+
+  Never logs, caches, or memoises the value on any branch — a fresh
+  `Store.get_secret/2` call happens on every reveal, including a
+  hide/re-reveal cycle, so a second reveal produces a second `secret_viewed`
+  record.
+  """
+  @spec reveal(environment :: String.t(), key :: String.t(), scope :: Scope.t()) ::
+          {:ok, Secret.t()} | {:error, Error.t()}
+  def reveal(environment, key, %Scope{token: token} = scope)
+      when is_binary(environment) and is_binary(key) do
+    with {:ok, _environment} <- Environments.fetch(environment, token),
+         :ok <- validate_key(key),
+         {:ok, secret} <- Store.get_secret(environment, key) do
+      :ok =
+        Audit.emit(:secret_viewed,
+          user: Scope.audit_user(scope),
+          tenant: scope.tenant,
+          resource: secret.path
+        )
+
+      {:ok, secret}
+    end
+  end
+
   defp sort(refs) do
     Enum.sort_by(refs, &{String.downcase(&1.key), &1.key})
+  end
+
+  # Minimal deny checks, pending `SEC-S6`'s consolidated key validator — see
+  # `reveal/3`'s doc for why this is weaker than
+  # `Nucleus.Environments.validate_name/1` and why that gap is acceptable
+  # for now.
+  defp validate_key(key) do
+    cond do
+      key == "" ->
+        invalid_key(key)
+
+      String.contains?(key, "..") ->
+        invalid_key(key)
+
+      String.contains?(key, "/") or String.contains?(key, "\\") ->
+        invalid_key(key)
+
+      String.contains?(key, <<0>>) ->
+        invalid_key(key)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp invalid_key(key) do
+    {:error, Error.new(:invalid, Store.boundary(), "invalid secret key", %{key: inspect(key)})}
   end
 end

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -64,11 +64,11 @@ defmodule NucleusWeb.SecretsLive do
   which have no `value` field — this module cannot render, prefetch, or leak
   a value during listing even by accident. The "Value" column renders a
   fixed-width mask that does not depend on the real value's length (which
-  would leak it). Revealing a value is `SEC-S4`'s `handle_event("reveal", …)`
-  — this module renders the control and a placeholder handler so a click
-  cannot crash the LiveView before that ticket replaces it. Creating a
-  secret is `SEC-S6`'s modal; the same placeholder-handler rule applies to
-  the create button.
+  would leak it), unless the row's key is in `:revealed` — see "Reveal, hide,
+  and a failed reveal" below for that state. Creating a secret is `SEC-S6`'s
+  modal; this module still only renders a placeholder handler for the create
+  button so a click cannot crash the LiveView before that ticket replaces
+  it.
 
   ## Row DOM ids are a hash of the ARN, not the key (`SEC-S2` decision 2)
 
@@ -95,12 +95,44 @@ defmodule NucleusWeb.SecretsLive do
   Button ids are suffixed with the row's `dom_id`, so they stay unique and
   stable across the same `stream_insert/3` churn the row id itself is
   designed to survive.
+
+  ## Reveal, hide, and a failed reveal (`SEC-S4`)
+
+  `:revealed` is a `%{key => Nucleus.Secrets.Secret.t()}` map — only the
+  secrets a user has actually revealed are in it, and each entry carries its
+  own fresh plaintext value. Nothing here caches a value across a
+  hide/re-reveal cycle: `handle_event("reveal", ...)` always calls
+  `Nucleus.Secrets.reveal/3` again, which is a fresh `Store.get_secret/2`
+  call and a fresh `secret_viewed` audit record every time (`SEC-A03`).
+
+  **Every reveal or hide re-streams the row** (`stream_insert/3`), converting
+  the `Secret` back to a `SecretRef` first — `AGENTS.md` is explicit that an
+  assign changing content *inside* a streamed item must re-stream that item,
+  and this is the single most likely cause of a "reveal does nothing" bug.
+  The stream itself still only ever carries `SecretRef` structs, which have
+  no `value` field — the plaintext lives only in the `:revealed` assign, read
+  directly from `@revealed` in the template, never smuggled into the stream.
+
+  A failed reveal (`SEC-A05`) leaves `:revealed` untouched — the value stays
+  masked, the control stays "View", and a kind-specific flash explains what
+  happened. `:auth_expired` does not yet have `SEC-S7`'s shared handler to
+  delegate to (that ticket is still open) — the copy here is deliberately
+  generic and will move under that handler once it lands, not duplicate it.
+
+  Hiding is local-only: it deletes the key from `:revealed` and re-streams
+  the row, with no backend call and no audit event — the wiki's audit
+  catalogue has no event for hiding a value.
+
+  `:revealed` is reset to `%{}` on every `handle_params/3` call, so patching
+  between environments (or navigating back to this same route) never carries
+  a previously-revealed plaintext value across.
   """
 
   use NucleusWeb, :live_view
 
   alias Nucleus.Backend.Error
   alias Nucleus.Secrets
+  alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
 
   @masked_value "••••••••"
@@ -120,14 +152,44 @@ defmodule NucleusWeb.SecretsLive do
     socket =
       socket
       |> assign(:environment, environment)
+      |> assign(:revealed, %{})
       |> fetch_secrets(environment)
 
     {:noreply, socket}
   end
 
   @impl Phoenix.LiveView
-  def handle_event("reveal", %{"key" => _key}, socket) do
-    {:noreply, put_flash(socket, :info, "Revealing a secret's value is not yet implemented.")}
+  def handle_event("reveal", %{"key" => key}, socket) do
+    case Secrets.reveal(socket.assigns.environment, key, socket.assigns.current_scope) do
+      {:ok, secret} ->
+        socket =
+          socket
+          |> update(:revealed, &Map.put(&1, key, secret))
+          |> stream_insert(:secrets, to_secret_ref(secret))
+
+        {:noreply, socket}
+
+      {:error, %Error{} = error} ->
+        {:noreply, put_flash(socket, :error, reveal_error_message(error))}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("hide", %{"key" => key}, socket) do
+    {secret, revealed} = Map.pop(socket.assigns.revealed, key)
+
+    socket =
+      case secret do
+        nil ->
+          assign(socket, :revealed, revealed)
+
+        %Secret{} = secret ->
+          socket
+          |> assign(:revealed, revealed)
+          |> stream_insert(:secrets, to_secret_ref(secret))
+      end
+
+    {:noreply, socket}
   end
 
   @impl Phoenix.LiveView
@@ -232,6 +294,7 @@ defmodule NucleusWeb.SecretsLive do
             </thead>
             <tbody id="secrets-table-body" phx-update="stream">
               <tr :for={{dom_id, ref} <- @streams.secrets} id={dom_id} data-key={ref.key}>
+                <% revealed = Map.get(@revealed, ref.key) %>
                 <td>{ref.key}</td>
                 <td>
                   <div class="flex items-center gap-1">
@@ -247,18 +310,30 @@ defmodule NucleusWeb.SecretsLive do
                 </td>
                 <td>{format_last_modified(ref.last_modified)}</td>
                 <td>
-                  <span aria-hidden="true">{masked_value()}</span>
-                  <span class="sr-only">value hidden</span>
+                  <div :if={revealed} class="flex items-center gap-2">
+                    <span id={secret_value_id(dom_id)} class="font-mono text-sm break-all">
+                      {revealed.value}
+                    </span>
+                    <.copy_button
+                      id={copy_value_id(dom_id)}
+                      value={revealed.value}
+                      label="Copy value"
+                    />
+                  </div>
+                  <div :if={!revealed}>
+                    <span aria-hidden="true">{masked_value()}</span>
+                    <span class="sr-only">value hidden</span>
+                  </div>
                 </td>
                 <td>
                   <button
                     id={reveal_id(dom_id)}
                     type="button"
                     class="btn btn-sm"
-                    phx-click="reveal"
+                    phx-click={if revealed, do: "hide", else: "reveal"}
                     phx-value-key={ref.key}
                   >
-                    View
+                    {if revealed, do: "Hide", else: "View"}
                   </button>
                 </td>
               </tr>
@@ -272,11 +347,44 @@ defmodule NucleusWeb.SecretsLive do
 
   defp masked_value, do: @masked_value
 
-  defp dom_id(%SecretRef{arn: arn}) do
+  defp dom_id(%SecretRef{arn: arn}), do: dom_id_from_arn(arn)
+  defp dom_id(%Secret{arn: arn}), do: dom_id_from_arn(arn)
+
+  defp dom_id_from_arn(arn) do
     "secret-" <> (:crypto.hash(:sha256, arn) |> Base.url_encode64(padding: false))
   end
 
   defp reveal_id("secret-" <> hash), do: "reveal-" <> hash
+  defp secret_value_id("secret-" <> hash), do: "secret-value-" <> hash
+  defp copy_value_id("secret-" <> hash), do: "copy-value-" <> hash
+
+  # The stream only ever carries `SecretRef` structs — no `value` field — so
+  # a reveal or hide converts the `Secret` back before re-streaming
+  # (`stream_insert/3`). The plaintext itself lives only in the `:revealed`
+  # assign, read directly in the template.
+  defp to_secret_ref(%Secret{key: key, path: path, arn: arn, last_modified: last_modified}) do
+    %SecretRef{key: key, path: path, arn: arn, last_modified: last_modified}
+  end
+
+  defp reveal_error_message(%Error{kind: :not_found}) do
+    "This secret no longer exists. It may have been removed outside Nucleus."
+  end
+
+  defp reveal_error_message(%Error{kind: :auth_expired}) do
+    "This environment's secrets can't be reached right now."
+  end
+
+  defp reveal_error_message(%Error{kind: :unavailable}) do
+    "Can't retrieve this secret's value right now. Try again shortly."
+  end
+
+  defp reveal_error_message(%Error{kind: :invalid}) do
+    "That secret key isn't valid."
+  end
+
+  defp reveal_error_message(%Error{}) do
+    "Can't retrieve this secret's value right now. Try again shortly."
+  end
 
   defp format_last_modified(nil), do: "—"
 

--- a/test/nucleus/secrets_test.exs
+++ b/test/nucleus/secrets_test.exs
@@ -6,12 +6,16 @@ defmodule Nucleus.SecretsTest do
   use Nucleus.BackendCase, async: false
   use Nucleus.AuditCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias Nucleus.Backend.Error
   alias Nucleus.Scope
   alias Nucleus.Secrets
+  alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
 
   @scope %Scope{tenant: "acme", user: %{email: "a@b.com", username: nil}}
+  @db_url_value "postgres://app:s3cr3t@prod-db.internal:5432/app"
 
   defmodule ExplodingSecretsStore do
     @moduledoc """
@@ -55,6 +59,61 @@ defmodule Nucleus.SecretsTest do
       :nucleus,
       :backends,
       Keyword.put(original, :secrets, ExplodingSecretsStore)
+    )
+  end
+
+  defmodule FailingGetSecretStore do
+    @moduledoc """
+    A `Nucleus.Secrets.Store` implementation whose `get_secret/2` always
+    fails `:unavailable`, for the `SEC-A05` test that needs a store-level
+    failure `reveal/3` cannot short-circuit before reaching.
+
+    `Nucleus.BackendCase.force_error/2` cannot exercise this: the underlying
+    `LOCAL_FORCE_ERROR` fault is node-global and checked by
+    `Nucleus.TenantApi.Local` too, so it would be caught by `reveal/3`'s
+    environment gate first (`boundary: :tenant_api`) and the store would
+    never be reached — the same reasoning
+    `NucleusWeb.SecretsLiveTest.FailingSecretsStore` documents. Swapping the
+    `:secrets` boundary's implementation instead is the only way to force a
+    `boundary: :secrets` failure here.
+    """
+    @behaviour Nucleus.Secrets.Store
+
+    @impl Nucleus.Secrets.Store
+    def list_secrets(_environment), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def get_secret(_environment, _key) do
+      {:error, Error.new(:unavailable, :secrets, "forced for test", %{})}
+    end
+
+    @impl Nucleus.Secrets.Store
+    def create_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def update_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def locate_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_environments, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_all_secrets, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_failing_get_secret_store do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, FailingGetSecretStore)
     )
   end
 
@@ -128,7 +187,101 @@ defmodule Nucleus.SecretsTest do
     test "does not leak a seeded secret's value into the audit trail" do
       Secrets.list("prod", @scope)
 
-      refute_audit_contains("postgres://app:s3cr3t@prod-db.internal:5432/app")
+      refute_audit_contains(@db_url_value)
+    end
+  end
+
+  describe "reveal/3 — SEC-A03 success" do
+    @tag action: "SEC-A03"
+    test "returns {:ok, %Secret{value: expected}}" do
+      assert {:ok, %Secret{} = secret} = Secrets.reveal("prod", "DATABASE_URL", @scope)
+
+      assert secret.key == "DATABASE_URL"
+      assert secret.value == @db_url_value
+    end
+
+    @tag action: "SEC-A03"
+    test "emits exactly one secret_viewed with resource equal to the full path" do
+      assert {:ok, secret} = Secrets.reveal("prod", "DATABASE_URL", @scope)
+
+      assert_audit_event(:secret_viewed, tenant: "acme", resource: secret.path)
+      assert length(audit_events()) == 1
+    end
+
+    @tag action: "SEC-A03"
+    test "user is Scope.audit_user/1's result, falling back to username when email is absent" do
+      scope = %Scope{tenant: "acme", user: %{email: nil, username: "auser"}}
+
+      Secrets.reveal("prod", "DATABASE_URL", scope)
+
+      assert_audit_event(:secret_viewed, user: "auser")
+    end
+
+    @tag action: "SEC-A03"
+    test "resource is the full path, not the bare key" do
+      assert {:ok, secret} = Secrets.reveal("prod", "DATABASE_URL", @scope)
+
+      record = assert_audit_event(:secret_viewed)
+      assert record.resource == secret.path
+      refute record.resource == "DATABASE_URL"
+    end
+
+    @tag action: "SEC-A03"
+    test "the AUD-A02 guard — the value appears in no audit record" do
+      Secrets.reveal("prod", "DATABASE_URL", @scope)
+
+      refute_audit_contains(@db_url_value)
+    end
+
+    @tag action: "SEC-A03"
+    test "two reveals emit two secret_viewed events" do
+      Secrets.reveal("prod", "DATABASE_URL", @scope)
+      Secrets.reveal("prod", "DATABASE_URL", @scope)
+
+      events = Enum.filter(audit_events(), &(&1.event == :secret_viewed))
+      assert length(events) == 2
+    end
+  end
+
+  describe "reveal/3 — SEC-A05 failed reveal" do
+    @tag action: "SEC-A05"
+    test "a store :not_found emits no audit event" do
+      assert {:error, %Error{kind: :not_found}} =
+               Secrets.reveal("prod", "NO_SUCH_KEY", @scope)
+
+      assert_no_audit_event(:secret_viewed)
+    end
+
+    @tag action: "SEC-A05"
+    test "a forced store :unavailable emits no audit event" do
+      use_failing_get_secret_store()
+
+      assert {:error, %Error{kind: :unavailable, boundary: :secrets}} =
+               Secrets.reveal("prod", "DATABASE_URL", @scope)
+
+      assert_no_audit_event(:secret_viewed)
+    end
+
+    @tag action: "SEC-A05"
+    test "a forged key containing '..' is rejected with :invalid, no store call, no audit event" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.reveal("prod", "../../other-env/secret", @scope)
+
+      assert_no_audit_event(:secret_viewed)
+    end
+
+    @tag action: "SEC-A05"
+    test "the value appears in no log line, on any branch" do
+      log =
+        capture_log(fn ->
+          Secrets.reveal("prod", "DATABASE_URL", @scope)
+          Secrets.reveal("prod", "NO_SUCH_KEY", @scope)
+          Secrets.reveal("prod", "../../other-env/secret", @scope)
+        end)
+
+      refute log =~ @db_url_value
     end
   end
 end

--- a/test/nucleus_web/live/secrets_live_test.exs
+++ b/test/nucleus_web/live/secrets_live_test.exs
@@ -8,15 +8,17 @@ defmodule NucleusWeb.SecretsLiveTest do
   defmodule FailingSecretsStore do
     @moduledoc """
     A `Nucleus.Secrets.Store` implementation that always fails `list_secrets/1`
-    with a controllable `Nucleus.Backend.Error`.
+    and `get_secret/2` with a controllable `Nucleus.Backend.Error`.
 
     `Nucleus.Backend.Faults`' `LOCAL_FORCE_ERROR` is node-global and checked by
-    `Nucleus.TenantApi.Local` too — since `Nucleus.Secrets.list/2` gates through
-    `Nucleus.Environments.fetch/2` first, a global fault is always caught there
-    (`boundary: :tenant_api`) and the store is never reached. Swapping the
-    `:secrets` boundary's implementation instead, the same technique
+    `Nucleus.TenantApi.Local` too — since `Nucleus.Secrets.list/2` and
+    `Nucleus.Secrets.reveal/3` both gate through `Nucleus.Environments.fetch/2`
+    first, a global fault is always caught there (`boundary: :tenant_api`) and
+    the store is never reached. Swapping the `:secrets` boundary's
+    implementation instead, the same technique
     `test/nucleus/environments_test.exs`'s `ExplodingTenantApi` uses, is the
-    only way to exercise a `boundary: :secrets` failure from this LiveView.
+    only way to exercise a `boundary: :secrets` failure from this LiveView —
+    for both listing (`SEC-A17`) and a failed reveal (`SEC-A05`).
     """
     @behaviour Nucleus.Secrets.Store
 
@@ -26,7 +28,9 @@ defmodule NucleusWeb.SecretsLiveTest do
     end
 
     @impl Nucleus.Secrets.Store
-    def get_secret(_environment, _key), do: raise("should not be called")
+    def get_secret(_environment, _key) do
+      {:error, Error.new(:unavailable, :secrets, "forced for test", %{})}
+    end
 
     @impl Nucleus.Secrets.Store
     def create_secret(_environment, _key, _value), do: raise("should not be called")
@@ -342,22 +346,216 @@ defmodule NucleusWeb.SecretsLiveTest do
   end
 
   describe "placeholder handlers do not crash the LiveView" do
-    test "clicking the reveal control does not crash", %{conn: conn} do
-      assert {:ok, view, _html} = live_secrets(conn, "prod")
-
-      view
-      |> element("button[phx-value-key=\"DATABASE_URL\"]")
-      |> render_click()
-
-      assert has_element?(view, "#secrets-table")
-    end
-
     test "clicking the create button does not crash", %{conn: conn} do
       assert {:ok, view, _html} = live_secrets(conn, "prod")
 
       view |> element("#secrets-create-button") |> render_click()
 
       assert has_element?(view, "#secrets-table")
+    end
+  end
+
+  describe "SEC-A03 — reveal a secret's value" do
+    @tag action: "SEC-A03"
+    test "shows plaintext, a copy affordance, and flips the control to Hide", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, html} = live_secrets(conn, "prod")
+      refute html =~ db_value
+
+      row_id = row_id(view, "DATABASE_URL")
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+
+      assert html =~ db_value
+      assert has_element?(view, "#secret-value-#{row_id}")
+      assert has_element?(view, "#copy-value-#{row_id}")
+    end
+
+    @tag action: "SEC-A03"
+    test "the control's label is now Hide", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+
+      assert view |> element("#reveal-#{row_id}") |> render() =~ "Hide"
+    end
+
+    @tag action: "SEC-A03"
+    test "only the revealed secret's value appears — other seeded values stay absent", %{
+      conn: conn
+    } do
+      assert {:ok, %{value: stripe_value}} = Secrets.Store.get_secret("prod", "STRIPE_API_KEY")
+      assert {:ok, %{value: jwt_value}} = Secrets.Store.get_secret("prod", "JWT_SIGNING_KEY")
+
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+
+      refute html =~ stripe_value
+      refute html =~ jwt_value
+    end
+
+    @tag action: "SEC-A03"
+    test "emits a secret_viewed audit event", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+
+      assert_audit_event(:secret_viewed, tenant: "local")
+    end
+  end
+
+  describe "SEC-A04 — hide a revealed secret's value" do
+    @tag action: "SEC-A04"
+    test "clicking Hide removes the plaintext from the payload and restores View", %{
+      conn: conn
+    } do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+
+      refute html =~ db_value
+      refute has_element?(view, "#secret-value-#{row_id}")
+      assert html =~ "View"
+    end
+
+    @tag action: "SEC-A04"
+    test "hiding emits no audit event", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      assert_audit_event(:secret_viewed)
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+
+      assert length(audit_events()) == 1
+    end
+
+    @tag action: "SEC-A04"
+    test "reveal -> hide -> reveal works and emits two events", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+      assert html =~ db_value
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+      refute html =~ db_value
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+      assert html =~ db_value
+
+      events = Enum.filter(audit_events(), &(&1.event == :secret_viewed))
+      assert length(events) == 2
+    end
+  end
+
+  describe "SEC-A05 — handle a failed reveal" do
+    @tag action: "SEC-A05"
+    test "store forced :unavailable: error flash shown, value stays absent, control stays View, view alive",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      use_failing_secrets_store()
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+
+      assert has_element?(view, "#flash-error")
+      refute has_element?(view, "#secret-value-#{row_id}")
+      assert html =~ "View"
+      assert has_element?(view, "#secrets-table")
+    end
+
+    @tag action: "SEC-A05"
+    test "store forced :not_found: distinct error copy", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      render_click(view, "reveal", %{"key" => "NO_SUCH_KEY"})
+
+      not_found_message = view |> element("#flash-error") |> render()
+      assert not_found_message =~ "no longer exists"
+
+      use_failing_secrets_store()
+      row_id = row_id(view, "DATABASE_URL")
+      unavailable_message = view |> element("#reveal-#{row_id}") |> render_click()
+
+      refute unavailable_message =~ "no longer exists"
+    end
+
+    @tag action: "SEC-A05"
+    test "the failure is distinguishable from success: the error element is present", %{
+      conn: conn
+    } do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      use_failing_secrets_store()
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+
+      assert has_element?(view, "#flash-error")
+    end
+
+    @tag action: "SEC-A05"
+    test "a forged phx-value-key containing '..' produces an error and no crash", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      render_click(view, "reveal", %{"key" => "../../other-env/secret"})
+
+      assert has_element?(view, "#flash-error")
+      assert has_element?(view, "#secrets-table")
+      refute_audit_contains("../../other-env/secret")
+    end
+  end
+
+  describe "SEC-S4 — reveal state is cleared on navigation" do
+    test "navigating away and back clears the reveal", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+      assert html =~ db_value
+
+      html = render_patch(view, "/environments/staging/secrets")
+      refute html =~ db_value
+
+      html = render_patch(view, "/environments/prod/secrets")
+      refute html =~ db_value
+      assert html =~ "View"
+    end
+  end
+
+  describe "SEC-S4 — multiple independent reveals" do
+    test "revealing two secrets independently, then hiding one, leaves the other revealed", %{
+      conn: conn
+    } do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, %{value: stripe_value}} = Secrets.Store.get_secret("prod", "STRIPE_API_KEY")
+
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      db_row_id = row_id(view, "DATABASE_URL")
+      stripe_row_id = row_id(view, "STRIPE_API_KEY")
+
+      view |> element("#reveal-#{db_row_id}") |> render_click()
+      html = view |> element("#reveal-#{stripe_row_id}") |> render_click()
+
+      assert html =~ db_value
+      assert html =~ stripe_value
+
+      html = view |> element("#reveal-#{db_row_id}") |> render_click()
+
+      refute html =~ db_value
+      assert html =~ stripe_value
     end
   end
 
@@ -448,5 +646,19 @@ defmodule NucleusWeb.SecretsLiveTest do
 
   defp key_position(html, key) do
     :binary.match(html, key) |> elem(0)
+  end
+
+  # `SEC-S2` decision 2: the row id is a hash of the ARN, not the key — a
+  # test selects on `[data-key="..."]` and reads the id LiveView actually
+  # assigned, rather than recomputing the sha256 hash itself (`docs/adr/0010`).
+  defp row_id(view, key) do
+    document = view |> render() |> LazyHTML.from_fragment()
+
+    ["secret-" <> hash] =
+      document
+      |> LazyHTML.query(~s([data-key="#{key}"]))
+      |> LazyHTML.attribute("id")
+
+    hash
   end
 end


### PR DESCRIPTION
## What

Implements SEC-A03/A04/A05: revealing a secret's plaintext value, hiding it again, and handling a failed reveal without an unexplained blank state. `Nucleus.Secrets.reveal/3` is the first function in this module to actually call `Store.get_secret/2` and produce a plaintext value; `SecretsLive`'s placeholder reveal handler (from SEC-S2) is replaced with real reveal/hide logic backed by it.

Closes #12

## How

- **`Nucleus.Secrets.reveal(environment, key, scope)`** — strict order: `Environments.fetch/2` re-validates the environment (never trust a client-originated value), then a local key validator rejects a forged `phx-value-key`, then `Store.get_secret/2` runs. `secret_viewed` is emitted **only** on success, with `resource` set to the full parameter path (never the bare key), and `user:` built from `Nucleus.Scope.audit_user/1`.
- **`SecretsLive`** — a new `:revealed` assign (`%{key => Secret.t()}`) holds plaintext only for rows the user actually revealed. Both `reveal` and `hide` convert the fetched `Secret` back to a `SecretRef` before `stream_insert/3`, so the stream itself never carries a `value` field on either branch — only `@revealed`, read directly in the template, can leak one. `:revealed` resets to `%{}` on every `handle_params/3`, so navigating between environments (or back to the same route) never carries a value across. A failed reveal leaves `:revealed` untouched, keeps the control on "View", and shows kind-specific flash copy (`:not_found`, `:auth_expired`, `:unavailable`, `:invalid`) with no crash.
- Requirement IDs satisfied: **SEC-A03**, **SEC-A04**, **SEC-A05**.

### Notable decisions (see ADR-0011 for full rationale)

- **`Nucleus.Audit.Sink.Test` gained a `Process.get(:"$callers")` fallback.** Every audit call before this ticket ran directly in the test process, so per-process registration via `register/1` was always sufficient. This is the first ticket to emit an audit event from *inside* a mounted LiveView — a distinct GenServer process a test never registers from directly, and there's no public API to run code inside an already-running view to register it there. `write/1` now falls back to the first pid in `$callers` when the writing process has no direct registration; `Phoenix.LiveViewTest` sets `$callers` on the spawned view process to the test that mounted it — the same ancestry mechanism Ecto's SQL Sandbox already relies on. This is test infrastructure outside the ticket's literal plan, but it's what makes "hiding emits no audit event" and "reveal → hide → reveal emits two events" (both required by the test plan) assertable at all.
- **`:auth_expired` does not delegate to a shared handler.** The plan called for delegating to "the shared handler SEC-S7 introduces," but SEC-S7 (#15) is still open — there is no shared handler to delegate to. `reveal/3`'s failure path renders its own local flash copy instead of inventing that cross-cutting handler prematurely; this copy is throwaway the moment SEC-S7 lands.
- **Key validation is a minimal, explicitly weaker deny list** (`..`, `/`, `\`, null byte), matching the plan's own fallback ("otherwise implement the minimal deny checks here and have SEC-S6 consolidate"). This is deliberately not as strong as `Environments.validate_name/1`'s allowlist-plus-length-cap — a denylist alone lets percent-encoded traversal and unicode lookalikes through — pending SEC-S6 (#14, still `needs-decision`) consolidating both into one validator.
- **Audit `user:` uses `Nucleus.Scope.audit_user/1`**, not a raw `scope.user.email` read, so a Cognito token with no `email` claim falls back to `username` then `"anonymous"` instead of a signed-in reveal being silently misattributed to `"anonymous"`. This is proven at a real call site for the first time here.

## Record

ADR-0011 (`docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`) settles the three decisions above plus the stream re-insertion approach, and is entry 11 in `decisions-log.md`. `business-tech-bridge.md` updates the `NucleusWeb.SecretsLive` row to claim SEC-A03–A05. `living-notes.md` adds a debt entry for the weaker key validator (pointing at SEC-S6) and a note on the `$callers` fallback being reusable by SEC-S5/SEC-S6's own LiveView audit tests.

## Verification

`mix precommit` ran clean after both commits: 398 tests passed (373 tests + 25 doctests), 10 excluded (`:external`), zero failures.

- `test/nucleus/secrets_test.exs` — context-level coverage tagged `SEC-A03`/`SEC-A05`: successful reveal, exactly-one `secret_viewed` with the full path as `resource`, `refute_audit_contains(value)` (the `AUD-A02` guard), `:not_found`/`:unavailable`/forged-key failures each emitting no audit event, and value absence across all captured log output.
- `test/nucleus_web/live/secrets_live_test.exs` — LiveView-level coverage tagged `SEC-A03`/`SEC-A04`/`SEC-A05`: plaintext + copy affordance + control label on reveal, per-row isolation (other seeded values stay absent), hide restores the mask and emits no audit event, reveal→hide→reveal emits two events, kind-specific error flashes with the LiveView still alive, navigation clears the reveal, and independent multi-row reveal/hide.
