### PR TITLE
SEC-S5: Edit a revealed secret's value (SEC-A06, A07, A08)

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.6 | Updated: 2026-08-18 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.7 | Updated: 2026-08-18 -->
 
 # Business ↔ Tech Bridge
 
@@ -54,16 +54,18 @@ to cite from test names and bug reports.
 sidebar) and `test/nucleus_web/live/shell_test.exs` now exist (EN-7) — a deliberate subset only,
 with no `@tag action:` claimed, so `NAV-A01`–`A12` coverage is still zero until the dedicated
 `NAV-*` ticket lands. `NucleusWeb.SecretsLive` and `test/nucleus_web/live/secrets_live_test.exs`
-also now exist (SEC-S1/#9, SEC-S2/#10, SEC-S3/#11, SEC-S4/#12) — `SEC-A01`–`A05`, `SEC-A14`–`A17`
-are claimed and covered; the module validates and resolves the environment, lists a
-`Nucleus.Secrets` boundary's secrets **with no value column at all** (no plaintext and no mask —
-ADR-0012), copies a row's path/ARN to the clipboard from icon-only buttons whose label is a
+also now exist (SEC-S1/#9, SEC-S2/#10, SEC-S3/#11, SEC-S4/#12, SEC-S5/#13) — `SEC-A01`–`A08`,
+`SEC-A14`–`A17` are claimed and covered; the module validates and resolves the environment, lists
+a `Nucleus.Secrets` boundary's secrets **with no value column at all** (no plaintext and no mask
+— ADR-0012), copies a row's path/ARN to the clipboard from icon-only buttons whose label is a
 tooltip (`SEC-A02` — wiring only; the clipboard write itself is a recorded browser gap,
 `docs/adr/0008-test-strategy.md`), reveals a value into a modal that is only in the DOM while it
-is open, with a fresh audited fetch on every reveal, and renders every
-fail-closed/empty/failed-reveal state (`SEC-A06`–`A13`, `A18` are SEC-S5–S7 and later). Every
-other row is unimplemented. These names are the agreed target so that work lands consistently —
-treat them as the convention to follow, and correct this table if a better structure emerges.
+is open, with a fresh audited fetch on every reveal, lets that same modal swap into an edit form
+gated on the revealed secret matching by key (`SEC-A06`–`A08`, `docs/adr/0013-secret-edit-in-modal-and-value-form.md`),
+and renders every fail-closed/empty/failed-reveal/failed-save state (`SEC-A09`–`A13`, `A18` are
+SEC-S6/S7 and later). Every other row is unimplemented. These names are the agreed target so that
+work lands consistently — treat them as the convention to follow, and correct this table if a
+better structure emerges.
 
 Two conformance notes worth carrying forward, both recorded in
 `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md`:
@@ -148,7 +150,10 @@ Each wiki action has an `Actor` / `Given` / `When` / `Then`, and often an `API:`
 - Architecture: values fetched live per reveal; nothing cached (stateless constraint), and a
   revealed value exists in the DOM only while its modal is drawn
 - Trade-offs: `SEC-A06` requires a value be *revealed before it can be edited*, deliberately
-  trading a slower edit path for protection against blind overwrites
+  trading a slower edit path for protection against blind overwrites. The edit control lives
+  inside the reveal modal itself, not a row — reveal state exists only while that modal is open,
+  so a row-level control would dead-end against the gate almost every time
+  (`docs/adr/0013-secret-edit-in-modal-and-value-form.md`).
 
 **Connection**:
 Secrets is where the read+update-only boundary earns its keep. There is no delete, so a

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.13 | Updated: 2026-08-18 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.14 | Updated: 2026-08-18 -->
 
 # Decisions Log
 
@@ -37,6 +37,7 @@ job and the row should point rather than paraphrase.
 | 10 | Secrets listing — one context call replaces two, ARN-hashed DOM ids with `data-key` carrying the real key, errors matched on `{kind, boundary}` | 2026-08-17 | Decided | `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md` |
 | 11 | Secret reveal — re-stream a converted `SecretRef` (never the value-bearing `Secret`), audit `user:` via `Scope.audit_user/1`, `Nucleus.Audit.Sink.Test` falls back to `$callers` for LiveView-emitted audit events | 2026-08-18 | Decided | `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` |
 | 12 | Secret reveal moves into a conditionally-rendered modal (plaintext never in the DOM while closed), Value column deleted outright, copy buttons icon-only with the label as a daisyUI tooltip; partially supersedes #11's map/re-stream mechanics | 2026-08-18 | Decided | `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md` |
+| 13 | Secret edit lives inside the reveal modal via content-swap-in-place (no second `<.modal>`), gated on `socket.assigns.revealed` matching `%Secret{key: ^key}`; `Nucleus.Secrets.Value` and an `embedded_schema` edit form set the pattern `SEC-S6` reuses | 2026-08-18 | Decided | `docs/adr/0013-secret-edit-in-modal-and-value-form.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -58,7 +59,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0012` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0013` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.13 | Updated: 2026-08-18 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.14 | Updated: 2026-08-18 -->
 
 # Living Notes
 
@@ -19,7 +19,6 @@
 | Nucleus's own AWS identity (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) is read ambiently by the `aws` package, with no boot-time check or ops-facing doc — unlike `TENANT_ROLE_ARN`/`AWS_REGION`/`CLUSTER_NAME`/`DEPLOYMENT_NAME`, which all raise at boot | A misconfigured deployment fails per-request as `:not_configured` on first `AssumeRole` call, not at boot | Low | `CLUSTER_NAME`/`DEPLOYMENT_NAME` are now correctly documented in the wiki's `Platform-Operations.md` config reference (issue #22). The ambient `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` doc gap remains open — was out of scope for #22 |
 | No browser-driven test coverage for `SEC-A02` (the `navigator.clipboard.writeText` call itself, the confirmation face swap/revert — an icon in a row, the word "Copied" in the modal — the non-secure-context `execCommand` fallback, the failure indication, and the hover/`:focus-visible` reveal of any tooltip, now on path and ARN values as well as the copy buttons) or for modal dismissal — `SEC-A13`'s focus trap and focus restoration, plus `SEC-A04`'s Escape and backdrop-click routes, which reach the server only by running the `JS` chain in `data-cancel` | Tests assert wiring only (hook attached, `data-value` full/untruncated, `phx-update="ignore"` present, `data-tip` set, `on_cancel`/`phx-key`/`phx-click-away` present), and claim `@tag action:` for `SEC-A04` **only** via the Close button, whose plain `phx-click="hide"` a `render_click/1` can actually drive | Medium | Add Wallaby once sign-in exists (deferred, EN-8); see `docs/adr/0008-test-strategy.md`. Both gap sets are skipped `:browser`-tagged placeholder modules in `secrets_live_test.exs` — `CopyButtonBrowserGaps` (4) and `SecretRevealModalBrowserGaps` (5) |
 | `LOCAL_FORCE_ERROR` (`Nucleus.Backend.Faults`) is node-global, not per-boundary — a fault set for one boundary is seen by every local implementation's next call | A test targeting the `:secrets` boundary's error path is actually caught by whichever boundary is called first; SEC-S2 found this when `Nucleus.Secrets.list/2`'s `Environments.fetch/2` gate always intercepted the fault before `Store.list_secrets/1` ran | Low | Swap in a real/failing module via `Application.put_env(:nucleus, :backends, ...)` instead of `force_error/2` for a specific-boundary test — see `SecretsLiveTest.FailingSecretsStore` |
-| `SEC-S5`'s plan (issue #13) specifies the reveal-before-edit gate against "the `:revealed` map established by SEC-S4", which ADR-0012 replaced with a single `%Secret{}` or `nil` | Following the plan literally will not compile; and a row-level Edit button is now the wrong shape, since reveal state lives only while the modal is open | Medium | Gate on `socket.assigns.revealed` being a `%Secret{}` whose `key` matches — still server-side, still re-checked on save — and put the edit affordance inside the reveal modal. `SEC-A07`'s re-masking then comes free with dismissal. Commented on #13 |
 | `Nucleus.Secrets.reveal/3`'s key validator is a second, weaker copy of `Environments.validate_name/1`'s deny-list (`..`, `/`, `\`, null byte only — no charset allowlist, no length cap) | A forged key using percent-double-encoding or a control character other than a null byte could still reach `Store.get_secret/2`/`Path.build/2`; cross-environment traversal is still blocked since `/`, `..`, `\` are denied | Low | `SEC-S6` (issue #14, `needs-decision`) should replace this with one shared validator, not add a third — see `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` |
 
 ### Technical Debt Details
@@ -121,6 +120,17 @@ deploys it.
   mounted LiveView, using the same ancestry chain Ecto's SQL Sandbox relies on. Any test
   asserting on an audit event emitted from a `handle_event/3` gets this for free; no per-ticket
   sink workaround needed. See `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`.
+- A LiveView form backed by a tiny `embedded_schema` + `Ecto.Changeset`, one module per form
+  (`NucleusWeb.SecretsLive.EditForm`), with shape validation (length, emptiness) delegated to a
+  plain function (`Nucleus.Secrets.Value.validate/1`) via `validate_change/3` — so the inline
+  error shown while typing and the error the context function returns on submission are the same
+  text, defined once. `SEC-S6`'s creation form is expected to follow this shape and reuse
+  `Value.validate/1` rather than invent a second copy. See
+  `docs/adr/0013-secret-edit-in-modal-and-value-form.md`.
+- Swap a modal's *content* in place (an `:editing`-style boolean toggling which `~H` block
+  renders inside one already-open `<.modal>`) rather than stacking a second `<.modal>` over the
+  first — sidesteps ADR-0012's `focusStack`/`JS.pop_focus/1` double-pop risk entirely instead of
+  needing a fix for it. See `docs/adr/0013-secret-edit-in-modal-and-value-form.md`.
 
 ### Gotchas for Maintainers
 - **Requirements are a submodule.** Fresh clones need
@@ -155,6 +165,15 @@ deploys it.
 ## Archive (Resolved Items)
 
 Moved here for historical reference.
+
+**`SEC-S5`'s plan (issue #13) was stale under ADR-0012** — *was: Technical Debt, Medium*
+*Resolved*: 2026-08-18 by SEC-S5 (issue #13).
+*Outcome*: Gated on `socket.assigns.revealed` matching `%Secret{key: ^key}`, not a map lookup.
+The edit affordance moved inside the reveal modal, swapping its content in place rather than
+stacking a second `<.modal>` — which also sidesteps ADR-0012's `focusStack` double-pop risk
+entirely instead of needing a fix for it. `SEC-A07`'s re-masking came free with `:revealed` going
+to `nil` on save success, exactly as ADR-0012 predicted.
+*See*: `docs/adr/0013-secret-edit-in-modal-and-value-form.md`
 
 **`NucleusWeb.SecretsLive` was a placeholder** — *was: Technical Debt, Medium*
 *Resolved*: 2026-08-14 by SEC-S1 (issue #9); listing added 2026-08-17 by SEC-S2 (issue #10).

--- a/docs/adr/0013-secret-edit-in-modal-and-value-form.md
+++ b/docs/adr/0013-secret-edit-in-modal-and-value-form.md
@@ -1,0 +1,195 @@
+# ADR-0013: Editing a Secret's Value In the Reveal Modal
+
+## Status
+
+Accepted — 2026-08-18
+
+Decided on [SEC-S5](https://github.com/dave-bell/nucleus/issues/13). Builds on
+`0012-secret-reveal-modal-and-icon-only-copy-affordances.md` (the single
+`%Secret{}`/`nil` `:revealed` shape and the conditionally-rendered modal this
+ticket edits inside of) and `0004-audit-emission.md` (the `secret_updated`
+call site this ticket wires). Confirms, rather than reverses, ADR-0012's own
+prediction of how this ticket would need to diverge from its original plan.
+
+## Context
+
+SEC-S5's plan (issue #13) was written against ADR-0011's `:revealed` shape —
+a `%{key => Secret.t()}` map — and specified a row-level Edit control gated by
+`handle_event("edit", %{"key" => key})` rejecting when `key` was absent from
+that map. ADR-0012 landed first (`#43`) and replaced the map with a single
+`%Secret{}` or `nil`, tied to one conditionally-rendered modal. ADR-0012's own
+"Negative" consequences section already named the fix: gate on
+`socket.assigns.revealed` being a `%Secret{}` whose `key` matches, and put the
+edit affordance inside the modal rather than a row. This ADR is that fix,
+plus three mechanics ADR-0012 flagged but did not settle: what "inside the
+modal" means concretely, how a save button should behave, and how the
+form itself is built — this is the first form this application has needed.
+
+## Decision
+
+### Edit swaps the modal's content in place; there is no second `<.modal>`
+
+`:editing` (boolean) toggles which of two `~H` blocks renders inside the one
+already-open `#secret-modal`: the existing value-display block, or a
+`to_form/2`-built edit form. Both read `@revealed` for the key and the
+original value; neither is its own `<.modal>`. This was chosen over stacking
+a second modal specifically because of the `focusStack`/`JS.pop_focus/1`
+gotcha ADR-0012 recorded as a risk for exactly this ticket: two conditionally
+rendered modals open at once would have the inner one's dismissal consume the
+outer one's saved focus. Swapping content in one modal never opens a second
+one, so the gotcha does not need a fix — it does not arise.
+
+### The reveal-before-edit gate matches `%Secret{key: ^key}`, not a boolean
+
+`handle_event("edit", %{"key" => key}, socket)` and
+`handle_event("save_edit", %{"key" => key, "secret" => params}, socket)` both
+pattern-match `socket.assigns.revealed` against `%Secret{key: ^key}` and
+reject anything else — including `nil`, and including a `%Secret{}` for a
+*different* key. `:editing` (the UI toggle) is never consulted for the gate
+itself; a client that dispatches `save_edit` directly, having never dispatched
+`edit`, is rejected purely on the `revealed`/`key` match. This is the same
+shape ADR-0011 and ADR-0012 both used for their own gates — checked in
+`handle_event/3`, re-checked on every state-changing event, never trusted from
+what the UI happens to render.
+
+### `SEC-A07`'s re-masking is `:revealed` going to `nil`, not a separate step
+
+A successful `save_edit` sets `:revealed` to `nil` (alongside `:editing` and
+`:edit_form`). Because the modal is `:if={@revealed}` (ADR-0012), this single
+assign removes the modal, the displayed value, and the edit form from the DOM
+in the same step that confirms success — there is no second "now hide the
+value" instruction to get wrong or forget. A failed save leaves `:revealed`
+untouched, which is equally deliberate: `SEC-A08` requires the edit survive a
+failure, and re-masking would close the form along with the value.
+
+### Save starts disabled, and enables only once the value differs from the original
+
+`edit_dirty?/2` compares the form's current `:value` field against
+`@revealed.value` (the original, still held in `:revealed` while editing) and
+drives the Save button's `disabled` attribute. This was a direct product
+decision for this ticket, not derived from the plan's DOM id table, which
+assumed a row-scoped control this design does not have. It is UI convenience
+only — `handle_event("save_edit", ...)` re-validates and re-checks the gate
+regardless of whether the browser ever sent a disabled click, the same
+"hiding a button is not a gate" reasoning the plan itself insisted on for the
+reveal-before-edit check.
+
+### The value shape validator is `Nucleus.Secrets.Value`, shared with `SEC-S6`
+
+`Nucleus.Secrets.Value.validate/1` checks non-empty and at most 4096
+characters, via `String.length/1` — not `byte_size/1`, so a multi-byte value
+is measured the way a person reading `SEC-A11`'s "live running count of
+characters" would expect. It returns `Nucleus.Backend.Error.t()`, the same
+shape every other validation step in `Nucleus.Secrets` returns, so
+`Nucleus.Secrets.update/4`'s `with` chain needs no special case for a value
+error. `SEC-S6` (issue #14, still `needs-decision`) is expected to reuse this
+module unchanged for its own value field rather than writing a second copy.
+
+### The edit form is an `embedded_schema` changeset, not a schemaless one
+
+`NucleusWeb.SecretsLive.EditForm` is a tiny `embedded_schema` with one
+`:value` field, whose `changeset/2` calls `Value.validate/1` through
+`validate_change/3` so the inline error a user sees while typing and the
+error `update/4` would return on submission are always the same text — one
+message, defined once. A schemaless changeset (`{data, types}`) would have
+worked structurally, but this application had no form before this ticket, and
+`AGENTS.md`'s guideline names `embedded_schema`/`Ecto.Changeset` specifically;
+this establishes the pattern `SEC-S6`'s creation form (key + value) is
+expected to follow, rather than leaving the first form to set a precedent
+nobody chose on purpose.
+
+### `NucleusWeb.CoreComponents.button/1` gained `type` in its global attribute allowlist
+
+The component's `attr :rest, :global, include: ~w(...)` list did not include
+`type`, because no existing caller needed to override a `<button>`'s implicit
+type inside a `<form>`. The Cancel button in the edit form does — an
+un-typed `<button>` inside a `<form>` defaults to `type="submit"` in HTML5,
+which would make Cancel submit the form it is meant to discard. Adding `type`
+to the allowlist is additive and backward compatible; every existing call
+site that omits it is unaffected.
+
+## Consequences
+
+### Positive
+
+- No second modal, so ADR-0012's `focusStack` risk for this ticket is
+  structurally avoided rather than mitigated.
+- The reveal-before-edit gate is provable by direct event dispatch exactly
+  the way ADR-0011's and ADR-0012's gates are — `render_click(view, "edit",
+  ...)` and `render_click(view, "save_edit", ...)` without a prior reveal are
+  both rejected, with no store mutation and no audit event, in
+  `test/nucleus_web/live/secrets_live_test.exs`.
+- `Nucleus.Secrets.Value` and `NucleusWeb.SecretsLive.EditForm` give `SEC-S6`
+  a validator and a form pattern to reuse rather than invent.
+- `SEC-A07`'s re-masking required no dedicated code path — confirming
+  ADR-0012's own prediction that it would "come close to free" under the
+  single-`Secret` shape.
+
+### Negative
+
+- The plan's DOM id table (`#edit-{row_id}`, `#secret-edit-form-{row_id}`,
+  etc.) is not implemented as written — there is one edit form, not one per
+  row, so the ids carry no row suffix (`#secret-edit-form`,
+  `#secret-edit-value`, `#save-edit`, `#cancel-edit`, `#secret-edit-count`).
+  A reviewer checking the plan literally against the code will find this ADR,
+  not a row-suffixed id.
+- `edit_dirty?/2`'s disabled-Save convenience has no server-side enforcement
+  of its own beyond the gate that already exists — a determined client could
+  submit an unchanged value and it would simply succeed as a no-op update
+  (same value written back, a new `last_modified`, one more `secret_updated`
+  audit record). No requirement asks this to be prevented, and Parameter
+  Store's last-write-wins semantics make it harmless, but it is worth naming:
+  the dirty-check is a nicety, not a second gate.
+- `button/1`'s widened global attribute list is a shared component change
+  riding in on a feature ticket, rather than its own isolated change — every
+  future `<.button>` caller now silently gains the ability to pass `type`,
+  which is desirable here but was not separately reviewed as a component API
+  change.
+
+## Alternatives considered
+
+**A second `<.modal>` for editing, stacked over the reveal modal.** Rejected
+— this is precisely the shape ADR-0012 warned would double-pop
+`JS.pop_focus/1` against a module-global `focusStack`, consuming the outer
+modal's saved focus. Content-swap-in-place avoids the interaction entirely
+instead of fixing it.
+
+**A row-level Edit button, as the original plan specified.** Rejected, per
+ADR-0012's own "Negative" consequences: reveal state exists only while the
+modal is open, so a row-level control would almost always hit the gate and
+dead-end — a user who reveals, dismisses, and then clicks a row's Edit has
+nothing left to edit against.
+
+**A schemaless `Ecto.Changeset` (`{data, types}`) instead of an
+`embedded_schema`.** Rejected — functionally equivalent for this one field,
+but this is the first form in the codebase and `AGENTS.md` names
+`embedded_schema` specifically; picking the schemaless shape here would leave
+`SEC-S6` to either follow an unstated precedent or invent its own.
+
+**Enforce the dirty-check server-side, rejecting a `save_edit` whose value
+equals the original.** Rejected — no requirement asks for it, Parameter
+Store's last-write-wins behavior (recorded as out of scope in the ticket
+itself) makes a no-op update harmless, and rejecting it would add a rule a
+future reader would have to reverse-engineer the reason for.
+
+## References
+
+- SEC-S5 (issue #13) — the deciding issue, including its own comment thread
+  where the map-to-single-`Secret` mismatch was flagged before implementation
+  began
+- `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md` — the
+  `:revealed` shape this ticket edits inside of, and the `focusStack` risk
+  this ticket's content-swap design avoids
+- `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`
+  — the gate-in-`handle_event`/re-check-on-every-call shape this ticket's own
+  gate follows
+- `docs/adr/0004-audit-emission.md` — the `secret_updated` call site and the
+  per-event field allowlist with no key named `value`
+- `AGENTS.md` — `embedded_schema`/`Ecto.Changeset` for form validation with no
+  database; `to_form/2` and `<.form for={@form}>` conventions
+- `.opencode/context/project-intelligence/living-notes.md` — the Technical
+  Debt entry this ADR resolves (SEC-S5's plan going stale under ADR-0012)
+- SEC-S6 (issue #14, `needs-decision`) — expected to reuse
+  `Nucleus.Secrets.Value` and the `embedded_schema` form pattern for its own
+  key+value creation form
+</content>

--- a/lib/nucleus/secrets.ex
+++ b/lib/nucleus/secrets.ex
@@ -33,6 +33,15 @@ defmodule Nucleus.Secrets do
   that emits `:secret_viewed`. Keeping the two separate means `SEC-A01`'s
   "never included in the listing response" is not something a future change
   to `list/2` could quietly break by merging in a value.
+
+  ## `update/4` mirrors `reveal/3`'s validation ladder, but owns no gate (`SEC-S5`)
+
+  `update/4` re-validates the environment, the key shape, and — via
+  `Nucleus.Secrets.Value.validate/1` — the value shape, in that order, before
+  ever calling `Store.update_secret/3`. It deliberately does **not** enforce
+  `SEC-A06`'s "editing requires the value to have been revealed first" — that
+  precondition is UI session state this context module cannot see. See
+  `update/4`'s own doc for where the gate actually lives.
   """
 
   alias Nucleus.Audit
@@ -42,6 +51,7 @@ defmodule Nucleus.Secrets do
   alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
   alias Nucleus.Secrets.Store
+  alias Nucleus.Secrets.Value
 
   @doc """
   Every secret's metadata for `environment`, re-validating the environment
@@ -140,6 +150,75 @@ defmodule Nucleus.Secrets do
         )
 
       {:ok, secret}
+    end
+  end
+
+  @doc """
+  Updates `key`'s value in `environment` to `value`, re-validating the
+  environment, the key shape, and the value shape — in that order — before
+  any store call (`SEC-A06`).
+
+  Strict order, mirroring `reveal/3`:
+
+  1. `Nucleus.Environments.fetch/2` — the same gate every other function in
+     this module uses. Never trust an environment name arriving from a
+     client-originated event.
+  2. The **key** shape, via the same `validate_key/1` `reveal/3` already
+     uses — not a second copy. `key` comes from `phx-value-key`, forgeable
+     the same way it is for a reveal.
+  3. `Nucleus.Secrets.Value.validate/1` — the value shape (non-empty, at most
+     4096 characters), checked before the store is ever reached, so an
+     invalid value never becomes a `PutParameter` call.
+  4. `Nucleus.Secrets.Store.update_secret/3` — fails `{:error, kind:
+     :not_found}` on a missing key and **never creates one**; this function
+     adds no upsert behaviour on top.
+
+  On success **only**, emits `secret_updated` with `resource` set to the
+  full parameter path from the returned `SecretRef` — never the bare key,
+  and never the value: `SecretRef` has no `value` field, so there is nowhere
+  for one to leak into the audit record even by accident. `user` comes from
+  `Nucleus.Scope.audit_user/1`, matching `reveal/3` and ADR-0011's reasoning
+  for why a raw `scope.user.email` read is not enough.
+
+  Returns `SecretRef` (no value field), so the success path cannot
+  accidentally carry the new plaintext back into a caller's render.
+
+  ## This function does not enforce reveal-before-edit
+
+  `SEC-A06`'s "editing requires the value to have been revealed first" is UI
+  session state (`NucleusWeb.SecretsLive`'s `:revealed` assign) — this
+  context module has no view of a caller's session and cannot check it.
+  **The gate lives in the LiveView's `handle_event/3`, on both opening the
+  edit form and on save.** A future caller of this function — a future API
+  endpoint, a script — must add an equivalent check of its own; calling
+  `update/4` directly is not safe against a blind overwrite on its own.
+
+  The value must appear in no log line, on any branch, including a failure
+  — `Store.update_secret/3`'s underlying `PutParameter` call carries the
+  value in its request body, so any code that logged a failed request body
+  would leak it. This function never logs, and neither does anything it
+  calls.
+  """
+  @spec update(
+          environment :: String.t(),
+          key :: String.t(),
+          value :: String.t(),
+          scope :: Scope.t()
+        ) :: {:ok, SecretRef.t()} | {:error, Error.t()}
+  def update(environment, key, value, %Scope{token: token} = scope)
+      when is_binary(environment) and is_binary(key) and is_binary(value) do
+    with {:ok, _environment} <- Environments.fetch(environment, token),
+         :ok <- validate_key(key),
+         :ok <- Value.validate(value),
+         {:ok, ref} <- Store.update_secret(environment, key, value) do
+      :ok =
+        Audit.emit(:secret_updated,
+          user: Scope.audit_user(scope),
+          tenant: scope.tenant,
+          resource: ref.path
+        )
+
+      {:ok, ref}
     end
   end
 

--- a/lib/nucleus/secrets/value.ex
+++ b/lib/nucleus/secrets/value.ex
@@ -1,0 +1,85 @@
+defmodule Nucleus.Secrets.Value do
+  @moduledoc """
+  Shape validation for a secret's plaintext value — `SEC-A06`'s edit path and
+  `SEC-A09`'s creation path (`SEC-S6`) share this module rather than each
+  keeping its own copy; whichever ticket lands first builds it.
+
+  Per the wiki's API contract (`value (≤4096 chars)`) and `SEC-A11`: a value
+  must be non-empty and no more than 4096 characters.
+
+  ## Characters, not bytes
+
+  Length is checked with `String.length/1`, never `byte_size/1`. The
+  requirement says "4096 characters" and `SEC-A11` asks for "a live running
+  count of characters used" — counting bytes would fail a multi-byte value
+  (a signing key with non-ASCII content, say) at a length that looks wrong to
+  the person who typed it, since one visible character can be several bytes.
+
+  ## Returns a `Nucleus.Backend.Error`, not a bare atom or string
+
+  Callers on both the create and update paths already handle
+  `Nucleus.Backend.Error.t()` from every other validation step
+  (`Nucleus.Environments.fetch/2`, the key-shape check) — returning the same
+  shape here means one `case`/`with` chain handles all three without a
+  special branch for value errors. `kind: :invalid` matches the meaning
+  `Nucleus.Backend.Error`'s moduledoc gives that kind: "caller-supplied input
+  rejected before any backend call." `boundary` is `:secrets`
+  (`Nucleus.Secrets.Store.boundary/0`) since this is a `:secrets`-domain
+  shape rule, not a generic one.
+  """
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Secrets.Store
+
+  @max_length 4096
+
+  @doc """
+  The maximum number of characters a secret value may contain.
+  """
+  @spec max_length() :: pos_integer()
+  def max_length, do: @max_length
+
+  @doc """
+  Validates `value`'s shape: non-empty, at most #{@max_length} characters.
+
+  Accepts `term()`, not just `String.t()` — a value arriving from a
+  client-controlled form param has not been shown to be a string yet, and
+  rejecting a non-binary as `:invalid` here is simpler than a `FunctionClauseError`
+  reaching a caller that forgot to guard first.
+
+      iex> Nucleus.Secrets.Value.validate("s3cr3t")
+      :ok
+
+      iex> {:error, error} = Nucleus.Secrets.Value.validate("")
+      iex> error.kind
+      :invalid
+
+      iex> {:error, error} = Nucleus.Secrets.Value.validate(String.duplicate("a", 4097))
+      iex> error.kind
+      :invalid
+  """
+  @spec validate(term()) :: :ok | {:error, Error.t()}
+  def validate(value) when is_binary(value) do
+    cond do
+      value == "" ->
+        {:error, invalid("secret value must not be empty")}
+
+      String.length(value) > @max_length ->
+        {:error,
+         invalid("secret value exceeds #{@max_length} characters", %{
+           length: String.length(value)
+         })}
+
+      true ->
+        :ok
+    end
+  end
+
+  def validate(other) do
+    {:error, invalid("secret value must be a string", %{value: inspect(other)})}
+  end
+
+  defp invalid(message, details \\ %{}) do
+    Error.new(:invalid, Store.boundary(), message, details)
+  end
+end

--- a/lib/nucleus_web/components/core_components.ex
+++ b/lib/nucleus_web/components/core_components.ex
@@ -95,7 +95,7 @@ defmodule NucleusWeb.CoreComponents do
       <.button phx-click="go" variant="primary">Send!</.button>
       <.button navigate={~p"/"}>Home</.button>
   """
-  attr :rest, :global, include: ~w(href navigate patch method download name value disabled)
+  attr :rest, :global, include: ~w(href navigate patch method download name value disabled type)
   attr :class, :any
   attr :variant, :string, values: ~w(primary)
   slot :inner_block, required: true

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -534,7 +534,7 @@ defmodule NucleusWeb.SecretsLive do
                 type="textarea"
                 label="Value"
                 rows="6"
-                class="font-mono text-sm"
+                class="w-full textarea font-mono text-sm"
               />
               <div id="secret-edit-count" class="text-xs text-base-content/70 text-right mt-1">
                 {edit_value_length(@edit_form)}/{Value.max_length()} characters
@@ -554,7 +554,7 @@ defmodule NucleusWeb.SecretsLive do
                 <.button
                   id="save-edit"
                   type="submit"
-                  class="btn-primary"
+                  variant="primary"
                   disabled={not edit_dirty?(@edit_form, @revealed.value)}
                   phx-disable-with="Saving..."
                 >
@@ -582,7 +582,12 @@ defmodule NucleusWeb.SecretsLive do
               {@revealed.value}
             </div>
             <div class="modal-action">
-              <.button id="edit-secret" phx-click="edit" phx-value-key={@revealed.key}>
+              <.button
+                id="edit-secret"
+                variant="primary"
+                phx-click="edit"
+                phx-value-key={@revealed.key}
+              >
                 Edit
               </.button>
               <.copy_button

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -210,6 +210,7 @@ defmodule NucleusWeb.SecretsLive do
   alias Nucleus.Secrets
   alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
+  alias Nucleus.Secrets.Value
   alias NucleusWeb.SecretsLive.EditForm
 
   @modal_id "secret-modal"
@@ -536,7 +537,7 @@ defmodule NucleusWeb.SecretsLive do
                 class="font-mono text-sm"
               />
               <div id="secret-edit-count" class="text-xs text-base-content/70 text-right mt-1">
-                {edit_value_length(@edit_form)}/{Nucleus.Secrets.Value.max_length()} characters
+                {edit_value_length(@edit_form)}/{Value.max_length()} characters
               </div>
               <p
                 :if={@edit_error}

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -156,13 +156,61 @@ defmodule NucleusWeb.SecretsLive do
   `:revealed` is reset to `nil` on every `handle_params/3` call, so patching
   between environments (or navigating back to this same route) never carries
   a previously-revealed plaintext value across.
+
+  ## Editing lives inside the reveal modal, not a row (`SEC-S5`)
+
+  The plan this ticket originally shipped with (issue #13) specified the
+  reveal-before-edit gate against "the `:revealed` map established by
+  SEC-S4" and a row-level Edit button. Both are stale by the time this
+  module implements them: `#43`/ADR-0012 (above) already narrowed
+  `:revealed` to a single `%Secret{}` or `nil`, so there is no map, and
+  reveal state now lives only as long as the modal is open — a row-level
+  Edit button would almost always hit the gate and dead-end, since a user
+  who reveals, dismisses, and then clicks a row's Edit has nothing left to
+  edit against. See `docs/adr/0012-...md`'s own "Negative" consequences and
+  `living-notes.md`'s Technical Debt entry for this ticket, both of which
+  record the correction this module implements:
+
+  - **The gate checks `socket.assigns.revealed` is a `%Secret{}` whose `key`
+    matches the incoming key** — still server-side, in `handle_event/3`,
+    still re-checked on save. `handle_event("edit", %{"key" => key}, ...)`
+    and `handle_event("save_edit", %{"key" => key, ...}, ...)` both pattern
+    match `%Secret{key: ^key}` and reject (flash, no other effect) on
+    anything else, including no reveal at all. Hiding the Edit button unless
+    revealed is UI convenience; a `phx-click` can be dispatched directly
+    against the socket regardless of what is rendered, so the check here is
+    the actual gate.
+  - **Edit swaps the modal's own content, in place** — there is no second
+    `<.modal>`. `:editing` (boolean) toggles between the value-display
+    content and a `to_form/2`-built edit form, both inside the same
+    `#secret-modal`. This sidesteps ADR-0012's recorded `focusStack`
+    gotcha entirely: two modals stacked would have the inner one's dismissal
+    consume the outer one's saved `JS.push_focus/1` call, and swapping
+    content in one modal never opens a second one.
+  - **`SEC-A07`'s re-masking is a consequence of `:revealed` going to `nil`
+    on save success, not a separate step.** Because the modal is wrapped in
+    `:if={@revealed}` (see above), clearing `:revealed` removes the modal —
+    plaintext and edit form both — from the DOM in the same assign that
+    confirms success. There is nothing else to re-mask.
+  - **Save starts disabled and enables only once the entered value differs
+    from `@revealed.value`.** A dirty-check, not merely non-empty — decided
+    directly for this ticket rather than following the plan's DOM id table
+    literally, since that table assumed a row-scoped edit control this
+    module does not have. The disabled attribute is UI convenience only;
+    the reveal-before-edit gate above is what actually stops a save.
+  - **Cancel clears `:editing`/`:edit_form` only.** `:revealed` is
+    untouched — `SEC-A06`'s "cancel to discard the change" is not
+    `SEC-A04`'s hide, and the value stays revealed exactly as it does today
+    when a user dismisses nothing at all.
   """
 
   use NucleusWeb, :live_view
 
   alias Nucleus.Backend.Error
   alias Nucleus.Secrets
+  alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
+  alias NucleusWeb.SecretsLive.EditForm
 
   @modal_id "secret-modal"
 
@@ -182,6 +230,9 @@ defmodule NucleusWeb.SecretsLive do
       socket
       |> assign(:environment, environment)
       |> assign(:revealed, nil)
+      |> assign(:editing, false)
+      |> assign(:edit_form, nil)
+      |> assign(:edit_error, nil)
       |> fetch_secrets(environment)
 
     {:noreply, socket}
@@ -191,7 +242,14 @@ defmodule NucleusWeb.SecretsLive do
   def handle_event("reveal", %{"key" => key}, socket) do
     case Secrets.reveal(socket.assigns.environment, key, socket.assigns.current_scope) do
       {:ok, secret} ->
-        {:noreply, assign(socket, :revealed, secret)}
+        socket =
+          socket
+          |> assign(:revealed, secret)
+          |> assign(:editing, false)
+          |> assign(:edit_form, nil)
+          |> assign(:edit_error, nil)
+
+        {:noreply, socket}
 
       {:error, %Error{} = error} ->
         {:noreply, put_flash(socket, :error, reveal_error_message(error))}
@@ -203,7 +261,86 @@ defmodule NucleusWeb.SecretsLive do
   # so there is nothing to identify.
   @impl Phoenix.LiveView
   def handle_event("hide", _params, socket) do
-    {:noreply, assign(socket, :revealed, nil)}
+    socket =
+      socket
+      |> assign(:revealed, nil)
+      |> assign(:editing, false)
+      |> assign(:edit_form, nil)
+      |> assign(:edit_error, nil)
+
+    {:noreply, socket}
+  end
+
+  # `SEC-A06`'s reveal-before-edit gate: `key` is forgeable via
+  # `phx-value-key`, exactly like `reveal/3`'s `key` argument, so this
+  # pattern-matches `socket.assigns.revealed` — never trusts the UI having
+  # hidden the Edit button — and rejects anything that is not a `%Secret{}`
+  # for this exact key. Hiding a button is convenience; this check is the
+  # gate.
+  @impl Phoenix.LiveView
+  def handle_event("edit", %{"key" => key}, socket) do
+    case socket.assigns.revealed do
+      %Secret{key: ^key} = secret ->
+        socket =
+          socket
+          |> assign(:editing, true)
+          |> assign(:edit_form, build_edit_form(secret.value))
+          |> assign(:edit_error, nil)
+
+        {:noreply, socket}
+
+      _not_revealed ->
+        {:noreply, put_flash(socket, :error, "Reveal the value before editing it.")}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate_edit", %{"secret" => params}, socket) do
+    if socket.assigns.editing do
+      changeset =
+        %EditForm{}
+        |> EditForm.changeset(params)
+        |> Map.put(:action, :validate)
+
+      {:noreply, assign(socket, :edit_form, to_form(changeset, as: :secret))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # Re-checked here, not only in "edit" — the reveal could have been cleared
+  # (a hide, a navigation) between opening the form and submitting it.
+  @impl Phoenix.LiveView
+  def handle_event("save_edit", %{"key" => key, "secret" => params}, socket) do
+    case socket.assigns.revealed do
+      %Secret{key: ^key} ->
+        changeset =
+          %EditForm{}
+          |> EditForm.changeset(params)
+          |> Map.put(:action, :validate)
+
+        if changeset.valid? do
+          save_edit(socket, key, Ecto.Changeset.get_field(changeset, :value))
+        else
+          {:noreply, assign(socket, :edit_form, to_form(changeset, as: :secret))}
+        end
+
+      _not_revealed ->
+        {:noreply, put_flash(socket, :error, "Reveal the value before editing it.")}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("cancel_edit", _params, socket) do
+    # `:revealed` is untouched — cancelling an edit is not hiding
+    # (`SEC-A04`), and no backend call or audit event happens on this path.
+    socket =
+      socket
+      |> assign(:editing, false)
+      |> assign(:edit_form, nil)
+      |> assign(:edit_error, nil)
+
+    {:noreply, socket}
   end
 
   @impl Phoenix.LiveView
@@ -214,6 +351,41 @@ defmodule NucleusWeb.SecretsLive do
   @impl Phoenix.LiveView
   def handle_event("retry", _params, socket) do
     {:noreply, fetch_secrets(socket, socket.assigns.environment)}
+  end
+
+  defp save_edit(socket, key, value) do
+    case Secrets.update(socket.assigns.environment, key, value, socket.assigns.current_scope) do
+      {:ok, ref} ->
+        socket =
+          socket
+          # `SEC-A07`: re-masked because `:revealed` goes to `nil`, which
+          # also removes the modal (and the edit form inside it) from the
+          # DOM — there is no separate re-mask step.
+          |> assign(:revealed, nil)
+          |> assign(:editing, false)
+          |> assign(:edit_form, nil)
+          |> assign(:edit_error, nil)
+          |> put_flash(:info, "#{key} was updated.")
+          |> stream_insert(:secrets, ref)
+
+        {:noreply, socket}
+
+      {:error, %Error{} = error} ->
+        # `SEC-A08`: the form stays open (`:editing` untouched, `:edit_form`
+        # keeps the submitted value via the caller's own reassignment below)
+        # and `:revealed` is untouched — a failure must not re-mask.
+        changeset =
+          %EditForm{}
+          |> EditForm.changeset(%{"value" => value})
+          |> Map.put(:action, :validate)
+
+        socket =
+          socket
+          |> assign(:edit_form, to_form(changeset, as: :secret))
+          |> assign(:edit_error, edit_error_message(error))
+
+        {:noreply, socket}
+    end
   end
 
   defp fetch_secrets(socket, environment) do
@@ -347,32 +519,80 @@ defmodule NucleusWeb.SecretsLive do
         --%>
         <.modal :if={@revealed} id={modal_id()} show on_cancel={JS.push("hide")}>
           <:title>{@revealed.key}</:title>
-          <%!--
-          `tabindex="0"` is not decoration: `max-h-60` is about twelve lines
-          of `font-mono text-sm`, and a PEM key or a service-account JSON blob
-          runs past that. Without it the region scrolls for a mouse and is
-          unreachable for a keyboard, since `focus_wrap` cycles only the three
-          buttons. `role="region"` + a name is what makes a focus stop on
-          non-interactive content announce as something rather than nothing.
-          --%>
-          <div
-            id="secret-modal-value"
-            tabindex="0"
-            role="region"
-            aria-label="Secret value"
-            class="font-mono text-sm break-all select-all rounded-box bg-base-200 p-3 max-h-60 overflow-y-auto"
-          >
-            {@revealed.value}
-          </div>
-          <div class="modal-action">
-            <.copy_button
-              id="secret-modal-copy"
-              value={@revealed.value}
-              label="Copy value"
-              show_label
-            />
-            <.button id="secret-modal-dismiss" phx-click="hide">Close</.button>
-          </div>
+          <%= if @editing do %>
+            <.form
+              for={@edit_form}
+              id="secret-edit-form"
+              phx-change="validate_edit"
+              phx-submit="save_edit"
+            >
+              <input type="hidden" name="key" value={@revealed.key} />
+              <.input
+                field={@edit_form[:value]}
+                id="secret-edit-value"
+                type="textarea"
+                label="Value"
+                rows="6"
+                class="font-mono text-sm"
+              />
+              <div id="secret-edit-count" class="text-xs text-base-content/70 text-right mt-1">
+                {edit_value_length(@edit_form)}/{Nucleus.Secrets.Value.max_length()} characters
+              </div>
+              <p
+                :if={@edit_error}
+                id="secret-edit-error"
+                role="alert"
+                class="text-error text-sm mt-2"
+              >
+                {@edit_error}
+              </p>
+              <div class="modal-action">
+                <.button id="cancel-edit" type="button" phx-click="cancel_edit">
+                  Cancel
+                </.button>
+                <.button
+                  id="save-edit"
+                  type="submit"
+                  class="btn-primary"
+                  disabled={not edit_dirty?(@edit_form, @revealed.value)}
+                  phx-disable-with="Saving..."
+                >
+                  Save
+                </.button>
+              </div>
+            </.form>
+          <% else %>
+            <%!--
+            `tabindex="0"` is not decoration: `max-h-60` is about twelve lines
+            of `font-mono text-sm`, and a PEM key or a service-account JSON
+            blob runs past that. Without it the region scrolls for a mouse
+            and is unreachable for a keyboard, since `focus_wrap` cycles only
+            the buttons. `role="region"` + a name is what makes a focus stop
+            on non-interactive content announce as something rather than
+            nothing.
+            --%>
+            <div
+              id="secret-modal-value"
+              tabindex="0"
+              role="region"
+              aria-label="Secret value"
+              class="font-mono text-sm break-all select-all rounded-box bg-base-200 p-3 max-h-60 overflow-y-auto"
+            >
+              {@revealed.value}
+            </div>
+            <div class="modal-action">
+              <.button id="edit-secret" phx-click="edit" phx-value-key={@revealed.key}>
+                Edit
+              </.button>
+              <.copy_button
+                id="secret-modal-copy"
+                value={@revealed.value}
+                label="Copy value"
+                show_label
+              />
+              <.button id="secret-modal-dismiss" phx-click="hide">Close</.button>
+            </div>
+          <% end %>
         </.modal>
       </div>
     </Layouts.app>
@@ -407,6 +627,55 @@ defmodule NucleusWeb.SecretsLive do
 
   defp reveal_error_message(%Error{}) do
     "Can't retrieve this secret's value right now. Try again shortly."
+  end
+
+  # `SEC-A08`'s kind-specific copy for a failed save — mirrors
+  # `reveal_error_message/1`'s shape, but distinct text: a reveal failure
+  # means no dialog opens at all, where a save failure means the dialog (and
+  # the user's typed value) must stay exactly where it was.
+  defp edit_error_message(%Error{kind: :not_found}) do
+    "This secret no longer exists. It may have been removed outside Nucleus."
+  end
+
+  defp edit_error_message(%Error{kind: :auth_expired}) do
+    "This environment's secrets can't be reached right now."
+  end
+
+  defp edit_error_message(%Error{kind: :unavailable}) do
+    "Can't save this value right now. Try again shortly."
+  end
+
+  defp edit_error_message(%Error{kind: :invalid}) do
+    "That value isn't valid."
+  end
+
+  defp edit_error_message(%Error{}) do
+    "Can't save this value right now. Try again shortly."
+  end
+
+  # Fresh each time, never reused across a reveal/edit cycle — a schemaless
+  # `%EditForm{}` prefilled with the currently-revealed value, unvalidated
+  # (`action: nil`) so opening the form shows no errors before the user has
+  # typed anything.
+  defp build_edit_form(value) do
+    %EditForm{}
+    |> EditForm.changeset(%{"value" => value})
+    |> to_form(as: :secret)
+  end
+
+  defp edit_value_length(form) do
+    form[:value].value
+    |> to_string()
+    |> String.length()
+  end
+
+  # Save starts disabled and enables only once the entered value differs
+  # from the currently-revealed one — decided directly for this ticket, not
+  # merely "non-empty". Convenience only: the reveal-before-edit gate in
+  # `handle_event("save_edit", ...)` is what actually stops a save, not this
+  # attribute.
+  defp edit_dirty?(form, original_value) do
+    to_string(form[:value].value) != to_string(original_value)
   end
 
   defp format_last_modified(nil), do: "—"

--- a/lib/nucleus_web/live/secrets_live/edit_form.ex
+++ b/lib/nucleus_web/live/secrets_live/edit_form.ex
@@ -1,0 +1,54 @@
+defmodule NucleusWeb.SecretsLive.EditForm do
+  @moduledoc """
+  The changeset backing `SEC-A06`'s edit-value form.
+
+  An `embedded_schema` with a single `:value` field — no repo, per
+  `AGENTS.md`'s Ecto guideline that `Ecto.Changeset` is retained for form
+  validation with no database involved. This is the first form this
+  application has needed; `SEC-S6`'s creation form is expected to follow the
+  same shape for its own value field.
+
+  `changeset/2` runs `Nucleus.Secrets.Value.validate/1` — the same function
+  `Nucleus.Secrets.update/4` calls before ever reaching the store — via
+  `validate_change/3`, so the inline error a user sees while typing and the
+  error the context function would return on submission are always the same
+  text. There is deliberately no second copy of "must not be empty" or
+  "exceeds 4096 characters" here.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Secrets.Value
+
+  @primary_key false
+  embedded_schema do
+    field :value, :string
+  end
+
+  @doc """
+  Builds a changeset from `attrs` (string-keyed form params, e.g.
+  `%{"value" => "..."}`).
+  """
+  @spec changeset(t :: Ecto.Schema.t(), attrs :: map()) :: Ecto.Changeset.t()
+  def changeset(form, attrs) do
+    form
+    |> cast(attrs, [:value])
+    |> validate_required([:value], message: "can't be blank")
+    |> validate_change(:value, &validate_secret_value/2)
+  end
+
+  # Emptiness is `validate_required/3`'s job, above — skipped here so a blank
+  # value shows exactly one error, not "can't be blank" and "must not be
+  # empty" stacked on the same field.
+  defp validate_secret_value(:value, ""), do: []
+
+  defp validate_secret_value(:value, value) do
+    case Value.validate(value) do
+      :ok -> []
+      {:error, %Error{message: message}} -> [value: message]
+    end
+  end
+end

--- a/test/nucleus/secrets_test.exs
+++ b/test/nucleus/secrets_test.exs
@@ -117,6 +117,59 @@ defmodule Nucleus.SecretsTest do
     )
   end
 
+  defmodule FailingUpdateSecretStore do
+    @moduledoc """
+    A `Nucleus.Secrets.Store` implementation whose `update_secret/3` always
+    fails `:unavailable`, mirroring `FailingGetSecretStore` above — same
+    reasoning: `LOCAL_FORCE_ERROR` is node-global and would be intercepted by
+    `update/4`'s environment gate (`boundary: :tenant_api`) first.
+
+    `get_secret/2` delegates to the real `Nucleus.Secrets.Store.Local`, so a
+    test can still confirm the value is unchanged after a forced update
+    failure.
+    """
+    @behaviour Nucleus.Secrets.Store
+
+    @impl Nucleus.Secrets.Store
+    def list_secrets(_environment), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def get_secret(environment, key) do
+      Nucleus.Secrets.Store.Local.get_secret(environment, key)
+    end
+
+    @impl Nucleus.Secrets.Store
+    def create_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def update_secret(_environment, _key, _value) do
+      {:error, Error.new(:unavailable, :secrets, "forced for test", %{})}
+    end
+
+    @impl Nucleus.Secrets.Store
+    def locate_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_environments, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_all_secrets, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_failing_get_secret_or_update_store do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, FailingUpdateSecretStore)
+    )
+  end
+
   describe "list/2 — SEC-A01 shape" do
     @tag action: "SEC-A01"
     test "returns SecretRef structs with key, path, arn populated" do
@@ -282,6 +335,157 @@ defmodule Nucleus.SecretsTest do
         end)
 
       refute log =~ @db_url_value
+    end
+  end
+
+  describe "update/4 — SEC-A06 success" do
+    @tag action: "SEC-A06"
+    test "changes the value; a subsequent reveal/3 returns the new value" do
+      assert {:ok, %SecretRef{key: "DATABASE_URL"}} =
+               Secrets.update("prod", "DATABASE_URL", "new-value", @scope)
+
+      assert {:ok, %Secret{value: "new-value"}} =
+               Secrets.reveal("prod", "DATABASE_URL", @scope)
+    end
+
+    @tag action: "SEC-A06"
+    test "emits exactly one secret_updated with the full path as resource" do
+      assert {:ok, ref} = Secrets.update("prod", "DATABASE_URL", "new-value", @scope)
+
+      assert_audit_event(:secret_updated, tenant: "acme", resource: ref.path)
+
+      events = Enum.filter(audit_events(), &(&1.event == :secret_updated))
+      assert length(events) == 1
+    end
+
+    @tag action: "SEC-A06"
+    test "the AUD-A02 guard — refute_audit_contains/1 for both the old and the new value" do
+      Secrets.update("prod", "DATABASE_URL", "new-value", @scope)
+
+      refute_audit_contains(@db_url_value)
+      refute_audit_contains("new-value")
+    end
+
+    @tag action: "SEC-A06"
+    test "user is Scope.audit_user/1's result, falling back to username when email is absent" do
+      scope = %Scope{tenant: "acme", user: %{email: nil, username: "auser"}}
+
+      Secrets.update("prod", "DATABASE_URL", "new-value", scope)
+
+      assert_audit_event(:secret_updated, user: "auser")
+    end
+
+    @tag action: "SEC-A06"
+    test "resource is the full path, not the bare key" do
+      assert {:ok, ref} = Secrets.update("prod", "DATABASE_URL", "new-value", @scope)
+
+      record = assert_audit_event(:secret_updated)
+      assert record.resource == ref.path
+      refute record.resource == "DATABASE_URL"
+    end
+
+    @tag action: "SEC-A06"
+    test "returns a SecretRef, with no value key" do
+      assert {:ok, ref} = Secrets.update("prod", "DATABASE_URL", "new-value", @scope)
+
+      refute Map.has_key?(ref, :value)
+    end
+  end
+
+  describe "update/4 — SEC-A06 missing key" do
+    @tag action: "SEC-A06"
+    test "on a missing key returns :not_found, creates nothing, emits no audit event" do
+      assert {:error, %Error{kind: :not_found}} =
+               Secrets.update("prod", "NO_SUCH_KEY", "value", @scope)
+
+      assert {:error, %Error{kind: :not_found}} =
+               Secrets.reveal("prod", "NO_SUCH_KEY", @scope)
+
+      assert_no_audit_event(:secret_updated)
+    end
+  end
+
+  describe "update/4 — SEC-A08 validation failures" do
+    @tag action: "SEC-A08"
+    test "an over-4096-character value is :invalid, no store call, no audit event" do
+      use_exploding_secrets_store()
+      too_long = String.duplicate("a", 4097)
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.update("prod", "DATABASE_URL", too_long, @scope)
+
+      assert_no_audit_event(:secret_updated)
+    end
+
+    @tag action: "SEC-A08"
+    test "an empty value is :invalid" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.update("prod", "DATABASE_URL", "", @scope)
+
+      assert_no_audit_event(:secret_updated)
+    end
+
+    @tag action: "SEC-A08"
+    test "a forged key containing '..' is :invalid, no store call" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.update("prod", "../../other-env/secret", "value", @scope)
+
+      assert_no_audit_event(:secret_updated)
+    end
+
+    @tag action: "SEC-A08"
+    test "a forced store :unavailable emits no audit event; the value is unchanged in the store" do
+      original = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      use_failing_get_secret_or_update_store()
+
+      assert {:error, %Error{kind: :unavailable, boundary: :secrets}} =
+               Secrets.update("prod", "DATABASE_URL", "attempted-new-value", @scope)
+
+      assert_no_audit_event(:secret_updated)
+      assert original == Secrets.Store.get_secret("prod", "DATABASE_URL")
+    end
+  end
+
+  describe "update/4 — value length boundary" do
+    @tag action: "SEC-A06"
+    test "a 4096-character value succeeds; 4097 fails" do
+      exactly_max = String.duplicate("a", 4096)
+      over_max = String.duplicate("a", 4097)
+
+      assert {:ok, _ref} = Secrets.update("prod", "DATABASE_URL", exactly_max, @scope)
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.update("prod", "DATABASE_URL", over_max, @scope)
+    end
+
+    @tag action: "SEC-A06"
+    test "a multi-byte value of 4096 characters succeeds — String.length, not byte_size" do
+      # "é" is two bytes in UTF-8 but one character.
+      multibyte_value = String.duplicate("é", 4096)
+      assert String.length(multibyte_value) == 4096
+      assert byte_size(multibyte_value) > 4096
+
+      assert {:ok, _ref} = Secrets.update("prod", "DATABASE_URL", multibyte_value, @scope)
+    end
+  end
+
+  describe "update/4 — no value in logs" do
+    test "neither the old nor the new value appears in captured log output, success or failure" do
+      new_value = "brand-new-value"
+
+      log =
+        capture_log(fn ->
+          Secrets.update("prod", "DATABASE_URL", new_value, @scope)
+          Secrets.update("prod", "NO_SUCH_KEY", new_value, @scope)
+          Secrets.update("prod", "DATABASE_URL", "", @scope)
+        end)
+
+      refute log =~ @db_url_value
+      refute log =~ new_value
     end
   end
 end

--- a/test/nucleus_web/live/secrets_live_test.exs
+++ b/test/nucleus_web/live/secrets_live_test.exs
@@ -742,6 +742,352 @@ defmodule NucleusWeb.SecretsLiveTest do
     end
   end
 
+  defmodule FailingUpdateSecretsStore do
+    @moduledoc """
+    A `Nucleus.Secrets.Store` implementation whose `update_secret/3` always
+    fails `:unavailable` while `list_secrets/1` and `get_secret/2` delegate
+    to the real `Nucleus.Secrets.Store.Local` — so a reveal (needed to open
+    the edit form in the first place) still succeeds, and only the save
+    itself fails. Mirrors `FailingSecretsStore`'s reasoning for why swapping
+    the boundary's implementation, not `LOCAL_FORCE_ERROR`, is the only way
+    to force a `boundary: :secrets` failure from this LiveView.
+    """
+    @behaviour Nucleus.Secrets.Store
+
+    @impl Nucleus.Secrets.Store
+    def list_secrets(environment), do: Nucleus.Secrets.Store.Local.list_secrets(environment)
+
+    @impl Nucleus.Secrets.Store
+    def get_secret(environment, key), do: Nucleus.Secrets.Store.Local.get_secret(environment, key)
+
+    @impl Nucleus.Secrets.Store
+    def create_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def update_secret(_environment, _key, _value) do
+      {:error, Error.new(:unavailable, :secrets, "forced for test", %{})}
+    end
+
+    @impl Nucleus.Secrets.Store
+    def locate_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_environments, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_all_secrets, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_failing_update_secrets_store do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, FailingUpdateSecretsStore)
+    )
+  end
+
+  defp restore_secrets_store do
+    original = Application.get_env(:nucleus, :backends, [])
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, Secrets.Store.Local)
+    )
+  end
+
+  describe "SEC-A06 — edit a secret's value" do
+    @tag action: "SEC-A06"
+    test "rejects editing a value that has not been revealed", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      refute has_element?(view, "#secret-edit-form")
+      assert has_element?(view, "#flash-error")
+    end
+
+    @tag action: "SEC-A06"
+    test "rejects save_edit dispatched directly without a prior reveal: no mutation, no audit event",
+         %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      render_click(view, "save_edit", %{
+        "key" => "DATABASE_URL",
+        "secret" => %{"value" => "attacker-value"}
+      })
+
+      assert {:ok, %{value: ^db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert_no_audit_event(:secret_updated)
+    end
+
+    @tag action: "SEC-A06"
+    test "reveal -> edit opens the form prefilled with the current value", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      html = render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      assert has_element?(view, "#secret-edit-form")
+      assert has_element?(view, "#secret-edit-value")
+      assert html =~ db_value
+    end
+
+    @tag action: "SEC-A06"
+    test "save with a new value updates it; revealing again shows the new value", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      view
+      |> form("#secret-edit-form", secret: %{"value" => "brand-new-connection-string"})
+      |> render_submit()
+
+      row_id = row_id(view, "DATABASE_URL")
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+
+      assert html =~ "brand-new-connection-string"
+    end
+
+    @tag action: "SEC-A06"
+    test "cancel discards the change, the value is unchanged in the store, and stays revealed",
+         %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+      assert html =~ db_value
+
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+      assert has_element?(view, "#secret-edit-form")
+
+      view
+      |> form("#secret-edit-form", secret: %{"value" => "not-going-to-be-saved"})
+      |> render_change()
+
+      html = view |> element("#cancel-edit") |> render_click()
+
+      refute has_element?(view, "#secret-edit-form")
+      # The value stays revealed — cancelling an edit is not hiding.
+      assert has_element?(view, "#secret-modal")
+      assert html =~ db_value
+
+      assert {:ok, %{value: ^db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert_no_audit_event(:secret_updated)
+    end
+  end
+
+  describe "SEC-A07 — confirmation on successful secret update" do
+    @tag action: "SEC-A07"
+    test "a confirmation flash appears on success", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      view
+      |> form("#secret-edit-form", secret: %{"value" => "brand-new-connection-string"})
+      |> render_submit()
+
+      assert has_element?(view, "#flash-info")
+      assert view |> element("#flash-info") |> render() =~ "DATABASE_URL"
+    end
+
+    @tag action: "SEC-A07"
+    test "after save the value is re-masked: absent from the payload and the control reads View again",
+         %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      html =
+        view
+        |> form("#secret-edit-form", secret: %{"value" => "brand-new-connection-string"})
+        |> render_submit()
+
+      refute html =~ db_value
+      refute html =~ "brand-new-connection-string"
+      refute has_element?(view, "#secret-modal")
+      assert html =~ "View"
+    end
+
+    @tag action: "SEC-A07"
+    test "the form is closed after a successful save", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+      assert has_element?(view, "#secret-edit-form")
+
+      view
+      |> form("#secret-edit-form", secret: %{"value" => "brand-new-connection-string"})
+      |> render_submit()
+
+      refute has_element?(view, "#secret-edit-form")
+    end
+
+    @tag action: "SEC-A07"
+    test "last_modified in the row updates", %{conn: conn} do
+      assert {:ok, view, html_before} = live_secrets(conn, "prod")
+      row_id_before = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id_before}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      html_after =
+        view
+        |> form("#secret-edit-form", secret: %{"value" => "brand-new-connection-string"})
+        |> render_submit()
+
+      before_row =
+        LazyHTML.from_fragment(html_before) |> LazyHTML.query("[data-key=\"DATABASE_URL\"]")
+
+      before_text = LazyHTML.text(before_row)
+
+      after_row =
+        LazyHTML.from_fragment(html_after) |> LazyHTML.query("[data-key=\"DATABASE_URL\"]")
+
+      after_text = LazyHTML.text(after_row)
+
+      refute before_text == after_text
+    end
+  end
+
+  describe "SEC-A08 — clear failure feedback on update" do
+    @tag action: "SEC-A08"
+    test "with the store forced :unavailable, an error is shown, the form stays open, and the entered value is still in the input",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      use_failing_update_secrets_store()
+
+      html =
+        view
+        |> form("#secret-edit-form", secret: %{"value" => "attempted-new-value"})
+        |> render_submit()
+
+      assert has_element?(view, "#secret-edit-error")
+      assert has_element?(view, "#secret-edit-form")
+      assert html =~ "attempted-new-value"
+    end
+
+    @tag action: "SEC-A08"
+    test "after a failure, retrying with the store restored succeeds without re-entering the value",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      use_failing_update_secrets_store()
+
+      form =
+        view
+        |> form("#secret-edit-form", secret: %{"value" => "attempted-new-value"})
+
+      render_submit(form)
+      assert has_element?(view, "#secret-edit-error")
+
+      restore_secrets_store()
+
+      html = render_submit(form)
+
+      refute html =~ "attempted-new-value"
+      refute has_element?(view, "#secret-edit-form")
+      assert has_element?(view, "#flash-info")
+    end
+
+    @tag action: "SEC-A08"
+    test "after a failure, cancel is still available and discards cleanly", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      use_failing_update_secrets_store()
+
+      view
+      |> form("#secret-edit-form", secret: %{"value" => "attempted-new-value"})
+      |> render_submit()
+
+      assert has_element?(view, "#secret-edit-error")
+
+      html = view |> element("#cancel-edit") |> render_click()
+
+      refute has_element?(view, "#secret-edit-form")
+      assert html =~ db_value
+      assert {:ok, %{value: ^db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+    end
+
+    @tag action: "SEC-A08"
+    test "an over-length value shows an inline error and does not submit", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      view |> element("#reveal-#{row_id}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+
+      too_long = String.duplicate("a", 4097)
+
+      html =
+        view
+        |> form("#secret-edit-form", secret: %{"value" => too_long})
+        |> render_change()
+
+      assert html =~ "exceeds 4096 characters"
+
+      view
+      |> form("#secret-edit-form", secret: %{"value" => too_long})
+      |> render_submit()
+
+      assert has_element?(view, "#secret-edit-form")
+      assert {:ok, %{value: ^db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert_no_audit_event(:secret_updated)
+    end
+  end
+
+  describe "SEC-S5 — editing does not disturb another row's state" do
+    test "revealing a second secret while editing the first discards the first's edit cleanly",
+         %{conn: conn} do
+      assert {:ok, %{value: stripe_value}} = Secrets.Store.get_secret("prod", "STRIPE_API_KEY")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#reveal-#{row_id(view, "DATABASE_URL")}") |> render_click()
+      render_click(view, "edit", %{"key" => "DATABASE_URL"})
+      assert has_element?(view, "#secret-edit-form")
+
+      html = view |> element("#reveal-#{row_id(view, "STRIPE_API_KEY")}") |> render_click()
+
+      assert html =~ stripe_value
+      refute has_element?(view, "#secret-edit-form")
+    end
+  end
+
   describe "SEC-S4 — reveal state is cleared on navigation" do
     test "navigating away and back closes the modal and drops the plaintext", %{conn: conn} do
       assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")


### PR DESCRIPTION
## What

This implements editing a revealed secret's value directly inside the existing reveal modal from SEC-S4/SEC-S3, gated so a value must currently be revealed before it can be edited. Opening edit swaps the modal's content in place from the value display to a `to_form/2`-built edit form; saving successfully re-masks the value (by clearing `:revealed`) and closes the modal with a confirmation flash; a failed save keeps the form open with the entered value intact so nothing is silently discarded; and cancelling discards the change without touching reveal state or hitting the backend. `Nucleus.Secrets.update/4` validates environment, key, and value shape before calling the store, and emits exactly one `secret_updated` audit event on success with neither the old nor new value in the record.

Closes #13

## How

- `Nucleus.Secrets.Value.validate/1` — shared value validator (non-empty, ≤4096 characters via `String.length/1`, not `byte_size/1`), returning the same `Nucleus.Backend.Error.t()` shape as every other validation step in the module.
- `Nucleus.Secrets.update/4` — fetches the environment, re-validates the key shape, validates the value, then delegates to `Nucleus.Secrets.Store.update_secret/3` (which cannot create), emitting `secret_updated` only on success. The context does not itself enforce reveal-before-edit — that's UI session state the context has no view of — and this is documented in the `@doc`.
- `NucleusWeb.SecretsLive.EditForm` — a tiny `embedded_schema` with one `:value` field, whose changeset runs `Value.validate/1` through `validate_change/3` so the inline typing error and the submission error are the same text, defined once. This is the first form in the codebase and establishes the pattern.
- The reveal-before-edit gate lives in `handle_event/3` for both `"edit"` and `"save_edit"`, matching `socket.assigns.revealed` against `%Secret{key: ^key}` and rejecting anything else — `nil`, or a revealed secret for a different key. The gate is re-checked independently of the `:editing` UI toggle, so it fires the same way whether or not a client ever rendered the Edit control.
- A successful `save_edit` sets `:revealed` to `nil`; because the modal is conditionally rendered on `@revealed`, this single assign removes the modal, the value, and the form from the DOM in one step — re-masking is a consequence of that assign, not a separate instruction.
- The Save button is disabled client-side until the form's value differs from the original (`edit_dirty?/2`); this is UI convenience only, and `save_edit` re-validates and re-checks the gate regardless of what the browser sent.
- `NucleusWeb.CoreComponents.button/1`'s global attribute allowlist gained `type`, needed so the Cancel button inside the new `<form>` doesn't default to `type="submit"`.
- Satisfies **SEC-A06** (edit gated on prior reveal, cancel discards), **SEC-A07** (confirmation flash and re-masking on success), and **SEC-A08** (clear failure feedback, form stays open with the entered value preserved, retry and cancel remain available).

## Record

**ADR-0013** (`docs/adr/0013-secret-edit-in-modal-and-value-form.md`) settles: editing swaps the reveal modal's content in place rather than stacking a second modal (avoiding ADR-0012's recorded `focusStack`/`JS.pop_focus` double-pop risk structurally rather than mitigating it); the gate matches `%Secret{key: ^key}` rather than consulting the `:editing` toggle; re-masking is a side effect of `:revealed` going to `nil`; the Save button's disabled state is a direct, undocumented-by-the-plan product decision; and `Nucleus.Secrets.Value` plus the `embedded_schema` `EditForm` are introduced as shared, precedent-setting pieces for SEC-S6. `decisions-log.md`, `business-tech-bridge.md`, and `living-notes.md` were updated alongside it, including moving the "SEC-S5's plan going stale under ADR-0012" technical-debt item to the archive now that it's resolved.

## Divergence from the plan

The issue body's plan was written against ADR-0011's `:revealed` shape (a `%{key => Secret.t()}` map) and specified a row-level Edit control gated by checking `key` against that map. ADR-0012 landed first (#43) and replaced the map with a single `%Secret{}` or `nil` tied to one conditionally-rendered modal — and ADR-0012's own "Negative consequences" section already predicted this ticket would need to diverge exactly this way, naming the fix before this ticket started: gate on `socket.assigns.revealed` matching a `%Secret{}` by key, and move the edit affordance inside the modal rather than a row (a row-level control would almost always hit the gate and dead-end, since reveal state only exists while the modal is open). ADR-0013 records the concrete mechanics of that predicted fix. One consequence worth flagging for reviewers checking the plan literally: the plan's row-scoped DOM id table (`#edit-{row_id}`, `#secret-edit-form-{row_id}`, etc.) is not implemented as written — there is one edit form, not one per row, so the ids carry no row suffix (`#secret-edit-form`, `#secret-edit-value`, `#save-edit`, `#cancel-edit`, `#secret-edit-count`).

## Verification

- `test/nucleus/secrets_test.exs` — context-layer coverage for `update/4` tagged `@tag action: "SEC-A06"` and `"SEC-A08"`: value change round-trips through `reveal/3`, exactly one `secret_updated` audit event with the full path as `resource`, neither old nor new value present in the audit record, `:not_found` on a missing key with no secret created, `:invalid` on empty/over-length/forged-key values with no store call.
- `test/nucleus_web/live/secrets_live_test.exs` — LiveView coverage tagged `@tag action: "SEC-A06"` / `"SEC-A07"` / `"SEC-A08"`, including two direct-event-dispatch tests that prove the gate is enforced server-side rather than by hiding a button: `render_click(view, "edit", ...)` and `render_click(view, "save_edit", ...)` dispatched without a prior reveal are both rejected, with no form opening, no store mutation, and no audit event.
- `mix precommit` passed: 448 tests (25 doctests, 423 tests), 9 skipped (pre-existing, documented browser-driver gaps unrelated to this ticket), 10 excluded (`@moduletag :external`, unrelated to this ticket).
