### PR TITLE
docs: amend M2M access token validity requirement (EN-10 Decisions 3, 4)

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -45,7 +45,7 @@ to cite from test names and bug reports.
 | `Environments.md` | `ENV-A01`–`A07` | 7 | `NucleusWeb.EnvironmentsLive` | `test/nucleus_web/live/environments_live_test.exs` |
 | `Data-Export-Configuration.md` | `DEX-A01`–`A14` | 14 | `NucleusWeb.DataExportLive` + Nomad Variables client | `test/nucleus_web/live/data_export_live_test.exs` |
 | `Secrets.md` | `SEC-A01`–`A18` | 18 | `NucleusWeb.SecretsLive` + SSM Parameter Store client | `test/nucleus_web/live/secrets_live_test.exs` |
-| `M2M-Clients.md` | `M2M-A01`–`A16` | 16 | `NucleusWeb.M2MClientsLive` + Cognito client | `test/nucleus_web/live/m2m_clients_live_test.exs` |
+| `M2M-Clients.md` | `M2M-A01`–`A17` | 17 | `NucleusWeb.M2MClientsLive` + Cognito client | `test/nucleus_web/live/m2m_clients_live_test.exs` |
 | `Audit-and-Compliance.md` | `AUD-A01`–`A07` | 7 | `Nucleus.Audit` (emit-only; no local store — stateless constraint) | `test/nucleus/audit_test.exs` |
 | `API-Proxy.md` | `PRX-A01`–`A07` | 7 | Backing-API forwarding layer | `test/nucleus_web/proxy_test.exs` |
 | `Platform-Operations.md` | `OPS-A01`–`A13` | 13 | Health/readiness endpoints, config reference | `test/nucleus_web/ops_test.exs` |


### PR DESCRIPTION
Amends the M2M-Clients wiki requirement per two decisions recorded on #33:

- **Decision 3** — the M2M client OAuth scope is derived (`{TENANT_NAMESPACE}/api`), not a new config variable. `Platform-Operations.md` now documents that the pool's resource-server identifier must match `TENANT_NAMESPACE` exactly.
- **Decision 4** — access token validity is operator-chosen at creation (5–60 whole minutes, default 15), not a fixed value. `M2M-A04`/`M2M-A08` updated, new `M2M-A17` added for range validation, `M2M-A16`'s display rule rewritten to a unit-agnostic largest-exact-unit rule (was hours-only).

Also folds in the `Platform-Operations.md` config-reference amendment EN-10 (#33) already owed from #32: adds `COGNITO_ROLE_ARN`, `COGNITO_REGION`, `COGNITO_STS_EXTERNAL_ID`; drops the stale `SSM_REGION` row; adds the previously-undocumented `AWS_REGION` row for Parameter Store access.

`docs/requirements` wiki pointer bumped to pick up the corresponding commit (`dave-bell/nucleus.wiki.git@23f8610`). `business-tech-bridge.md`'s M2M-Clients.md action-ID count updated from 16 to 17.

No code change. EN-10 (#33) and its downstream slices (#35–#38) implement against this amended text.

Refs #33