### PR TITLE
SEC-S6: Create a secret, with key and value validation

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.7 | Updated: 2026-08-18 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.8 | Updated: 2026-08-19 -->
 
 # Business ↔ Tech Bridge
 
@@ -54,25 +54,30 @@ to cite from test names and bug reports.
 sidebar) and `test/nucleus_web/live/shell_test.exs` now exist (EN-7) — a deliberate subset only,
 with no `@tag action:` claimed, so `NAV-A01`–`A12` coverage is still zero until the dedicated
 `NAV-*` ticket lands. `NucleusWeb.SecretsLive` and `test/nucleus_web/live/secrets_live_test.exs`
-also now exist (SEC-S1/#9, SEC-S2/#10, SEC-S3/#11, SEC-S4/#12, SEC-S5/#13) — `SEC-A01`–`A08`,
-`SEC-A14`–`A17` are claimed and covered; the module validates and resolves the environment, lists
-a `Nucleus.Secrets` boundary's secrets **with no value column at all** (no plaintext and no mask
-— ADR-0012), copies a row's path/ARN to the clipboard from icon-only buttons whose label is a
+also now exist (SEC-S1/#9, SEC-S2/#10, SEC-S3/#11, SEC-S4/#12, SEC-S5/#13, SEC-S6/#14) —
+`SEC-A01`–`A14`, `A17` are claimed and covered; the module validates and resolves the environment,
+lists a `Nucleus.Secrets` boundary's secrets **with no value column at all** (no plaintext and no
+mask — ADR-0012), copies a row's path/ARN to the clipboard from icon-only buttons whose label is a
 tooltip (`SEC-A02` — wiring only; the clipboard write itself is a recorded browser gap,
 `docs/adr/0008-test-strategy.md`), reveals a value into a modal that is only in the DOM while it
 is open, with a fresh audited fetch on every reveal, lets that same modal swap into an edit form
 gated on the revealed secret matching by key (`SEC-A06`–`A08`, `docs/adr/0013-secret-edit-in-modal-and-value-form.md`),
-and renders every fail-closed/empty/failed-reveal/failed-save state (`SEC-A09`–`A13`, `A18` are
-SEC-S6/S7 and later). Every other row is unimplemented. These names are the agreed target so that
+creates a new secret through a second, independently conditionally-rendered modal
+(`Nucleus.Secrets.Key`/`Nucleus.Secrets.create/4`, `SEC-A09`–`A13`) that closes whichever of the
+two modals is open before opening the other, and renders every fail-closed/empty/failed-reveal/
+failed-save/failed-create state. `SEC-A18` is `SEC-S7` and later. Every other row is
+unimplemented. These names are the agreed target so that
 work lands consistently — treat them as the convention to follow, and correct this table if a
 better structure emerges.
+
 
 Two conformance notes worth carrying forward, both recorded in
 `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md`:
 `SEC-A03`'s "the control changes to 'Hide'" is **not** implemented literally — the row's control
-always reads "View" and the modal's dismiss controls are the hide affordance. `SEC-A04` is
-claimed on the modal's Close button only, the one dismissal route `Phoenix.LiveViewTest` can
-drive; Escape and a backdrop click are wiring-only browser gaps.
+always reads "View" and the modal's dismiss controls are the hide affordance. `SEC-A04`/`SEC-A13`
+are each claimed on their modal's plain-`phx-click` dismiss control only (Close, Cancel) — the
+one dismissal route `Phoenix.LiveViewTest` can drive; Escape and a backdrop click are wiring-only
+browser gaps for both modals.
 
 ## Tagging Convention
 

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.14 | Updated: 2026-08-18 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.15 | Updated: 2026-08-19 -->
 
 # Decisions Log
 
@@ -38,6 +38,7 @@ job and the row should point rather than paraphrase.
 | 11 | Secret reveal — re-stream a converted `SecretRef` (never the value-bearing `Secret`), audit `user:` via `Scope.audit_user/1`, `Nucleus.Audit.Sink.Test` falls back to `$callers` for LiveView-emitted audit events | 2026-08-18 | Decided | `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` |
 | 12 | Secret reveal moves into a conditionally-rendered modal (plaintext never in the DOM while closed), Value column deleted outright, copy buttons icon-only with the label as a daisyUI tooltip; partially supersedes #11's map/re-stream mechanics | 2026-08-18 | Decided | `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md` |
 | 13 | Secret edit lives inside the reveal modal via content-swap-in-place (no second `<.modal>`), gated on `socket.assigns.revealed` matching `%Secret{key: ^key}`; `Nucleus.Secrets.Value` and an `embedded_schema` edit form set the pattern `SEC-S6` reuses | 2026-08-18 | Decided | `docs/adr/0013-secret-edit-in-modal-and-value-form.md` |
+| 14 | Secret creation — one consolidated `Nucleus.Secrets.Key.validate/1` (denylist, no casing rule, `Error.t()` shape matching `Value`), `create/4` relies on the store's atomic `:already_exists` refusal, and the creation modal is mutually exclusive with the reveal modal to structurally avoid ADR-0012's `focusStack` double-pop | 2026-08-19 | Decided | `docs/adr/0014-secret-creation-key-consolidation-and-modal-exclusion.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -59,7 +60,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0013` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0014` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.14 | Updated: 2026-08-18 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.15 | Updated: 2026-08-19 -->
 
 # Living Notes
 
@@ -17,9 +17,8 @@
 | `docs/adr/` had no ADRs while 7 prototype ADRs sit in the wiki | ADR-shaped questions get answered in chat and lost | Medium | Write this project's own ADRs as decisions land — `0001` now exists |
 | LiveDashboard at `/dev/dashboard` unauthenticated | Fine in dev; a leak if ever exposed in prod | Medium | Gate behind auth before any production deploy |
 | Nucleus's own AWS identity (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`) is read ambiently by the `aws` package, with no boot-time check or ops-facing doc — unlike `TENANT_ROLE_ARN`/`AWS_REGION`/`CLUSTER_NAME`/`DEPLOYMENT_NAME`, which all raise at boot | A misconfigured deployment fails per-request as `:not_configured` on first `AssumeRole` call, not at boot | Low | `CLUSTER_NAME`/`DEPLOYMENT_NAME` are now correctly documented in the wiki's `Platform-Operations.md` config reference (issue #22). The ambient `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` doc gap remains open — was out of scope for #22 |
-| No browser-driven test coverage for `SEC-A02` (the `navigator.clipboard.writeText` call itself, the confirmation face swap/revert — an icon in a row, the word "Copied" in the modal — the non-secure-context `execCommand` fallback, the failure indication, and the hover/`:focus-visible` reveal of any tooltip, now on path and ARN values as well as the copy buttons) or for modal dismissal — `SEC-A13`'s focus trap and focus restoration, plus `SEC-A04`'s Escape and backdrop-click routes, which reach the server only by running the `JS` chain in `data-cancel` | Tests assert wiring only (hook attached, `data-value` full/untruncated, `phx-update="ignore"` present, `data-tip` set, `on_cancel`/`phx-key`/`phx-click-away` present), and claim `@tag action:` for `SEC-A04` **only** via the Close button, whose plain `phx-click="hide"` a `render_click/1` can actually drive | Medium | Add Wallaby once sign-in exists (deferred, EN-8); see `docs/adr/0008-test-strategy.md`. Both gap sets are skipped `:browser`-tagged placeholder modules in `secrets_live_test.exs` — `CopyButtonBrowserGaps` (4) and `SecretRevealModalBrowserGaps` (5) |
+| No browser-driven test coverage for `SEC-A02` (the `navigator.clipboard.writeText` call itself, the confirmation face swap/revert — an icon in a row, the word "Copied" in the modal — the non-secure-context `execCommand` fallback, the failure indication, and the hover/`:focus-visible` reveal of any tooltip, now on path and ARN values as well as the copy buttons) or for modal dismissal — `SEC-A13`'s focus trap and focus restoration (both the reveal modal's and the create modal's), plus `SEC-A04`'s Escape and backdrop-click routes, which reach the server only by running the `JS` chain in `data-cancel` | Tests assert wiring only (hook attached, `data-value` full/untruncated, `phx-update="ignore"` present, `data-tip` set, `on_cancel`/`phx-key`/`phx-click-away` present), and claim `@tag action:` for `SEC-A04`/`SEC-A13` **only** via each modal's plain-`phx-click` dismiss control (Close, Cancel), which `render_click/1` can actually drive | Medium | Add Wallaby once sign-in exists (deferred, EN-8); see `docs/adr/0008-test-strategy.md`. Three gap sets are skipped `:browser`-tagged placeholder modules in `secrets_live_test.exs` — `CopyButtonBrowserGaps` (4), `SecretRevealModalBrowserGaps` (5), and `NewSecretModalBrowserGaps` (5) |
 | `LOCAL_FORCE_ERROR` (`Nucleus.Backend.Faults`) is node-global, not per-boundary — a fault set for one boundary is seen by every local implementation's next call | A test targeting the `:secrets` boundary's error path is actually caught by whichever boundary is called first; SEC-S2 found this when `Nucleus.Secrets.list/2`'s `Environments.fetch/2` gate always intercepted the fault before `Store.list_secrets/1` ran | Low | Swap in a real/failing module via `Application.put_env(:nucleus, :backends, ...)` instead of `force_error/2` for a specific-boundary test — see `SecretsLiveTest.FailingSecretsStore` |
-| `Nucleus.Secrets.reveal/3`'s key validator is a second, weaker copy of `Environments.validate_name/1`'s deny-list (`..`, `/`, `\`, null byte only — no charset allowlist, no length cap) | A forged key using percent-double-encoding or a control character other than a null byte could still reach `Store.get_secret/2`/`Path.build/2`; cross-environment traversal is still blocked since `/`, `..`, `\` are denied | Low | `SEC-S6` (issue #14) should replace this with one shared validator, not add a third — see `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` |
 
 ### Technical Debt Details
 
@@ -131,6 +130,13 @@ deploys it.
   renders inside one already-open `<.modal>`) rather than stacking a second `<.modal>` over the
   first — sidesteps ADR-0012's `focusStack`/`JS.pop_focus/1` double-pop risk entirely instead of
   needing a fix for it. See `docs/adr/0013-secret-edit-in-modal-and-value-form.md`.
+- A denylist validator returning `Nucleus.Backend.Error.t()` with the specific reason carried in
+  `error.details.reason` (`Nucleus.Secrets.Key`), matching a sibling shape validator
+  (`Nucleus.Secrets.Value`) that returns the same struct — two validators feeding the same
+  `with` chain (`Nucleus.Secrets.create/4`) need no special case for either one's failure, and a
+  form layer that needs distinct per-rule copy (`SEC-A10`) reads `error.message` directly rather
+  than pattern-matching a bare atom. See `docs/adr/0013-secret-edit-in-modal-and-value-form.md`'s
+  addendum.
 
 ### Gotchas for Maintainers
 - **Requirements are a submodule.** Fresh clones need
@@ -149,8 +155,13 @@ deploys it.
   `JS.exec("phx-remove")`, then again when the server removes the element and `phx-remove` fires
   for real. Harmless while one modal is open — the second pop finds an empty `focusStack` and
   no-ops — but `focusStack` is module-global, so **two modals open at once would have the inner
-  one consume the outer one's saved focus**. `SEC-S6`'s creation form must not open over the
-  reveal modal without revisiting this. See
+  one consume the outer one's saved focus**. `NucleusWeb.SecretsLive` now has two independently
+  conditionally-rendered modals (reveal, `SEC-S4`/ADR-0012; create, `SEC-S6`) and resolves this by
+  **mutual exclusion, not a fix to the interaction itself**: opening either one
+  (`"reveal"`/`"new_secret"`) resets the other's assigns to its closed state in the same step, so
+  the two are never both mounted at once as a structural guarantee. Reaching for a third
+  conditionally-rendered modal in this LiveView means extending that mutual-exclusion set, not
+  assuming the existing pair already covers it. See
   `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md`.
 - **`CoreComponents.modal/1` has two legitimate usages, and the wrong one leaks.** Left mounted
   and toggled with `modal-open`, its inner block is in the DOM (and in view-source) while the
@@ -165,6 +176,19 @@ deploys it.
 ## Archive (Resolved Items)
 
 Moved here for historical reference.
+
+**`Nucleus.Secrets.reveal/3`'s key validator was a second, weaker copy of `Environments.validate_name/1`'s deny-list** — *was: Technical Debt, Low*
+*Resolved*: 2026-08-19 by SEC-S6 (issue #14).
+*Outcome*: Consolidated into `Nucleus.Secrets.Key.validate/1` — the one key validator in the
+application, shared by `reveal/3`, `update/4`, and the new `create/4` (`SEC-A09`). Same denylist
+(`..`, `/`, `\`, null byte, empty, over 256 characters), now with a distinct reason atom per rule
+in `error.details.reason` (`SEC-A10`'s "the form indicates the specific problem"), and a
+deliberate decision to add **no casing rule** — considered and rejected, since a create-only
+casing constraint would route a rejected legitimate key around Nucleus entirely rather than
+through its audit trail. The 256-character cap now applies to the read path too, documented as a
+deliberate consequence rather than left to be discovered.
+*See*: `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`,
+`docs/adr/0013-secret-edit-in-modal-and-value-form.md`'s addendum, and SEC-S6's own ADR.
 
 **`SEC-S5`'s plan (issue #13) was stale under ADR-0012** — *was: Technical Debt, Medium*
 *Resolved*: 2026-08-18 by SEC-S5 (issue #13).

--- a/docs/adr/0013-secret-edit-in-modal-and-value-form.md
+++ b/docs/adr/0013-secret-edit-in-modal-and-value-form.md
@@ -85,6 +85,24 @@ shape every other validation step in `Nucleus.Secrets` returns, so
 error. `SEC-S6` (issue #14) is expected to reuse this module unchanged for
 its own value field rather than writing a second copy.
 
+### `SEC-S6`'s sibling key validator returns the same `Error.t()` shape, not a bare atom
+
+`SEC-S6`'s own plan (issue #14) originally specified
+`Nucleus.Secrets.Key.validate/1 :: :ok | {:error, atom()}` — a bare reason
+atom per rule. Settled during that ticket's implementation, against this
+ADR's own precedent: `Key.validate/1` returns `:ok | {:error,
+Nucleus.Backend.Error.t()}`, matching `Value.validate/1` exactly, with the
+distinct per-rule reason atom carried in `error.details.reason` (e.g.
+`%{reason: :too_long}`) rather than as the return value itself. Two
+sibling validators in one namespace, feeding the same `create/4` `with`
+chain `update/4` already established, returning different shapes on
+success would have been an accident of authorship order, not a deliberate
+choice — `create/4` needs no special case for either validator's failure,
+the same reason `update/4` needs none for `Value`'s. `SEC-A10`'s "the form
+indicates the specific problem" is still satisfied: the reason atom in
+`details` is what a test or the changeset layer matches on, and
+`error.message` still carries the distinct human-readable copy per rule.
+
 ### The edit form is an `embedded_schema` changeset, not a schemaless one
 
 `NucleusWeb.SecretsLive.EditForm` is a tiny `embedded_schema` with one
@@ -191,5 +209,7 @@ future reader would have to reverse-engineer the reason for.
   Debt entry this ADR resolves (SEC-S5's plan going stale under ADR-0012)
 - SEC-S6 (issue #14) — expected to reuse
   `Nucleus.Secrets.Value` and the `embedded_schema` form pattern for its own
-  key+value creation form
+  key+value creation form; settled its own `Key.validate/1`'s return shape
+  against this ADR's `Value.validate/1` precedent rather than the bare atom
+  its original plan specified
 </content>

--- a/docs/adr/0014-secret-creation-key-consolidation-and-modal-exclusion.md
+++ b/docs/adr/0014-secret-creation-key-consolidation-and-modal-exclusion.md
@@ -1,0 +1,196 @@
+# ADR-0014: Secret Creation — Key Validator Consolidation and Modal Mutual Exclusion
+
+## Status
+
+Accepted — 2026-08-19
+
+Decided on [SEC-S6](https://github.com/dave-bell/nucleus/issues/14). Builds on
+`0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` (the
+provisional weak key denylist this ticket replaces),
+`0012-secret-reveal-modal-and-icon-only-copy-affordances.md` (the
+conditionally-rendered modal shape and its `focusStack` risk), and
+`0013-secret-edit-in-modal-and-value-form.md` (the `Value`/`EditForm`
+pattern this ticket's own form follows, plus its own addendum settling the
+error-shape question below).
+
+## Context
+
+SEC-S6 implements `SEC-A09`–`SEC-A13`: creating a secret, validating its key
+and value, rejecting a duplicate, and dismissing the form cleanly. Three
+things the plan (issue #14) either left open or got overtaken by what
+SEC-S4/SEC-S5 actually shipped:
+
+1. `Nucleus.Secrets.reveal/3` and `update/4` carried a private, weaker key
+   denylist (`..`, `/`, `\`, null byte only), explicitly marked provisional
+   pending this ticket's consolidation.
+2. The issue thread settled, before implementation began, that the key
+   validator would add **no casing rule** — the plan itself did not specify
+   this, but the decision was made deliberately as part of this ticket
+   rather than deferred further.
+3. ADR-0012 already predicted that a second conditionally-rendered modal
+   (this ticket's creation form, alongside SEC-S4's reveal modal) risked a
+   `focusStack`/`JS.pop_focus/1` double-pop if both were ever open at once,
+   without prescribing the fix.
+
+## Decision
+
+### `Nucleus.Secrets.Key.validate/1` is the one key validator, denylist not allowlist
+
+One function, in `lib/nucleus/secrets/key.ex`, replacing the private copies
+in `reveal/3` and `update/4` and backing the new `create/4`. Denylist
+exactly as the wiki specifies — empty, over 256 characters, `/`, `\`, a
+null byte, `..` — not `Nucleus.Environments.validate_name/1`'s allowlist:
+keys are user-chosen and resemble environment-variable names (dots, dashes,
+mixed case are all legitimate), where an allowlist strict enough to matter
+would reject real keys.
+
+### It returns `Nucleus.Backend.Error.t()`, not a bare reason atom
+
+The plan specified `:ok | {:error, atom()}`. Settled against
+`Nucleus.Secrets.Value.validate/1`'s already-landed shape instead (see
+ADR-0013's addendum): two sibling validators feeding the same `create/4`
+`with` chain returning different shapes on failure would be an accident of
+authorship order, not a deliberate choice. The per-rule distinction
+`SEC-A10` requires lives in `error.details.reason` — one of `:empty`,
+`:too_long`, `:forward_slash`, `:backslash`, `:null_byte`,
+`:path_traversal` — checked in a fixed order so a key violating more than
+one rule reports deterministically, while `error.message` carries the
+distinct human-readable copy the form shows directly.
+
+### No casing rule, and no create-only tightening beyond the wiki's four denied sequences
+
+Considered and rejected: "lowercase except the final, uppercase segment,"
+meant to mirror the seeded fixtures' `DATABASE_URL`-style convention. The
+deciding argument is asymmetric risk, not aesthetics: a validator that
+wrongly rejects a legitimate key does not stop an operator, it routes them
+to the AWS console directly, where no `secret_created` event exists and
+nothing is audited. Wrongly permissive costs a cosmetically inconsistent
+key name; wrongly strict costs audit coverage that cannot be reconstructed
+afterward. Reinforcing that: the requirement is silent on casing (`SEC-A10`
+enumerates its rules exhaustively and casing is not among them), Parameter
+Store keys created outside Nucleus can be any casing regardless of what a
+create-only rule enforces, and `Nucleus.Secrets.list/2` already sorts
+case-insensitively to cope with that reality. The convention is expressed
+as guidance only — a `placeholder="DATABASE_URL"` on `#new-secret-key` plus
+a hint line beneath it — never enforcement. Duplicate detection stays
+case-sensitive, matching Parameter Store's own semantics exactly as
+planned.
+
+### The 256-character cap applies uniformly — read, write, and create alike
+
+`Key.validate/1` backs `reveal/3` and `update/4` as well as `create/4`,
+with one rule set rather than a stricter create-time cap layered on a
+looser read-time one. The accepted, documented consequence: a key longer
+than 256 characters created outside Nucleus would be listable (`list/2`
+runs no per-key validation) but not revealable (`reveal/3` does). Stated
+directly in `Key`'s `@doc` rather than left to be discovered as a bug
+report.
+
+### The creation form is `NucleusWeb.SecretsLive.CreateForm`, following `EditForm`'s landed shape
+
+An `embedded_schema` with `:key` and `:value`, in the web layer — not
+`lib/nucleus/secrets/new_secret.ex` in the domain layer as the plan
+originally specified. ADR-0013 chose the web-layer placement specifically
+so this ticket would not have to rediscover it; this ticket follows that
+choice rather than revisiting it. `changeset/3` takes an `existing_keys`
+list (from the LiveView's already-loaded stream) for `SEC-A10`'s advisory,
+form-side duplicate check — `SEC-A12`'s backend `:already_exists` rejection
+via `Store.create_secret/3`'s atomic `Overwrite: false` refusal remains the
+authoritative, race-safe check; `create/4` never reads before writing.
+
+### The creation modal and the reveal modal are mutually exclusive, not merely unlikely to overlap
+
+Both are `Phoenix.Component`-conditional (`:if={@creating}` /
+`:if={@revealed}`), matching the reveal modal's own shape rather than the
+"mounted and toggled" usage ADR-0012 calls acceptable for a creation form.
+Opening either resets the other's assigns to its closed state in the same
+step: `"new_secret"` clears `:revealed`/`:editing`/`:edit_form`, and
+`"reveal"` clears `:creating`/`:create_form`. This is the concrete fix for
+the `focusStack` double-pop ADR-0012 predicted — structurally preventing
+both modals from existing at once, rather than patching the interaction
+after two were observed stacked. A client can dispatch either `phx-click`
+directly regardless of which button is visually reachable behind a
+backdrop, so the guard lives in `handle_event/3`, not in what is rendered.
+
+### A successful create re-lists rather than computing a stream insertion position
+
+`Nucleus.Secrets.list/2` already sorts case-insensitively with a raw-key
+tiebreak; recomputing that ordering to call `stream_insert/3` at a
+specific index would duplicate logic that already exists and risks getting
+the tiebreak wrong. `save_new_secret/3` calls the same `fetch_secrets/2`
+`handle_params/3` uses, which re-streams with `reset: true` and refreshes
+`:secret_count` and `:secret_keys` in the same step — which is also what
+flips `#secrets-empty` to `#secrets-table` on a first secret, with no
+separate code path, the same way ADR-0013 observed `SEC-A07`'s re-masking
+falls out of `:revealed` going to `nil`.
+
+## Consequences
+
+### Positive
+
+- One key validator exists in the application; `reveal/3` and `update/4`'s
+  provisional weak copies are gone, closing the technical-debt item ADR-0011
+  opened.
+- `create/4`'s `with` chain needs no special case for either `Key.validate/1`
+  or `Value.validate/1`'s failure — both return the same struct.
+- The `focusStack` double-pop ADR-0012 predicted is structurally impossible
+  rather than merely untested — verified by a test that opens the reveal
+  modal, opens the creation modal, and confirms only the latter is present.
+- The no-casing-rule decision is stated in `Key`'s moduledoc, not left to be
+  reverse-engineered from its absence.
+
+### Negative
+
+- `create/4`'s re-list on success is one extra `Store.list_secrets/1` call
+  compared to a precisely-targeted `stream_insert/3` — accepted because
+  correctness (matching `list/2`'s exact tiebreak) was judged more valuable
+  than the saved call, and the requirement places no latency bound on it.
+- Mutual exclusion between the two modals means a client dispatching
+  `"reveal"` while `"new_secret"`'s modal is open loses whatever was typed
+  into the creation form, with no confirmation. No requirement describes
+  this interaction, and it is a narrow, deliberately-a rare path (both
+  triggers are not simultaneously clickable in the rendered UI), but it is
+  a real, silent discard worth naming rather than discovering later.
+- `Key.validate/1`'s 256-character cap now rejects an externally-created,
+  over-length key on `reveal/3`/`update/4` that `list/2` would still show —
+  a narrower gap than before (previously any length reached the store), but
+  not a closed one.
+
+## Alternatives considered
+
+**A per-rule reason atom returned bare (`{:error, :too_long}`), matching the
+plan literally.** Rejected — see ADR-0013's addendum; would have required
+`create/4`'s `with` chain to special-case one sibling validator's failure
+shape differently from the other's.
+
+**A casing rule modelled on the seeded fixtures'
+`DATABASE_URL` convention.** Rejected at length in issue #14's comment
+thread — summarized above; full reasoning lives there, not duplicated here.
+
+**Computing a `stream_insert/3` index from `:secret_keys`' sorted
+position.** Rejected — re-deriving `list/2`'s tiebreak logic a second time
+in the LiveView risked the two drifting apart silently; re-listing cannot
+drift because it *is* `list/2`.
+
+**Leaving the creation modal "mounted and toggled" per ADR-0012's stated
+allowance for non-sensitive content.** Rejected in favor of matching the
+reveal modal's conditional shape — the resulting mutual-exclusion guard is
+simpler to reason about and test as "at most one modal assign is ever
+truthy" than as two different mechanisms (one conditional render, one CSS
+class toggle) that both need the same guard applied differently.
+
+## References
+
+- SEC-S6 (issue #14) — the deciding issue, including the full key-casing
+  rejection and the error-shape/form-placement divergences flagged before
+  implementation began
+- `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`
+  — the provisional weak key validator this ticket replaces
+- `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md` —
+  the `focusStack` double-pop risk this ticket's mutual-exclusion guard
+  resolves, and the two legitimate `<.modal>` usages
+- `docs/adr/0013-secret-edit-in-modal-and-value-form.md` — the
+  `Value`/`EditForm` pattern this ticket's `Value` reuse and `CreateForm`
+  follow, and its own addendum settling `Key.validate/1`'s return shape
+- `AGENTS.md` — `embedded_schema`/`Ecto.Changeset` for form validation with
+  no database; `to_form/2` and `<.form for={@form}>` conventions

--- a/lib/nucleus/secrets.ex
+++ b/lib/nucleus/secrets.ex
@@ -42,12 +42,33 @@ defmodule Nucleus.Secrets do
   `SEC-A06`'s "editing requires the value to have been revealed first" — that
   precondition is UI session state this context module cannot see. See
   `update/4`'s own doc for where the gate actually lives.
+
+  ## One key validator, shared by every function that touches a key (`SEC-S6`)
+
+  `reveal/3`, `update/4`, and `create/4` all validate the key shape through
+  `Nucleus.Secrets.Key.validate/1` — not a private copy each. Before this
+  ticket, `reveal/3` and `update/4` shared a weaker, inline denylist (see
+  `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`);
+  `Key.validate/1` replaces it, applying the same rules and the same
+  256-character cap to a read, a write, and a create alike (`Key`'s own
+  moduledoc explains why that cap is deliberately not create-only).
+
+  ## `create/4` validates before any store call, and relies on the store's atomic refusal (`SEC-A09`, `SEC-A12`)
+
+  `create/4` does **not** implement `SEC-A12`'s "reject an existing key" as a
+  read-then-write — that would be racy: another operator, or a process
+  outside Nucleus, could create the key between a pre-check and the write.
+  `Store.create_secret/3` already refuses atomically with
+  `{:error, %Error{kind: :already_exists}}` (`Overwrite: false` on the
+  underlying `PutParameter` call), so `create/4` calls it directly and lets
+  that refusal propagate. See `create/4`'s own doc.
   """
 
   alias Nucleus.Audit
   alias Nucleus.Backend.Error
   alias Nucleus.Environments
   alias Nucleus.Scope
+  alias Nucleus.Secrets.Key
   alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
   alias Nucleus.Secrets.Store
@@ -97,23 +118,16 @@ defmodule Nucleus.Secrets do
   1. `Nucleus.Environments.fetch/2` — re-validate the environment, the same
      gate `list/2` uses. Never trust an environment name arriving from a
      client-originated event.
-  2. The **key** shape, validated here. `key` comes from `phx-value-key`,
-     which a client can forge — an attacker-supplied key such as
-     `"../../other-env/secret"` must never reach
-     `Nucleus.Secrets.Path.build/2`, which concatenates its arguments
-     verbatim. `SEC-S6` (key creation) owns the authoritative key rules;
-     until it lands, this rejects only `..`, `/`, `\`, and a null byte as
-     `{:error, kind: :invalid}`, **before** the store is ever called. This
-     is deliberately **not** as strong as
-     `Nucleus.Environments.validate_name/1`, which layers a positive
-     charset allowlist and a length cap on top of the same denylist for
-     exactly the reason its own moduledoc gives — a denylist alone lets
-     percent-encoded traversal, unicode lookalikes, and other control
-     characters through. Blocking `/`, `..`, and `\` is enough to stop a
-     forged key from reaching another environment's Parameter Store path,
-     which is the concrete risk this function guards against, but `SEC-S6`
-     should not assume this validator is a drop-in replacement for
-     `validate_name/1`'s stronger guarantee when it consolidates the two.
+  2. The **key** shape, via `Nucleus.Secrets.Key.validate/1` — the single
+     shared validator `update/4` and `create/4` also use, not a private
+     copy. `key` comes from `phx-value-key`, which a client can forge — an
+     attacker-supplied key such as `"../../other-env/secret"` must never
+     reach `Nucleus.Secrets.Path.build/2`, which concatenates its arguments
+     verbatim. `Key.validate/1`'s denylist (`..`, `/`, `\`, a null byte,
+     empty, over 256 characters) is enough to stop a forged key from
+     reaching another environment's Parameter Store path, which is the
+     concrete risk this function guards against — see `Key`'s own moduledoc
+     for why it is a denylist rather than `validate_name/1`'s allowlist.
   3. `Nucleus.Secrets.Store.get_secret/2` — the one place in this module a
      value is fetched.
 
@@ -140,7 +154,7 @@ defmodule Nucleus.Secrets do
   def reveal(environment, key, %Scope{token: token} = scope)
       when is_binary(environment) and is_binary(key) do
     with {:ok, _environment} <- Environments.fetch(environment, token),
-         :ok <- validate_key(key),
+         :ok <- Key.validate(key),
          {:ok, secret} <- Store.get_secret(environment, key) do
       :ok =
         Audit.emit(:secret_viewed,
@@ -163,9 +177,9 @@ defmodule Nucleus.Secrets do
   1. `Nucleus.Environments.fetch/2` — the same gate every other function in
      this module uses. Never trust an environment name arriving from a
      client-originated event.
-  2. The **key** shape, via the same `validate_key/1` `reveal/3` already
-     uses — not a second copy. `key` comes from `phx-value-key`, forgeable
-     the same way it is for a reveal.
+  2. The **key** shape, via the same `Nucleus.Secrets.Key.validate/1`
+     `reveal/3` already uses — not a second copy. `key` comes from
+     `phx-value-key`, forgeable the same way it is for a reveal.
   3. `Nucleus.Secrets.Value.validate/1` — the value shape (non-empty, at most
      4096 characters), checked before the store is ever reached, so an
      invalid value never becomes a `PutParameter` call.
@@ -208,7 +222,7 @@ defmodule Nucleus.Secrets do
   def update(environment, key, value, %Scope{token: token} = scope)
       when is_binary(environment) and is_binary(key) and is_binary(value) do
     with {:ok, _environment} <- Environments.fetch(environment, token),
-         :ok <- validate_key(key),
+         :ok <- Key.validate(key),
          :ok <- Value.validate(value),
          {:ok, ref} <- Store.update_secret(environment, key, value) do
       :ok =
@@ -222,34 +236,77 @@ defmodule Nucleus.Secrets do
     end
   end
 
-  defp sort(refs) do
-    Enum.sort_by(refs, &{String.downcase(&1.key), &1.key})
-  end
+  @doc """
+  Creates a new secret in `environment` with `key` and `value`,
+  re-validating the environment, the key shape, and the value shape — in
+  that order — before any store call (`SEC-A09`).
 
-  # Minimal deny checks, pending `SEC-S6`'s consolidated key validator — see
-  # `reveal/3`'s doc for why this is weaker than
-  # `Nucleus.Environments.validate_name/1` and why that gap is acceptable
-  # for now.
-  defp validate_key(key) do
-    cond do
-      key == "" ->
-        invalid_key(key)
+  Strict order, matching `reveal/3` and `update/4`:
 
-      String.contains?(key, "..") ->
-        invalid_key(key)
+  1. `Nucleus.Environments.fetch/2` — the same gate every other function in
+     this module uses. Never trust an environment name arriving from a
+     client-originated event.
+  2. `Nucleus.Secrets.Key.validate/1` — the same validator `reveal/3` and
+     `update/4` use, not a create-specific copy. `key` comes from a
+     client-submitted form and is validated here regardless of whatever the
+     form layer (`NucleusWeb.SecretsLive.CreateForm`) already checked —
+     `SEC-A10`'s form-side check is advisory, this is authoritative.
+  3. `Nucleus.Secrets.Value.validate/1` — the value shape (non-empty, at
+     most 4096 characters), checked before the store is ever reached.
+  4. `Nucleus.Secrets.Store.create_secret/3` — fails
+     `{:error, %Error{kind: :already_exists}}` (`SEC-A12`) when `key`
+     already exists in `environment`, via the store's own atomic
+     `Overwrite: false` refusal. **Not** a read-then-write: this function
+     never calls `Store.get_secret/2` or `list_secrets/1` first, so a
+     concurrent create racing this one is still rejected correctly by
+     whichever `PutParameter` call the store's implementation processes
+     second — see the moduledoc's "`create/4` validates before any store
+     call" section.
 
-      String.contains?(key, "/") or String.contains?(key, "\\") ->
-        invalid_key(key)
+  On success **only**, emits `secret_created` with `resource` set to the
+  full parameter path from the returned `SecretRef` — never the bare key,
+  and never the value: `SecretRef` has no `value` field. `user` comes from
+  `Nucleus.Scope.audit_user/1`, matching `reveal/3` and `update/4`.
 
-      String.contains?(key, <<0>>) ->
-        invalid_key(key)
+  A rejected create — an invalid key, an invalid value, or an
+  `:already_exists` conflict — reaches no store call that could mutate
+  anything, so the existing value behind a duplicate key is guaranteed
+  untouched; `SEC-A12`'s rejection is a pure read from the store's
+  perspective.
 
-      true ->
-        :ok
+  Returns `SecretRef` (no value field), so the success path cannot
+  accidentally carry the new plaintext back into a caller's render. The
+  new secret is **not** revealed by creating it — no `secret_viewed` event
+  is emitted here, and no plaintext round-trips back through this
+  function's return value.
+
+  The value must appear in no log line, on any branch, including a failure
+  — the same guarantee `update/4` makes, for the same reason.
+  """
+  @spec create(
+          environment :: String.t(),
+          key :: String.t(),
+          value :: String.t(),
+          scope :: Scope.t()
+        ) :: {:ok, SecretRef.t()} | {:error, Error.t()}
+  def create(environment, key, value, %Scope{token: token} = scope)
+      when is_binary(environment) and is_binary(key) and is_binary(value) do
+    with {:ok, _environment} <- Environments.fetch(environment, token),
+         :ok <- Key.validate(key),
+         :ok <- Value.validate(value),
+         {:ok, ref} <- Store.create_secret(environment, key, value) do
+      :ok =
+        Audit.emit(:secret_created,
+          user: Scope.audit_user(scope),
+          tenant: scope.tenant,
+          resource: ref.path
+        )
+
+      {:ok, ref}
     end
   end
 
-  defp invalid_key(key) do
-    {:error, Error.new(:invalid, Store.boundary(), "invalid secret key", %{key: inspect(key)})}
+  defp sort(refs) do
+    Enum.sort_by(refs, &{String.downcase(&1.key), &1.key})
   end
 end

--- a/lib/nucleus/secrets/key.ex
+++ b/lib/nucleus/secrets/key.ex
@@ -1,0 +1,164 @@
+defmodule Nucleus.Secrets.Key do
+  @moduledoc """
+  Shape validation for a secret's key — the authoritative rules `SEC-A10`
+  describes, shared by every path that touches a key: `create/4` (`SEC-A09`,
+  this ticket, `SEC-S6`), and `reveal/3`/`update/4`, which previously carried
+  their own weaker, second copy of this denylist (see
+  `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`).
+  There is exactly one key validator in the application after this module
+  lands — `Nucleus.Secrets` no longer defines its own `validate_key/1`.
+
+  ## Denylist, not allowlist — and that is deliberate
+
+  Contrast this with `Nucleus.Environments.validate_name/1`, which layers a
+  positive charset allowlist on top of the same three denied sequences.
+  That contrast looks like an inconsistency and is not: an environment name
+  is operator-chosen from a small, controlled set (config, a provisioning
+  script) and gains nothing from allowing dots, mixed case, or unusual
+  characters. A secret key is arbitrary, user-chosen text meant to resemble
+  an environment-variable name — `db.password`, `my-key`, `DATABASE_URL` are
+  all legitimate, and mixed case, dots, and dashes are all plausible. An
+  allowlist strict enough to be meaningful would reject real keys; the wiki
+  enumerates exactly four denied sequences (empty, `/`, `\\`, a null byte,
+  `..`) plus a length cap, and this module implements exactly those — no
+  more, no less. Tightening beyond `SEC-A10` is out of this ticket's scope
+  by design, not an oversight.
+
+  ## No casing rule, and that is also deliberate
+
+  `validate/1` does not constrain a key's casing. The rule considered and
+  rejected was "lowercase except the last, uppercase segment" — meant to
+  mirror the `DATABASE_URL`-style convention used by the seeded fixtures and
+  real Parameter Store keys. It was rejected because the risk is not
+  symmetric: a validator that wrongly rejects a legitimate key does not stop
+  an operator, it routes them around Nucleus entirely — straight to the AWS
+  console, where nothing is audited and no `secret_created` event exists.
+  Wrongly permissive costs a cosmetically inconsistent key name; wrongly
+  strict costs audit coverage that cannot be reconstructed after the fact.
+  Parameter Store is also not exclusively Nucleus's — keys created by
+  Terraform, the console, or any other tooling can be any casing, and
+  `Nucleus.Secrets.list/2` already sorts case-insensitively
+  (`&{String.downcase(&1.key), &1.key}`) to cope with that. A create-only
+  casing rule would produce a list showing `api-key` next to a form that
+  refuses to create it. The convention is expressed as guidance in the
+  creation form (a placeholder and a hint), not enforcement here.
+
+  ## The 256-character cap applies to every caller, including reads
+
+  `validate/1` is the single gate for `create/4`, `reveal/3`, and `update/4`
+  alike — there is one rule set, not a stricter create-time rule layered on
+  a looser read-time one. The deliberate consequence: a key longer than 256
+  characters, created outside Nucleus (Parameter Store enforces its own,
+  much longer limit), would be listable by `Nucleus.Secrets.list/2` — which
+  calls no per-key validation, only `Store.list_secrets/1` — but rejected by
+  `reveal/3` and `update/4`, which both call `validate/1` before reaching the
+  store. This is accepted, not a bug: a list-then-reveal path with a
+  since-created oversized key visibly fails at reveal, rather than silently
+  succeeding against a rule this module does not enforce for reads and
+  writes differently.
+
+  ## Distinct reason atoms, not a single generic message
+
+  `SEC-A10` requires the form "clearly indicate the specific problem" — one
+  generic "invalid key" message does not satisfy that. `validate/1` returns
+  `Nucleus.Backend.Error.t()`, matching `Nucleus.Secrets.Value.validate/1`'s
+  shape (see
+  `docs/adr/0013-secret-edit-in-modal-and-value-form.md`'s addendum) so
+  `create/4`'s `with` chain needs no special case for either sibling
+  validator's failure. The per-rule distinction lives in
+  `error.details.reason` — one of `:empty`, `:too_long`, `:forward_slash`,
+  `:backslash`, `:null_byte`, `:path_traversal` — while `error.message`
+  carries the human-readable copy a form can show directly.
+
+  Checked in a fixed order, so a key violating more than one rule always
+  reports the same reason rather than one that depends on how the checks
+  happen to be listed: empty/whitespace-only, then path traversal, then
+  forward slash, then backslash, then a null byte, then the length cap.
+  Path traversal is checked before forward slash specifically because
+  `"../x"` contains both `..` and `/` — checking slash first would report
+  the less specific rule for a key that is unambiguously a traversal
+  attempt.
+  """
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Secrets.Store
+
+  @max_length 256
+
+  @doc """
+  The maximum number of characters a secret key may contain.
+  """
+  @spec max_length() :: pos_integer()
+  def max_length, do: @max_length
+
+  @doc """
+  Validates `key`'s shape: non-empty (and not whitespace-only), at most
+  #{@max_length} characters (`String.length/1`, not `byte_size/1`), and free
+  of `/`, `\\`, a null byte, and `..`.
+
+  Accepts `term()`, not just `String.t()` — a key arriving from a
+  client-controlled form param has not been shown to be a string yet.
+
+      iex> Nucleus.Secrets.Key.validate("DATABASE_URL")
+      :ok
+
+      iex> Nucleus.Secrets.Key.validate("db.password")
+      :ok
+
+      iex> {:error, error} = Nucleus.Secrets.Key.validate("")
+      iex> error.details.reason
+      :empty
+
+      iex> {:error, error} = Nucleus.Secrets.Key.validate("a/b")
+      iex> error.details.reason
+      :forward_slash
+
+      iex> {:error, error} = Nucleus.Secrets.Key.validate("../x")
+      iex> error.details.reason
+      :path_traversal
+
+      iex> {:error, error} = Nucleus.Secrets.Key.validate(String.duplicate("a", 257))
+      iex> error.details.reason
+      :too_long
+  """
+  @spec validate(term()) :: :ok | {:error, Error.t()}
+  def validate(key) when is_binary(key) do
+    cond do
+      String.trim(key) == "" ->
+        invalid(:empty, "secret key must not be empty", key)
+
+      String.contains?(key, "..") ->
+        invalid(
+          :path_traversal,
+          "secret key must not contain a path-traversal sequence (\"..\")",
+          key
+        )
+
+      String.contains?(key, "/") ->
+        invalid(:forward_slash, "secret key must not contain a forward slash (\"/\")", key)
+
+      String.contains?(key, "\\") ->
+        invalid(:backslash, "secret key must not contain a backslash (\"\\\")", key)
+
+      String.contains?(key, <<0>>) ->
+        invalid(:null_byte, "secret key must not contain a null byte", key)
+
+      String.length(key) > @max_length ->
+        invalid(:too_long, "secret key exceeds #{@max_length} characters", key, %{
+          length: String.length(key)
+        })
+
+      true ->
+        :ok
+    end
+  end
+
+  def validate(other) do
+    invalid(:not_a_string, "secret key must be a string", other)
+  end
+
+  defp invalid(reason, message, key, extra_details \\ %{}) do
+    details = Map.merge(%{reason: reason, key: inspect(key)}, extra_details)
+    {:error, Error.new(:invalid, Store.boundary(), message, details)}
+  end
+end

--- a/lib/nucleus_web/live/secrets_live.ex
+++ b/lib/nucleus_web/live/secrets_live.ex
@@ -66,9 +66,7 @@ defmodule NucleusWeb.SecretsLive do
   all: not a plaintext one, and not a masked one either. A mask is only ever
   a promise that nothing was leaked, and it still has to be careful not to
   encode the real length; a column that does not exist makes no promise to
-  break. Creating a secret is `SEC-S6`'s modal; this module still only
-  renders a placeholder handler for the create button so a click cannot crash
-  the LiveView before that ticket replaces it.
+  break.
 
   ## Row DOM ids are a hash of the ARN, not the key (`SEC-S2` decision 2)
 
@@ -202,6 +200,62 @@ defmodule NucleusWeb.SecretsLive do
     untouched — `SEC-A06`'s "cancel to discard the change" is not
     `SEC-A04`'s hide, and the value stays revealed exactly as it does today
     when a user dismisses nothing at all.
+
+  ## Creating a secret is its own conditionally-rendered modal, mutually exclusive with reveal (`SEC-S6`)
+
+  `:creating` (boolean) and `:create_form` follow the same `:if`-wrapped
+  shape ADR-0012 established for `:revealed` — the modal (`#new-secret-modal`)
+  only exists in the DOM while `:creating` is true, and `handle_event/3`
+  drives it in and out exactly as `edit`/`hide` drive the reveal modal, not a
+  client-side `show_modal/2`/`hide_modal/2` pair. This was a deliberate
+  choice over the "mounted and toggled" usage ADR-0012 calls acceptable for
+  this form (a key and a not-yet-created value are not the same risk as an
+  already-stored plaintext secret) — using the same conditional shape as the
+  reveal modal means `on_cancel={JS.push("cancel_new")}` closes it the same
+  way `on_cancel={JS.push("hide")}` closes the reveal modal (removal fires
+  the component's own `phx-remove`), with no second client-side code path to
+  keep in sync.
+
+  **Opening either modal closes the other.** `"new_secret"` resets
+  `:revealed`/`:editing`/`:edit_form`/`:edit_error` to their closed state in
+  the same assign that opens the create modal, and `"reveal"` does the
+  mirror on `:creating`/`:create_form`/`:create_error`. Nothing renders two
+  `<.modal>`s at once as a structural guarantee, not merely as an unlikely
+  sequence of clicks — a client can dispatch `phx-click` events directly
+  regardless of which button is visually reachable behind a backdrop, the
+  same reasoning every other gate in this module already relies on. This is
+  the concrete fix for the `focusStack`/`JS.pop_focus/1` double-pop risk
+  ADR-0012 and `living-notes.md` both flag by name against this ticket: two
+  conditionally-rendered modals stacked would have the inner one's dismissal
+  consume the outer one's saved focus, so this module never lets both exist
+  at once rather than fixing the interaction after the fact.
+
+  **`:secret_keys` is kept in lock-step with the stream, not fetched separately
+  for the duplicate check.** `fetch_secrets/2` — already the one place
+  `:secret_count` and the stream are set — also assigns `:secret_keys` (the
+  plain list of keys from the same `Nucleus.Secrets.list/2` call) so
+  `NucleusWeb.SecretsLive.CreateForm.changeset/3`'s `SEC-A10` duplicate check
+  always compares against what is actually currently rendered, with no
+  second store call and no risk of the two drifting apart.
+
+  **A successful create re-lists rather than computing a stream insertion
+  position.** `Nucleus.Secrets.list/2` already sorts
+  case-insensitively — recomputing that ordering here to call
+  `stream_insert/3` at the right index would duplicate logic that already
+  exists and risks getting the tiebreak wrong. `save_new_secret/3` calls
+  `fetch_secrets/2` again on success, which re-streams with `reset: true`;
+  this also means a first-secret creation flips `:secret_count` from `0` and
+  swaps `#secrets-empty` for `#secrets-table` for free, the same way
+  `SEC-A07`'s re-masking falls out of `:revealed` going to `nil` rather than
+  being a separate step.
+
+  **`Nucleus.Secrets.Key.validate/1` and `Nucleus.Secrets.Value.validate/1`
+  run twice, deliberately.** `CreateForm.changeset/3` runs both — the same
+  functions `Nucleus.Secrets.create/4` runs again before ever reaching the
+  store. The first run is `SEC-A10`/`SEC-A11`'s fast, advisory feedback while
+  typing; the second is what actually stops an invalid `save_new` dispatched
+  directly, bypassing the disabled submit button the same way `save_edit`'s
+  reveal-before-edit gate cannot be satisfied by hiding a button alone.
   """
 
   use NucleusWeb, :live_view
@@ -211,9 +265,11 @@ defmodule NucleusWeb.SecretsLive do
   alias Nucleus.Secrets.Secret
   alias Nucleus.Secrets.SecretRef
   alias Nucleus.Secrets.Value
+  alias NucleusWeb.SecretsLive.CreateForm
   alias NucleusWeb.SecretsLive.EditForm
 
   @modal_id "secret-modal"
+  @create_modal_id "new-secret-modal"
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -234,6 +290,9 @@ defmodule NucleusWeb.SecretsLive do
       |> assign(:editing, false)
       |> assign(:edit_form, nil)
       |> assign(:edit_error, nil)
+      |> assign(:creating, false)
+      |> assign(:create_form, nil)
+      |> assign(:create_error, nil)
       |> fetch_secrets(environment)
 
     {:noreply, socket}
@@ -249,6 +308,13 @@ defmodule NucleusWeb.SecretsLive do
           |> assign(:editing, false)
           |> assign(:edit_form, nil)
           |> assign(:edit_error, nil)
+          # Mutual exclusion with the create modal — see the moduledoc's
+          # "Creating a secret" section for why this side structurally
+          # avoids ADR-0012's focusStack double-pop risk rather than fixing
+          # it after the fact.
+          |> assign(:creating, false)
+          |> assign(:create_form, nil)
+          |> assign(:create_error, nil)
 
         {:noreply, socket}
 
@@ -345,8 +411,64 @@ defmodule NucleusWeb.SecretsLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("create_secret", _params, socket) do
-    {:noreply, put_flash(socket, :info, "Creating a secret is not yet implemented.")}
+  def handle_event("new_secret", _params, socket) do
+    socket =
+      socket
+      # Mutual exclusion with the reveal modal — see the moduledoc.
+      |> assign(:revealed, nil)
+      |> assign(:editing, false)
+      |> assign(:edit_form, nil)
+      |> assign(:edit_error, nil)
+      |> assign(:creating, true)
+      |> assign(:create_form, build_create_form(socket.assigns.secret_keys))
+      |> assign(:create_error, nil)
+
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate_new", %{"new_secret" => params}, socket) do
+    changeset =
+      %CreateForm{}
+      |> CreateForm.changeset(params, socket.assigns.secret_keys)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :create_form, to_form(changeset, as: :new_secret))}
+  end
+
+  # Re-validated here, not only via `phx-change` — `SEC-A10`/`SEC-A11`
+  # require server-side enforcement, since a disabled submit button is UI
+  # convenience only: `save_new` can be dispatched directly, bypassing
+  # whatever `validate_new` already rejected client-side.
+  @impl Phoenix.LiveView
+  def handle_event("save_new", %{"new_secret" => params}, socket) do
+    changeset =
+      %CreateForm{}
+      |> CreateForm.changeset(params, socket.assigns.secret_keys)
+      |> Map.put(:action, :validate)
+
+    if changeset.valid? do
+      save_new_secret(
+        socket,
+        Ecto.Changeset.get_field(changeset, :key),
+        Ecto.Changeset.get_field(changeset, :value)
+      )
+    else
+      {:noreply, assign(socket, :create_form, to_form(changeset, as: :new_secret))}
+    end
+  end
+
+  # Every dismissal route the modal offers — Cancel, Escape, backdrop —
+  # arrives here, carrying no params, mirroring `"hide"` above.
+  @impl Phoenix.LiveView
+  def handle_event("cancel_new", _params, socket) do
+    socket =
+      socket
+      |> assign(:creating, false)
+      |> assign(:create_form, nil)
+      |> assign(:create_error, nil)
+
+    {:noreply, socket}
   end
 
   @impl Phoenix.LiveView
@@ -389,30 +511,83 @@ defmodule NucleusWeb.SecretsLive do
     end
   end
 
+  # `SEC-A12`'s rejection and any other failure both leave `:creating` and
+  # the entered `key`/`value` untouched (rebuilt into a fresh changeset
+  # below so they survive) — never a silent discard, matching `save_edit/3`'s
+  # `SEC-A08` reasoning above.
+  defp save_new_secret(socket, key, value) do
+    case Secrets.create(socket.assigns.environment, key, value, socket.assigns.current_scope) do
+      {:ok, _ref} ->
+        socket =
+          socket
+          |> assign(:creating, false)
+          |> assign(:create_form, nil)
+          |> assign(:create_error, nil)
+          |> put_flash(:info, "#{key} was created.")
+          # `SEC-A09`: re-lists rather than computing a stream insertion
+          # position — see the moduledoc's "Creating a secret" section.
+          # This also updates `:secret_count`/`:secret_keys`, which is what
+          # flips `#secrets-empty` to `#secrets-table` on a first secret.
+          |> fetch_secrets(socket.assigns.environment)
+
+        {:noreply, socket}
+
+      {:error, %Error{kind: :already_exists}} ->
+        changeset =
+          %CreateForm{}
+          |> CreateForm.changeset(%{"key" => key, "value" => value}, socket.assigns.secret_keys)
+          |> Ecto.Changeset.add_error(:key, "already exists in this environment")
+          |> Map.put(:action, :validate)
+
+        {:noreply, assign(socket, :create_form, to_form(changeset, as: :new_secret))}
+
+      {:error, %Error{} = error} ->
+        changeset =
+          %CreateForm{}
+          |> CreateForm.changeset(%{"key" => key, "value" => value}, socket.assigns.secret_keys)
+          |> Map.put(:action, :validate)
+
+        socket =
+          socket
+          |> assign(:create_form, to_form(changeset, as: :new_secret))
+          |> assign(:create_error, create_error_message(error))
+
+        {:noreply, socket}
+    end
+  end
+
   defp fetch_secrets(socket, environment) do
     case Secrets.list(environment, socket.assigns.current_scope) do
       {:ok, refs} ->
         socket
-        |> assign(environment_status: :ok, secret_count: length(refs))
+        |> assign(
+          environment_status: :ok,
+          secret_count: length(refs),
+          secret_keys: Enum.map(refs, & &1.key)
+        )
         |> stream(:secrets, refs, reset: true)
 
       {:error, %Error{kind: :invalid, boundary: :tenant_api}} ->
-        assign(socket, environment_status: :invalid, secret_count: 0)
+        assign(socket, environment_status: :invalid, secret_count: 0, secret_keys: [])
 
       {:error, %Error{kind: :not_found, boundary: :tenant_api}} ->
-        assign(socket, environment_status: :not_found, secret_count: 0)
+        assign(socket, environment_status: :not_found, secret_count: 0, secret_keys: [])
 
       {:error, %Error{kind: :unavailable, boundary: :tenant_api}} ->
-        assign(socket, environment_status: :validation_unavailable, secret_count: 0)
+        assign(socket,
+          environment_status: :validation_unavailable,
+          secret_count: 0,
+          secret_keys: []
+        )
 
       {:error, %Error{kind: :unavailable, boundary: :secrets}} ->
-        assign(socket, environment_status: :secrets_unavailable, secret_count: 0)
+        assign(socket, environment_status: :secrets_unavailable, secret_count: 0, secret_keys: [])
 
       {:error, %Error{kind: :auth_expired}} ->
-        assign(socket, environment_status: :auth_expired, secret_count: 0)
+        assign(socket, environment_status: :auth_expired, secret_count: 0, secret_keys: [])
 
       {:error, %Error{}} ->
-        assign(socket, environment_status: :secrets_unavailable, secret_count: 0)
+        assign(socket, environment_status: :secrets_unavailable, secret_count: 0, secret_keys: [])
     end
   end
 
@@ -457,7 +632,7 @@ defmodule NucleusWeb.SecretsLive do
       <div :if={@environment_status == :ok}>
         <div class="flex items-center justify-between gap-4 pb-4">
           <h1 class="text-lg font-semibold">Secrets</h1>
-          <.button id="secrets-create-button" phx-click="create_secret">New secret</.button>
+          <.button id="secrets-create-button" phx-click="new_secret">New secret</.button>
         </div>
 
         <.empty_state
@@ -600,6 +775,80 @@ defmodule NucleusWeb.SecretsLive do
             </div>
           <% end %>
         </.modal>
+
+        <%!--
+        Only in the DOM while it is open, mirroring the reveal modal above —
+        see the moduledoc's "Creating a secret" section for why the same
+        `:if`-wrapped shape was chosen over leaving this mounted and toggled.
+        --%>
+        <.modal
+          :if={@creating}
+          id={create_modal_id()}
+          show
+          on_cancel={JS.push("cancel_new")}
+        >
+          <:title>New secret</:title>
+          <.form
+            for={@create_form}
+            id="new-secret-form"
+            phx-change="validate_new"
+            phx-submit="save_new"
+          >
+            <.input
+              field={@create_form[:key]}
+              id="new-secret-key"
+              type="text"
+              label="Key"
+              placeholder="DATABASE_URL"
+              class="w-full input font-mono text-sm"
+            />
+            <p class="text-xs text-base-content/70 -mt-1 mb-2">
+              Convention: <code>UPPER_SNAKE_CASE</code>, e.g. <code>DATABASE_URL</code>. Not enforced.
+            </p>
+            <.input
+              field={@create_form[:value]}
+              id="new-secret-value"
+              type="textarea"
+              label="Value"
+              rows="6"
+              class="w-full textarea font-mono text-sm"
+            />
+            <div
+              id="new-secret-value-count"
+              class={[
+                "text-xs text-right mt-1",
+                if(create_value_length(@create_form) > Value.max_length(),
+                  do: "text-error font-semibold",
+                  else: "text-base-content/70"
+                )
+              ]}
+            >
+              {create_value_length(@create_form)}/{Value.max_length()} characters
+            </div>
+            <p
+              :if={@create_error}
+              id="new-secret-error"
+              role="alert"
+              class="text-error text-sm mt-2"
+            >
+              {@create_error}
+            </p>
+            <div class="modal-action">
+              <.button id="new-secret-cancel" type="button" phx-click="cancel_new">
+                Cancel
+              </.button>
+              <.button
+                id="new-secret-submit"
+                type="submit"
+                variant="primary"
+                disabled={not @create_form.source.valid?}
+                phx-disable-with="Creating..."
+              >
+                Create
+              </.button>
+            </div>
+          </.form>
+        </.modal>
       </div>
     </Layouts.app>
     """
@@ -608,6 +857,8 @@ defmodule NucleusWeb.SecretsLive do
   # A module attribute, not an assign — `@modal_id` inside `~H` would mean
   # `assigns.modal_id`.
   defp modal_id, do: @modal_id
+
+  defp create_modal_id, do: @create_modal_id
 
   defp dom_id(%SecretRef{arn: arn}) do
     "secret-" <> (:crypto.hash(:sha256, arn) |> Base.url_encode64(padding: false))
@@ -682,6 +933,41 @@ defmodule NucleusWeb.SecretsLive do
   # attribute.
   defp edit_dirty?(form, original_value) do
     to_string(form[:value].value) != to_string(original_value)
+  end
+
+  # `SEC-A12`/`SEC-A10`/`SEC-A11`'s kind-specific copy for a failed create —
+  # mirrors `edit_error_message/1`'s shape. `:already_exists` (`SEC-A12`) is
+  # handled separately, as a field-level error attached directly to `:key`
+  # rather than through this function — see `save_new_secret/3`.
+  defp create_error_message(%Error{kind: :auth_expired}) do
+    "This environment's secrets can't be reached right now."
+  end
+
+  defp create_error_message(%Error{kind: :unavailable}) do
+    "Can't create this secret right now. Try again shortly."
+  end
+
+  defp create_error_message(%Error{kind: :invalid}) do
+    "That key or value isn't valid."
+  end
+
+  defp create_error_message(%Error{}) do
+    "Can't create this secret right now. Try again shortly."
+  end
+
+  # Fresh each time, never reused across an open/cancel cycle — an unvalidated
+  # (`action: nil`) empty `%CreateForm{}` so opening the form shows no errors
+  # before the user has typed anything, mirroring `build_edit_form/1`.
+  defp build_create_form(existing_keys) do
+    %CreateForm{}
+    |> CreateForm.changeset(%{}, existing_keys)
+    |> to_form(as: :new_secret)
+  end
+
+  defp create_value_length(form) do
+    form[:value].value
+    |> to_string()
+    |> String.length()
   end
 
   defp format_last_modified(nil), do: "—"

--- a/lib/nucleus_web/live/secrets_live/create_form.ex
+++ b/lib/nucleus_web/live/secrets_live/create_form.ex
@@ -1,0 +1,94 @@
+defmodule NucleusWeb.SecretsLive.CreateForm do
+  @moduledoc """
+  The changeset backing `SEC-A09`'s creation form — a key and a value.
+
+  An `embedded_schema` with `:key` and `:value` fields, following
+  `NucleusWeb.SecretsLive.EditForm`'s shape exactly (`docs/adr/0013-secret-edit-in-modal-and-value-form.md`):
+  no repo, per `AGENTS.md`'s Ecto guideline that `Ecto.Changeset` is retained
+  for form validation with no database involved. This was the pattern that
+  ADR-0013 established specifically so this form would not have to invent
+  one.
+
+  `changeset/3` runs `Nucleus.Secrets.Key.validate/1` and
+  `Nucleus.Secrets.Value.validate/1` — the same functions
+  `Nucleus.Secrets.create/4` calls before ever reaching the store — via
+  `validate_change/3`, so the inline error a user sees while typing and the
+  error the context function would return on submission are always the same
+  text for both fields. There is deliberately no second copy of any of
+  `Key`'s six rules or `Value`'s two here.
+
+  ## Duplicate detection is case-sensitive, and lives here, not in `Key`
+
+  `Nucleus.Secrets.Key.validate/1` has no view of the other keys already in
+  this environment — it is a pure shape check. `SEC-A10`'s "duplicates an
+  existing key in this environment" is checked here, against the
+  `existing_keys` list the LiveView passes in from its already-loaded
+  stream, and compared with `in/2` (exact, case-sensitive): Parameter Store
+  paths are themselves case-sensitive, so `API_KEY` and `api_key` are
+  genuinely different secrets, and a case-insensitive check here would block
+  a legal key. This is advisory only — `SEC-A12`'s server-side
+  `:already_exists` rejection is the authoritative, race-safe check; this
+  form-side check exists purely for `SEC-A10`'s fast feedback while typing.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Secrets.Key
+  alias Nucleus.Secrets.Value
+
+  @primary_key false
+  embedded_schema do
+    field :key, :string
+    field :value, :string
+  end
+
+  @doc """
+  Builds a changeset from `attrs` (string-keyed form params, e.g.
+  `%{"key" => "...", "value" => "..."}`), validating `:key` against
+  `existing_keys` for `SEC-A10`'s duplicate check.
+  """
+  @spec changeset(t :: Ecto.Schema.t(), attrs :: map(), existing_keys :: [String.t()]) ::
+          Ecto.Changeset.t()
+  def changeset(form, attrs, existing_keys \\ []) do
+    form
+    |> cast(attrs, [:key, :value])
+    |> validate_required([:key, :value], message: "can't be blank")
+    |> validate_change(:key, &validate_secret_key/2)
+    |> validate_change(:key, fn :key, key -> validate_duplicate_key(key, existing_keys) end)
+    |> validate_change(:value, &validate_secret_value/2)
+  end
+
+  # Emptiness is `validate_required/3`'s job, above — skipped here so a blank
+  # key or value shows exactly one error, not "can't be blank" stacked on
+  # top of `Key`/`Value`'s own empty-input message.
+  defp validate_secret_key(:key, ""), do: []
+
+  defp validate_secret_key(:key, key) do
+    case Key.validate(key) do
+      :ok -> []
+      {:error, %Error{message: message}} -> [key: message]
+    end
+  end
+
+  defp validate_duplicate_key("", _existing_keys), do: []
+
+  defp validate_duplicate_key(key, existing_keys) do
+    if key in existing_keys do
+      [key: "already exists in this environment"]
+    else
+      []
+    end
+  end
+
+  defp validate_secret_value(:value, ""), do: []
+
+  defp validate_secret_value(:value, value) do
+    case Value.validate(value) do
+      :ok -> []
+      {:error, %Error{message: message}} -> [value: message]
+    end
+  end
+end

--- a/test/nucleus/secrets/key_test.exs
+++ b/test/nucleus/secrets/key_test.exs
@@ -1,0 +1,149 @@
+defmodule Nucleus.Secrets.KeyTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Secrets.Key
+
+  describe "validate/1 — SEC-A10 each rule reports its own reason" do
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "empty and whitespace-only" do
+      for key <- ["", "   "] do
+        assert {:error, %Error{kind: :invalid} = error} = Key.validate(key)
+        assert error.details.reason == :empty
+      end
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "exceeds 256 characters" do
+      key = String.duplicate("a", 257)
+
+      assert {:error, %Error{kind: :invalid} = error} = Key.validate(key)
+      assert error.details.reason == :too_long
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "contains a forward slash" do
+      assert {:error, %Error{kind: :invalid} = error} = Key.validate("a/b")
+      assert error.details.reason == :forward_slash
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "contains a backslash" do
+      assert {:error, %Error{kind: :invalid} = error} = Key.validate("a\\b")
+      assert error.details.reason == :backslash
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "contains a null byte" do
+      assert {:error, %Error{kind: :invalid} = error} = Key.validate("a\0b")
+      assert error.details.reason == :null_byte
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "contains a path-traversal sequence" do
+      for key <- ["a..b", "..", "../x"] do
+        assert {:error, %Error{kind: :invalid} = error} = Key.validate(key)
+        assert error.details.reason == :path_traversal,
+               "expected #{inspect(key)} to report :path_traversal, got #{inspect(error.details.reason)}"
+      end
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "each reason carries its own distinct message" do
+      messages =
+        for key <- ["", "a/b", "a\\b", "a\0b", "..", String.duplicate("a", 257)] do
+          {:error, error} = Key.validate(key)
+          error.message
+        end
+
+      assert Enum.uniq(messages) == messages,
+             "expected every rule to produce a distinct message, got #{inspect(messages)}"
+    end
+  end
+
+  describe "validate/1 — SEC-A10 accepts legitimate keys" do
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "plausible real-world keys" do
+      valid = ["API_KEY", "db.password", "my-key", "a", String.duplicate("a", 256)]
+
+      for key <- valid do
+        assert Key.validate(key) == :ok, "expected #{inspect(key)} to be accepted"
+      end
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "no casing constraint — mixed, upper, and lower case all pass" do
+      for key <- ["DATABASE_URL", "database_url", "Database_Url"] do
+        assert Key.validate(key) == :ok, "expected #{inspect(key)} to be accepted"
+      end
+    end
+  end
+
+  describe "validate/1 — SEC-A10 exact boundary" do
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "256 characters passes, 257 fails" do
+      assert Key.validate(String.duplicate("a", 256)) == :ok
+
+      assert {:error, %Error{} = error} = Key.validate(String.duplicate("a", 257))
+      assert error.details.reason == :too_long
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "a multi-byte 256-character key passes (String.length, not byte_size)" do
+      # Each "é" is two bytes in UTF-8, so this is 256 characters but 512 bytes.
+      key = String.duplicate("é", 256)
+
+      assert String.length(key) == 256
+      assert Key.validate(key) == :ok
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "a multi-byte 257-character key fails" do
+      key = String.duplicate("é", 257)
+
+      assert {:error, %Error{} = error} = Key.validate(key)
+      assert error.details.reason == :too_long
+    end
+  end
+
+  describe "validate/1 — a key violating two rules reports deterministically" do
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "path traversal wins over forward slash, since \"..\" also contains \"/\"" do
+      assert {:error, %Error{} = error} = Key.validate("../etc/passwd")
+      assert error.details.reason == :path_traversal
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "the same input always reports the same reason" do
+      key = "../etc/passwd"
+
+      results = for _ <- 1..5, do: Key.validate(key)
+
+      assert Enum.uniq(results) == [Enum.at(results, 0)]
+    end
+  end
+
+  describe "validate/1 — non-string input" do
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "rejects non-binary terms without raising" do
+      for term <- [nil, 123, :api_key] do
+        assert {:error, %Error{kind: :invalid}} = Key.validate(term)
+      end
+    end
+  end
+end

--- a/test/nucleus/secrets/key_test.exs
+++ b/test/nucleus/secrets/key_test.exs
@@ -49,6 +49,7 @@ defmodule Nucleus.Secrets.KeyTest do
     test "contains a path-traversal sequence" do
       for key <- ["a..b", "..", "../x"] do
         assert {:error, %Error{kind: :invalid} = error} = Key.validate(key)
+
         assert error.details.reason == :path_traversal,
                "expected #{inspect(key)} to report :path_traversal, got #{inspect(error.details.reason)}"
       end

--- a/test/nucleus/secrets_test.exs
+++ b/test/nucleus/secrets_test.exs
@@ -488,4 +488,151 @@ defmodule Nucleus.SecretsTest do
       refute log =~ new_value
     end
   end
+
+  describe "create/4 — SEC-A09 success" do
+    @tag action: "SEC-A09"
+    test "creates the secret; list/2 then includes it; reveal/3 returns the value" do
+      assert {:ok, %SecretRef{key: "NEW_KEY"} = ref} =
+               Secrets.create("prod", "NEW_KEY", "new-secret-value", @scope)
+
+      assert {:ok, refs} = Secrets.list("prod", @scope)
+      assert Enum.any?(refs, &(&1.key == "NEW_KEY"))
+
+      assert {:ok, %Secret{value: "new-secret-value"}} =
+               Secrets.reveal("prod", "NEW_KEY", @scope)
+
+      refute Map.has_key?(ref, :value)
+    end
+
+    @tag action: "SEC-A09"
+    test "emits exactly one secret_created with the full path as resource" do
+      assert {:ok, ref} = Secrets.create("prod", "NEW_KEY", "new-secret-value", @scope)
+
+      assert_audit_event(:secret_created, tenant: "acme", resource: ref.path)
+
+      events = Enum.filter(audit_events(), &(&1.event == :secret_created))
+      assert length(events) == 1
+    end
+
+    @tag action: "SEC-A09"
+    test "resource is the full path, not the bare key" do
+      assert {:ok, ref} = Secrets.create("prod", "NEW_KEY", "new-secret-value", @scope)
+
+      record = assert_audit_event(:secret_created)
+      assert record.resource == ref.path
+      refute record.resource == "NEW_KEY"
+    end
+
+    @tag action: "SEC-A09"
+    test "user is Scope.audit_user/1's result, falling back to username when email is absent" do
+      scope = %Scope{tenant: "acme", user: %{email: nil, username: "auser"}}
+
+      Secrets.create("prod", "NEW_KEY", "new-secret-value", scope)
+
+      assert_audit_event(:secret_created, user: "auser")
+    end
+
+    @tag action: "SEC-A09"
+    test "the AUD-A02 guard — the value appears in no audit record" do
+      Secrets.create("prod", "NEW_KEY", "new-secret-value", @scope)
+
+      refute_audit_contains("new-secret-value")
+    end
+
+    @tag action: "SEC-A09"
+    test "no secret_viewed is emitted by creation" do
+      Secrets.create("prod", "NEW_KEY", "new-secret-value", @scope)
+
+      assert_no_audit_event(:secret_viewed)
+    end
+  end
+
+  describe "create/4 — SEC-A12 reject an existing key" do
+    @tag action: "SEC-A12"
+    test "creating an existing key returns :already_exists, leaves the value unchanged, emits no audit event" do
+      assert {:error, %Error{kind: :already_exists}} =
+               Secrets.create("prod", "DATABASE_URL", "attempted-overwrite", @scope)
+
+      assert {:ok, %Secret{value: @db_url_value}} =
+               Secrets.reveal("prod", "DATABASE_URL", @scope)
+
+      assert_no_audit_event(:secret_created)
+    end
+
+    @tag action: "SEC-A12"
+    test "the value never appears in logs on a rejected create" do
+      log =
+        capture_log(fn ->
+          Secrets.create("prod", "DATABASE_URL", "attempted-overwrite", @scope)
+        end)
+
+      refute log =~ "attempted-overwrite"
+    end
+  end
+
+  describe "create/4 — SEC-A10 invalid key" do
+    @tag action: "SEC-A10"
+    test "an invalid key returns :invalid, no store call, no audit event" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.create("prod", "../../other-env/secret", "value", @scope)
+
+      assert_no_audit_event(:secret_created)
+    end
+
+    @tag action: "SEC-A10"
+    test "an empty key returns :invalid" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} = Secrets.create("prod", "", "value", @scope)
+
+      assert_no_audit_event(:secret_created)
+    end
+  end
+
+  describe "create/4 — SEC-A11 invalid value" do
+    @tag action: "SEC-A11"
+    test "an invalid value returns :invalid, no store call" do
+      use_exploding_secrets_store()
+      too_long = String.duplicate("a", 4097)
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.create("prod", "ANOTHER_NEW_KEY", too_long, @scope)
+
+      assert_no_audit_event(:secret_created)
+    end
+
+    @tag action: "SEC-A11"
+    test "an empty value returns :invalid" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} =
+               Secrets.create("prod", "ANOTHER_NEW_KEY", "", @scope)
+
+      assert_no_audit_event(:secret_created)
+    end
+  end
+
+  describe "create/4 — the environment gate holds through the context layer" do
+    @tag action: "SEC-A09"
+    test "an invalid environment name returns :invalid without calling the store" do
+      use_exploding_secrets_store()
+
+      assert {:error, %Error{kind: :invalid}} = Secrets.create("..", "NEW_KEY", "value", @scope)
+    end
+  end
+
+  describe "create/4 — no value in logs" do
+    test "the value appears in no captured log output, success or failure" do
+      log =
+        capture_log(fn ->
+          Secrets.create("prod", "NEW_KEY", "brand-new-value", @scope)
+          Secrets.create("prod", "DATABASE_URL", "brand-new-value", @scope)
+          Secrets.create("prod", "ANOTHER_NEW_KEY", "", @scope)
+        end)
+
+      refute log =~ "brand-new-value"
+    end
+  end
 end

--- a/test/nucleus_web/live/secrets_live/create_form_test.exs
+++ b/test/nucleus_web/live/secrets_live/create_form_test.exs
@@ -1,0 +1,134 @@
+defmodule NucleusWeb.SecretsLive.CreateFormTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Changeset
+  alias NucleusWeb.SecretsLive.CreateForm
+
+  describe "changeset/3 — SEC-A10 duplicate detection" do
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "a key already in existing_keys is rejected on the key field" do
+      changeset =
+        CreateForm.changeset(%CreateForm{}, %{"key" => "API_KEY", "value" => "s3cr3t"}, [
+          "API_KEY"
+        ])
+
+      refute changeset.valid?
+      assert %{key: [message]} = errors_on(changeset)
+      assert message =~ "already exists in this environment"
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "duplicate detection is case-sensitive: existing [\"API_KEY\"] does not block \"api_key\"" do
+      changeset =
+        CreateForm.changeset(%CreateForm{}, %{"key" => "api_key", "value" => "s3cr3t"}, [
+          "API_KEY"
+        ])
+
+      assert changeset.valid?
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "a key not in existing_keys is accepted" do
+      changeset =
+        CreateForm.changeset(%CreateForm{}, %{"key" => "NEW_KEY", "value" => "s3cr3t"}, [
+          "OTHER_KEY"
+        ])
+
+      assert changeset.valid?
+    end
+  end
+
+  describe "changeset/3 — SEC-A10 key shape errors reach the changeset" do
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "distinct messages per key rule reach the changeset" do
+      cases = [
+        {"a/b", "forward slash"},
+        {String.duplicate("a", 257), "256 characters"},
+        {"..", "path-traversal"}
+      ]
+
+      for {key, expected_fragment} <- cases do
+        changeset = CreateForm.changeset(%CreateForm{}, %{"key" => key, "value" => "v"}, [])
+
+        refute changeset.valid?
+        assert %{key: [message]} = errors_on(changeset)
+
+        assert message =~ expected_fragment,
+               "expected #{inspect(key)}'s message to mention #{inspect(expected_fragment)}, got #{inspect(message)}"
+      end
+    end
+
+    @tag action: "SEC-A10"
+    @tag :unit
+    test "an empty key shows exactly one error, not two stacked" do
+      changeset = CreateForm.changeset(%CreateForm{}, %{"key" => "", "value" => "v"}, [])
+
+      refute changeset.valid?
+      assert %{key: [_one_message]} = errors_on(changeset)
+    end
+  end
+
+  describe "changeset/3 — SEC-A11 value validation" do
+    @tag action: "SEC-A11"
+    @tag :unit
+    test "an empty value is invalid" do
+      changeset = CreateForm.changeset(%CreateForm{}, %{"key" => "K", "value" => ""}, [])
+
+      refute changeset.valid?
+      assert %{value: [_message]} = errors_on(changeset)
+    end
+
+    @tag action: "SEC-A11"
+    @tag :unit
+    test "a 4097-character value is invalid" do
+      changeset =
+        CreateForm.changeset(
+          %CreateForm{},
+          %{"key" => "K", "value" => String.duplicate("a", 4097)},
+          []
+        )
+
+      refute changeset.valid?
+      assert %{value: [message]} = errors_on(changeset)
+      assert message =~ "4096"
+    end
+
+    @tag action: "SEC-A11"
+    @tag :unit
+    test "a 4096-character value is valid" do
+      changeset =
+        CreateForm.changeset(
+          %CreateForm{},
+          %{"key" => "K", "value" => String.duplicate("a", 4096)},
+          []
+        )
+
+      assert changeset.valid?
+    end
+  end
+
+  describe "changeset/3 — a valid key and value together" do
+    @tag action: "SEC-A09"
+    @tag :unit
+    test "produces a valid changeset with both fields readable via get_field/2" do
+      changeset =
+        CreateForm.changeset(%CreateForm{}, %{"key" => "DATABASE_URL", "value" => "postgres://"}, [])
+
+      assert changeset.valid?
+      assert Changeset.get_field(changeset, :key) == "DATABASE_URL"
+      assert Changeset.get_field(changeset, :value) == "postgres://"
+    end
+  end
+
+  defp errors_on(changeset) do
+    Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+end

--- a/test/nucleus_web/live/secrets_live/create_form_test.exs
+++ b/test/nucleus_web/live/secrets_live/create_form_test.exs
@@ -116,7 +116,11 @@ defmodule NucleusWeb.SecretsLive.CreateFormTest do
     @tag :unit
     test "produces a valid changeset with both fields readable via get_field/2" do
       changeset =
-        CreateForm.changeset(%CreateForm{}, %{"key" => "DATABASE_URL", "value" => "postgres://"}, [])
+        CreateForm.changeset(
+          %CreateForm{},
+          %{"key" => "DATABASE_URL", "value" => "postgres://"},
+          []
+        )
 
       assert changeset.valid?
       assert Changeset.get_field(changeset, :key) == "DATABASE_URL"

--- a/test/nucleus_web/live/secrets_live_test.exs
+++ b/test/nucleus_web/live/secrets_live_test.exs
@@ -404,13 +404,459 @@ defmodule NucleusWeb.SecretsLiveTest do
     end
   end
 
-  describe "placeholder handlers do not crash the LiveView" do
-    test "clicking the create button does not crash", %{conn: conn} do
+  defmodule FailingCreateSecretsStore do
+    @moduledoc """
+    A `Nucleus.Secrets.Store` implementation whose `create_secret/3` always
+    fails `:unavailable`, mirroring `FailingUpdateSecretsStore` below —
+    `list_secrets/1` and `get_secret/2` delegate to the real
+    `Nucleus.Secrets.Store.Local`, so the table (and a subsequent retry)
+    still renders correctly and only the create call itself fails.
+    """
+    @behaviour Nucleus.Secrets.Store
+
+    @impl Nucleus.Secrets.Store
+    def list_secrets(environment), do: Nucleus.Secrets.Store.Local.list_secrets(environment)
+
+    @impl Nucleus.Secrets.Store
+    def get_secret(environment, key), do: Nucleus.Secrets.Store.Local.get_secret(environment, key)
+
+    @impl Nucleus.Secrets.Store
+    def create_secret(_environment, _key, _value) do
+      {:error, Error.new(:unavailable, :secrets, "forced for test", %{})}
+    end
+
+    @impl Nucleus.Secrets.Store
+    def update_secret(_environment, _key, _value), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def locate_secret(_environment, _key), do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_environments, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def list_all_secrets, do: raise("should not be called")
+
+    @impl Nucleus.Secrets.Store
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_failing_create_secrets_store do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, FailingCreateSecretsStore)
+    )
+  end
+
+  defp restore_secrets_store_for_create do
+    original = Application.get_env(:nucleus, :backends, [])
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :secrets, Secrets.Store.Local)
+    )
+  end
+
+  describe "SEC-A09 — create a new secret" do
+    @tag action: "SEC-A09"
+    test "opens the modal, submits valid key/value: modal closes, confirmation, row appears in the list",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      refute has_element?(view, "#new-secret-modal")
+
+      view |> element("#secrets-create-button") |> render_click()
+      assert has_element?(view, "#new-secret-modal")
+
+      view
+      |> form("#new-secret-form", new_secret: %{"key" => "NEW_KEY", "value" => "new-value"})
+      |> render_submit()
+
+      refute has_element?(view, "#new-secret-modal")
+      assert has_element?(view, "#flash-info")
+      assert view |> element("#flash-info") |> render() =~ "NEW_KEY"
+      assert has_element?(view, "[data-key=\"NEW_KEY\"]")
+    end
+
+    @tag action: "SEC-A09"
+    test "the new row lands in the same case-insensitive sort position list/2 would put it in",
+         %{conn: conn} do
       assert {:ok, view, _html} = live_secrets(conn, "prod")
 
       view |> element("#secrets-create-button") |> render_click()
 
+      html =
+        view
+        |> form("#new-secret-form", new_secret: %{"key" => "AAA_FIRST_KEY", "value" => "v"})
+        |> render_submit()
+
+      assert {:ok, refs} = Secrets.list("prod", %Nucleus.Scope{})
+      keys = Enum.map(refs, & &1.key)
+
+      assert "AAA_FIRST_KEY" in keys
+      positions = Enum.map(keys, &key_position(html, &1))
+      assert positions == Enum.sort(positions)
+    end
+
+    @tag action: "SEC-A09"
+    test "creating the first secret in the empty sandbox environment replaces #secrets-empty with #secrets-table",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "sandbox")
+      assert has_element?(view, "#secrets-empty")
+      refute has_element?(view, "#secrets-table")
+
+      view |> element("#secrets-create-button") |> render_click()
+
+      view
+      |> form("#new-secret-form", new_secret: %{"key" => "FIRST_KEY", "value" => "v"})
+      |> render_submit()
+
+      refute has_element?(view, "#secrets-empty")
       assert has_element?(view, "#secrets-table")
+      assert has_element?(view, "[data-key=\"FIRST_KEY\"]")
+    end
+
+    @tag action: "SEC-A09"
+    test "the new secret is not revealed after creation — no secret_viewed, no plaintext in the payload",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#secrets-create-button") |> render_click()
+
+      html =
+        view
+        |> form("#new-secret-form",
+          new_secret: %{"key" => "NEW_KEY", "value" => "brand-new-value"}
+        )
+        |> render_submit()
+
+      refute html =~ "brand-new-value"
+      refute has_element?(view, "#secret-modal")
+      assert_no_audit_event(:secret_viewed)
+      assert_audit_event(:secret_created)
+    end
+  end
+
+  describe "SEC-A10 — validate the secret key on creation" do
+    @tag action: "SEC-A10"
+    test "each invalid key shows a specific, distinct message", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      view |> element("#secrets-create-button") |> render_click()
+
+      slash_html =
+        view
+        |> form("#new-secret-form", new_secret: %{"key" => "a/b", "value" => "v"})
+        |> render_change()
+
+      too_long_html =
+        view
+        |> form("#new-secret-form",
+          new_secret: %{"key" => String.duplicate("a", 257), "value" => "v"}
+        )
+        |> render_change()
+
+      assert slash_html =~ "forward slash"
+      assert too_long_html =~ "256 characters"
+      refute slash_html =~ "256 characters"
+      refute too_long_html =~ "forward slash"
+    end
+
+    @tag action: "SEC-A10"
+    test "a duplicate key shows an error and disables #new-secret-submit", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      view |> element("#secrets-create-button") |> render_click()
+
+      html =
+        view
+        |> form("#new-secret-form", new_secret: %{"key" => "DATABASE_URL", "value" => "v"})
+        |> render_change()
+
+      assert html =~ "already exists in this environment"
+      assert has_element?(view, "#new-secret-submit[disabled]")
+    end
+
+    @tag action: "SEC-A10"
+    test "the submit button starts disabled on the freshly-opened, empty form", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      view |> element("#secrets-create-button") |> render_click()
+
+      assert has_element?(view, "#new-secret-submit[disabled]")
+    end
+  end
+
+  describe "SEC-A11 — validate the secret value on creation" do
+    @tag action: "SEC-A11"
+    test "#new-secret-value-count is present and updates as the value changes", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      view |> element("#secrets-create-button") |> render_click()
+
+      assert has_element?(view, "#new-secret-value-count")
+
+      html_one =
+        view
+        |> form("#new-secret-form", new_secret: %{"key" => "K", "value" => "abc"})
+        |> render_change()
+
+      html_two =
+        view
+        |> form("#new-secret-form", new_secret: %{"key" => "K", "value" => "abcdefghij"})
+        |> render_change()
+
+      assert html_one =~ "3/4096 characters"
+      assert html_two =~ "10/4096 characters"
+      refute html_one == html_two
+    end
+
+    @tag action: "SEC-A11"
+    test "over-limit shows the limit and blocks submission", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      view |> element("#secrets-create-button") |> render_click()
+
+      too_long = String.duplicate("a", 4097)
+
+      html =
+        view
+        |> form("#new-secret-form", new_secret: %{"key" => "K", "value" => too_long})
+        |> render_change()
+
+      assert html =~ "exceeds 4096 characters"
+      assert has_element?(view, "#new-secret-submit[disabled]")
+
+      view
+      |> form("#new-secret-form", new_secret: %{"key" => "K", "value" => too_long})
+      |> render_submit()
+
+      assert has_element?(view, "#new-secret-modal")
+      refute has_element?(view, "[data-key=\"K\"]")
+    end
+  end
+
+  describe "SEC-A10/SEC-A11 — server-side enforcement, bypassing the disabled button" do
+    @tag action: "SEC-A10"
+    test "dispatching save_new directly with an invalid key creates nothing", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      render_click(view, "save_new", %{"new_secret" => %{"key" => "a/b", "value" => "v"}})
+
+      refute has_element?(view, "[data-key=\"a/b\"]")
+      assert_no_audit_event(:secret_created)
+    end
+
+    @tag action: "SEC-A11"
+    test "dispatching save_new directly with an invalid value creates nothing", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      too_long = String.duplicate("a", 4097)
+
+      render_click(view, "save_new", %{
+        "new_secret" => %{"key" => "SOME_KEY", "value" => too_long}
+      })
+
+      refute has_element?(view, "[data-key=\"SOME_KEY\"]")
+      assert_no_audit_event(:secret_created)
+    end
+  end
+
+  describe "SEC-A12 — reject creating a secret that already exists" do
+    @tag action: "SEC-A12"
+    test "shows \"already exists in this environment\", modal stays open, existing value unchanged",
+         %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#secrets-create-button") |> render_click()
+
+      html =
+        view
+        |> form("#new-secret-form",
+          new_secret: %{"key" => "DATABASE_URL", "value" => "attempted-overwrite"}
+        )
+        |> render_submit()
+
+      assert html =~ "already exists in this environment"
+      assert has_element?(view, "#new-secret-modal")
+
+      assert {:ok, %{value: ^db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert_no_audit_event(:secret_created)
+    end
+  end
+
+  describe "SEC-A13 — dismiss the creation form without saving" do
+    @tag action: "SEC-A13"
+    test "cancel closes and creates nothing", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#secrets-create-button") |> render_click()
+      assert has_element?(view, "#new-secret-modal")
+
+      view
+      |> form("#new-secret-form", new_secret: %{"key" => "NOT_SAVED", "value" => "v"})
+      |> render_change()
+
+      view |> element("#new-secret-cancel") |> render_click()
+
+      refute has_element?(view, "#new-secret-modal")
+      refute has_element?(view, "[data-key=\"NOT_SAVED\"]")
+      assert_no_audit_event(:secret_created)
+    end
+
+    @tag action: "SEC-A13"
+    test "the modal's Escape wiring is present and reaches cancel_new", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#secrets-create-button") |> render_click()
+      doc = view |> render() |> LazyHTML.from_fragment()
+
+      assert [cancel] =
+               doc |> LazyHTML.query("#new-secret-modal") |> LazyHTML.attribute("data-cancel")
+
+      assert cancel =~ "cancel_new"
+
+      container = LazyHTML.query(doc, "#new-secret-modal-container")
+      assert LazyHTML.attribute(container, "phx-key") == ["escape"]
+      assert LazyHTML.attribute(container, "phx-window-keydown") != []
+    end
+
+    @tag action: "SEC-A13"
+    test "backdrop dismissal reaches cancel_new", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#secrets-create-button") |> render_click()
+      doc = view |> render() |> LazyHTML.from_fragment()
+
+      container = LazyHTML.query(doc, "#new-secret-modal-container")
+      assert LazyHTML.attribute(container, "phx-click-away") != []
+
+      assert [cancel] =
+               doc |> LazyHTML.query("#new-secret-modal") |> LazyHTML.attribute("data-cancel")
+
+      assert cancel =~ "cancel_new"
+    end
+
+    @tag action: "SEC-A13"
+    test "reopening after a cancelled attempt shows an empty form", %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+
+      view |> element("#secrets-create-button") |> render_click()
+
+      view
+      |> form("#new-secret-form",
+        new_secret: %{"key" => "DISCARDED", "value" => "discarded-value"}
+      )
+      |> render_change()
+
+      view |> element("#new-secret-cancel") |> render_click()
+
+      html = view |> element("#secrets-create-button") |> render_click()
+
+      refute html =~ "DISCARDED"
+      refute html =~ "discarded-value"
+      assert html =~ "0/4096 characters"
+    end
+
+    @tag action: "SEC-A13"
+    test "opening the create modal closes an open reveal modal, and vice versa", %{conn: conn} do
+      assert {:ok, %{value: db_value}} = Secrets.Store.get_secret("prod", "DATABASE_URL")
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      row_id = row_id(view, "DATABASE_URL")
+
+      html = view |> element("#reveal-#{row_id}") |> render_click()
+      assert html =~ db_value
+
+      html = view |> element("#secrets-create-button") |> render_click()
+      refute html =~ db_value
+      refute has_element?(view, "#secret-modal")
+      assert has_element?(view, "#new-secret-modal")
+
+      html = render_click(view, "reveal", %{"key" => "DATABASE_URL"})
+      assert html =~ db_value
+      refute has_element?(view, "#new-secret-modal")
+    end
+  end
+
+  describe "SEC-A09 — store forced :unavailable" do
+    @tag action: "SEC-A09"
+    test "error shown, modal open, entered values preserved, retry succeeds without re-entry",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_secrets(conn, "prod")
+      view |> element("#secrets-create-button") |> render_click()
+
+      use_failing_create_secrets_store()
+
+      form_input = %{"key" => "RETRY_KEY", "value" => "retry-value"}
+
+      html =
+        view
+        |> form("#new-secret-form", new_secret: form_input)
+        |> render_submit()
+
+      assert has_element?(view, "#new-secret-error")
+      assert has_element?(view, "#new-secret-modal")
+      assert html =~ "RETRY_KEY"
+      assert html =~ "retry-value"
+      refute has_element?(view, "[data-key=\"RETRY_KEY\"]")
+
+      restore_secrets_store_for_create()
+
+      html =
+        view
+        |> form("#new-secret-form", new_secret: form_input)
+        |> render_submit()
+
+      refute has_element?(view, "#new-secret-modal")
+      assert has_element?(view, "[data-key=\"RETRY_KEY\"]")
+      refute html =~ "retry-value"
+    end
+  end
+
+  defmodule NewSecretModalBrowserGaps do
+    @moduledoc """
+    `SEC-A13` dismissal behaviour `Phoenix.LiveViewTest` structurally cannot
+    execute, for exactly the reason `SecretRevealModalBrowserGaps` (below)
+    cannot: Escape and a backdrop click reach the server only by running the
+    `Phoenix.LiveView.JS` chain in `data-cancel`, which needs a real key
+    event, a real click outside the `.modal-box`, and a client to interpret
+    the command list (`docs/adr/0008-test-strategy.md`). Focus restoration —
+    "focus returns to a sensible place" — is the same story:
+    `JS.push_focus/1`/`JS.pop_focus/1` are client-side.
+
+    The describe block above (`"SEC-A13 — ..."`) proves the wiring these
+    gaps depend on (`data-cancel` present and pushing `cancel_new`,
+    `phx-key="escape"`, `phx-window-keydown`, `phx-click-away` all present)
+    and proves the one route a `render_click/1` can actually drive (the
+    Cancel button) discards cleanly. What remains unverified here is the
+    same as the reveal modal's own gap, carried in `living-notes.md`
+    alongside `SEC-A02`'s and `SEC-A04`'s.
+
+    Skipped unconditionally rather than by default-exclude tag, so `mix test`
+    always reports them as skipped instead of silently passing zero
+    assertions, and so the gap is discoverable in the suite itself and not
+    only in `living-notes.md`, once a driver (Wallaby, deferred to `EN-8`) is
+    adopted. None carry `@tag action:` — the describe block above records
+    what is actually proven.
+    """
+
+    use ExUnit.Case, async: true
+
+    @moduletag :browser
+    @moduletag skip: "no browser driver in this repo — see docs/adr/0008-test-strategy.md"
+
+    test "pressing Escape while the modal is open closes it and creates nothing" do
+    end
+
+    test "clicking the backdrop outside the modal box closes it and creates nothing" do
+    end
+
+    test "focus moves into the modal on open and returns to #secrets-create-button on dismissal" do
+    end
+
+    test "Tab is trapped inside the modal while it is open" do
+    end
+
+    test "the character counter updates smoothly on a long paste" do
     end
   end
 


### PR DESCRIPTION
## What

Adds secret creation to the Secrets UI: a create modal, a validated key + value form, and a `Nucleus.Secrets.create/4` context function that validates the environment, then key, then value, and only then writes — relying on the store's atomic `Overwrite: false` refusal for race-safety rather than a read-before-write check. Along the way it consolidates the key validator that `reveal/3` and `update/4` had each carried privately (and weakly) into a single `Nucleus.Secrets.Key` module, and fixes a `focusStack` double-pop risk between the new create modal and the existing reveal modal by making the two mutually exclusive. Satisfies SEC-A09 (create), SEC-A10 (key validation with per-rule error copy), SEC-A11 (value validation and length), SEC-A12 (duplicate-key rejection, race-safe), and SEC-A13 (modal dismissal wiring).

## How

- `Nucleus.Secrets.Key.validate/1` (`lib/nucleus/secrets/key.ex`) — new, single denylist key validator (empty, >256 chars, `/`, `\`, null byte, `..`), each rule checked in a fixed order and carrying a distinct reason atom in `error.details.reason`. Replaces the private, weaker copies previously inline in `reveal/3` and `update/4`; both now call this shared validator, so the 256-character cap and denylist apply uniformly on read and write, not just on create.
- `NucleusWeb.SecretsLive.CreateForm` (`lib/nucleus_web/live/secrets_live/create_form.ex`) — new `embedded_schema` form with `:key`/`:value`, following the `EditForm` pattern from SEC-S5/ADR-0013. Runs a case-sensitive, advisory duplicate check against an `existing_keys` list passed in from the LiveView's already-loaded stream (SEC-A10); the authoritative, race-safe duplicate rejection stays server-side in `create/4` via the store's atomic `:already_exists` refusal (SEC-A12).
- `Nucleus.Secrets.create/4` (`lib/nucleus/secrets.ex`) — validates environment, key, then value before any store call, and never reads before writing. Emits a `secret_created` audit event on success only, with the full path as `resource` and the value never logged.
- `lib/nucleus_web/live/secrets_live.ex` — wires a second, independently conditional modal (`:if={@creating}`) alongside the existing reveal modal (`:if={@revealed}`), and makes the two **mutually exclusive**: opening either resets the other's assigns to closed in the same step, guarded in `handle_event/3` since a client can dispatch either `phx-click` regardless of what's visually reachable. This is the concrete fix for the `focusStack`/`JS.pop_focus/1` double-pop risk ADR-0012 had predicted but left open. A successful create re-lists via the same `fetch_secrets/2` `handle_params/3` uses, rather than computing a manual `stream_insert/3` position, so the sort/tiebreak logic in `Nucleus.Secrets.list/2` stays owned in one place.
- Tests: `test/nucleus/secrets/key_test.exs`, `test/nucleus_web/live/secrets_live/create_form_test.exs`, extended `secrets_test.exs` (create success, audit event, SEC-A12 race-safety at the context level, invalid key/value, value never logged) and `secrets_live_test.exs` (17 new tests tagged SEC-A09 through SEC-A13).

## Record

ADR-0014 settles the key-validator consolidation, the no-casing-rule decision (and why it was rejected), the uniform 256-character cap across read/write, the web-layer placement of `CreateForm`, and the mutual-exclusion fix for the two modals. An addendum to ADR-0013 records that `Key.validate/1` returns `Nucleus.Backend.Error.t()` rather than a bare atom, matching `Value.validate/1`'s shape. `decisions-log.md` gets row 14; `business-tech-bridge.md`'s traceability marks SEC-A09–A13 as covered; `living-notes.md` resolves the weak-key-validator technical-debt item, updates the `focusStack` double-pop gotcha to describe the resolution, adds a "code pattern worth preserving" entry, and adds a browser-gap entry for the create modal's SEC-A13 Escape/backdrop/focus-restoration gaps, mirroring the reveal modal's existing gap entry.

## Divergence from the plan

1. **Error shape.** The plan specified `Key.validate/1 :: :ok | {:error, atom()}`. Shipped as `:ok | {:error, Nucleus.Backend.Error.t()}` instead, matching `Value.validate/1`'s already-landed shape — the issue thread itself flagged this mismatch before implementation and asked for a deliberate decision rather than an accident of authorship order. The per-rule atom now lives in `error.details.reason` instead of being the return value.
2. **Form module placement.** The plan specified `lib/nucleus/secrets/new_secret.ex` (`Nucleus.Secrets.NewSecret`, domain layer). Shipped as `NucleusWeb.SecretsLive.CreateForm` in the web layer, following ADR-0013's explicit instruction that `EditForm`'s placement "establishes the pattern SEC-S6's creation form is expected to follow."
3. **Trigger button DOM id.** The plan and issue thread both say `#new-secret-button`. The landed id from SEC-S2 is `#secrets-create-button`, and this PR keeps it as-is rather than renaming already-shipped, already-tested markup for no functional benefit.
4. **List insertion mechanics.** The plan called for inserting at the position matching SEC-S2's case-insensitive sort, or re-listing. Shipped as a re-list (reusing `fetch_secrets/2`) rather than a manual `stream_insert/3` position, since re-deriving `list/2`'s sort/tiebreak a second time in the LiveView risked the two implementations drifting apart silently.
5. **Key casing.** No casing rule was added to `Key.validate/1`. This was settled in the issue thread before implementation began, not decided by this diff — noted here because the landed `@doc`'s explicit "no casing rule" statement has no counterpart in the plan's original text, and a reviewer comparing the two might otherwise wonder where it came from.
6. **256-character cap applies on the read path too.** Confirmed deliberate, not scope creep: `Key.validate/1` backs `reveal/3` and `update/4` as well as `create/4`, so an externally-created key over 256 characters is listable but not revealable. Stated as an accepted consequence in `Key`'s `@doc`.

## Verification

`mix precommit`: 503 passed (25 doctests, 478 tests), 14 skipped, 10 excluded, 0 failures. The 14 skipped tests are three placeholder modules in `secrets_live_test.exs`, all tagged `skip: "no browser driver in this repo — see docs/adr/0008-test-strategy.md"`: `CopyButtonBrowserGaps` (4, pre-existing), `SecretRevealModalBrowserGaps` (5, pre-existing), and the new `NewSecretModalBrowserGaps` (5). The new module documents the SEC-A13 Escape/backdrop-click/focus-restoration paths that `Phoenix.LiveViewTest` cannot drive, mirroring `SecretRevealModalBrowserGaps`'s existing gap for the reveal modal. `mix nucleus.trace --feature SEC` shows SEC-A09 through SEC-A13 covered; only SEC-A18 (deferred to SEC-S7) remains uncovered in this feature.

Closes #14
