### PR TITLE
EN-10: M2M client boundary — Cognito App Clients adapter, seeded local impl

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.8 | Updated: 2026-08-19 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.9 | Updated: 2026-08-19 -->
 
 # Business ↔ Tech Bridge
 
@@ -45,7 +45,7 @@ to cite from test names and bug reports.
 | `Environments.md` | `ENV-A01`–`A07` | 7 | `NucleusWeb.EnvironmentsLive` | `test/nucleus_web/live/environments_live_test.exs` |
 | `Data-Export-Configuration.md` | `DEX-A01`–`A14` | 14 | `NucleusWeb.DataExportLive` + Nomad Variables client | `test/nucleus_web/live/data_export_live_test.exs` |
 | `Secrets.md` | `SEC-A01`–`A18` | 18 | `NucleusWeb.SecretsLive` + SSM Parameter Store client | `test/nucleus_web/live/secrets_live_test.exs` |
-| `M2M-Clients.md` | `M2M-A01`–`A17` | 17 | `NucleusWeb.M2MClientsLive` + Cognito client | `test/nucleus_web/live/m2m_clients_live_test.exs` |
+| `M2M-Clients.md` | `M2M-A01`–`A17`, minus `A09` | 16 | `NucleusWeb.M2MClientsLive` + Cognito client | `test/nucleus_web/live/m2m_clients_live_test.exs` |
 | `Audit-and-Compliance.md` | `AUD-A01`–`A07` | 7 | `Nucleus.Audit` (emit-only; no local store — stateless constraint) | `test/nucleus/audit_test.exs` |
 | `API-Proxy.md` | `PRX-A01`–`A07` | 7 | Backing-API forwarding layer | `test/nucleus_web/proxy_test.exs` |
 | `Platform-Operations.md` | `OPS-A01`–`A13` | 13 | Health/readiness endpoints, config reference | `test/nucleus_web/ops_test.exs` |

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.16 | Updated: 2026-08-19 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.17 | Updated: 2026-08-19 -->
 
 # Decisions Log
 
@@ -40,6 +40,7 @@ job and the row should point rather than paraphrase.
 | 13 | Secret edit lives inside the reveal modal via content-swap-in-place (no second `<.modal>`), gated on `socket.assigns.revealed` matching `%Secret{key: ^key}`; `Nucleus.Secrets.Value` and an `embedded_schema` edit form set the pattern `SEC-S6` reuses | 2026-08-18 | Decided | `docs/adr/0013-secret-edit-in-modal-and-value-form.md` |
 | 14 | Secret creation — one consolidated `Nucleus.Secrets.Key.validate/1` (denylist, no casing rule, `Error.t()` shape matching `Value`), `create/4` relies on the store's atomic `:already_exists` refusal, and the creation modal is mutually exclusive with the reveal modal to structurally avoid ADR-0012's `focusStack` double-pop | 2026-08-19 | Decided | `docs/adr/0014-secret-creation-key-consolidation-and-modal-exclusion.md` |
 | 15 | Shared AWS identity seam — two independent role ARNs (`TENANT_ROLE_ARN`, EN-10's `COGNITO_ROLE_ARN`), credential cache keyed on `{role_arn, external_id, session_name}` not the caller, region parameterised now with the second variable and its wiki amendment deferred to EN-10 | 2026-08-19 | Decided | `docs/adr/0015-shared-aws-identity-seam.md` |
+| 16 | M2M client adapter — derived OAuth scope (no new config var), operator-chosen token validity (5–60 min, stored in seconds), bounded fan-out with degrade-not-fail listing; `M2M-A09` removed mid-implementation — Cognito does not enforce client-name uniqueness | 2026-08-19 | Decided | `docs/adr/0016-m2m-client-adapter.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -61,7 +62,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0015` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0016` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,15 +22,16 @@ config :nucleus, NucleusWeb.Endpoint,
 # independently — see lib/nucleus/backend.ex and
 # docs/adr/0002-backend-adapter-boundaries.md.
 #
-# These are the `real` implementations, delivered by EN-3 and EN-4. dev and test
-# override both to the `.Local` implementations so a fresh clone needs no
-# credentials; runtime.exs allows a per-boundary override via SECRETS_BACKEND
-# and TENANT_API_BACKEND.
+# These are the `real` implementations, delivered by EN-3, EN-4, and EN-10.
+# dev and test override all three to the `.Local` implementations so a fresh
+# clone needs no credentials; runtime.exs allows a per-boundary override via
+# SECRETS_BACKEND, TENANT_API_BACKEND, and M2M_BACKEND.
 #
 # There is deliberately no `auth` boundary. Authentication is never swappable.
 config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Aws,
-  tenant_api: Nucleus.TenantApi.Http
+  tenant_api: Nucleus.TenantApi.Http,
+  m2m: Nucleus.M2M.Clients.Cognito
 
 # The tenant's backing API — the authority on environments. `base_url` has no
 # default on purpose: there is no sensible host to fall back to, and a boundary
@@ -58,6 +59,18 @@ config :nucleus, Nucleus.Secrets.Path,
 # assume by default, and runtime.exs requires this only when the :secrets
 # boundary is running its real implementation.
 config :nucleus, Nucleus.Secrets.Store.Aws,
+  role_arn: nil,
+  region: nil,
+  external_id: nil
+
+# The tenant's cross-account role for Cognito App Client operations — see
+# lib/nucleus/m2m/clients/cognito.ex. No default, matching
+# Nucleus.Secrets.Store.Aws above: runtime.exs requires COGNITO_ROLE_ARN and
+# COGNITO_REGION only when the :m2m boundary is running its real
+# implementation. COGNITO_USER_POOL_ID carries no such boot check (out of
+# scope for EN-10) — a nil value is :not_configured, never a crash.
+config :nucleus, Nucleus.M2M.Clients.Cognito,
+  user_pool_id: nil,
   role_arn: nil,
   region: nil,
   external_id: nil

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -47,10 +47,12 @@ config :nucleus, dev_routes: true
 
 # Run every boundary against its local implementation, so a fresh clone starts
 # with no AWS role and no tenant API reachable. Override per boundary with
-# SECRETS_BACKEND=real / TENANT_API_BACKEND=real (see config/runtime.exs).
+# SECRETS_BACKEND=real / TENANT_API_BACKEND=real / M2M_BACKEND=real (see
+# config/runtime.exs).
 config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Local,
-  tenant_api: Nucleus.TenantApi.Local
+  tenant_api: Nucleus.TenantApi.Local,
+  m2m: Nucleus.M2M.Clients.Local
 
 # Deploy-time cluster/deployment segments of the Parameter Store path (see
 # lib/nucleus/secrets/path.ex). Hardcoded here rather than sourced from an env

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,9 +23,9 @@ end
 config :nucleus, NucleusWeb.Endpoint,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
-# Per-boundary backend override: SECRETS_BACKEND / TENANT_API_BACKEND, each
-# "real" or "local". Unset boundaries keep whatever the compile-time config
-# chose — "real" in prod, "local" in dev and test.
+# Per-boundary backend override: SECRETS_BACKEND / TENANT_API_BACKEND /
+# M2M_BACKEND, each "real" or "local". Unset boundaries keep whatever the
+# compile-time config chose — "real" in prod, "local" in dev and test.
 #
 # Selection is per boundary, not one global switch: Parameter Store needs a
 # Terraform-provisioned cross-account IAM role, and a developer working only on
@@ -114,6 +114,35 @@ if Application.get_env(:nucleus, :backends, [])[:secrets] ==
     role_arn: role_arn,
     region: region,
     external_id: System.get_env("AWS_STS_EXTERNAL_ID")
+end
+
+# Cognito App Client operations for the :m2m boundary's real implementation —
+# read only when that implementation is actually selected, same reasoning as
+# the :secrets block above. COGNITO_USER_POOL_ID is read unconditionally,
+# below, with no boot check (out of scope for EN-10 — see issue #33); a nil
+# value is %Nucleus.Backend.Error{kind: :not_configured} at call time, never a
+# crash. COGNITO_REGION has **no fallback to AWS_REGION** — the two boundaries'
+# regions are independently configured, deliberately
+# (docs/adr/0015-shared-aws-identity-seam.md). COGNITO_STS_EXTERNAL_ID is
+# optional, mirroring AWS_STS_EXTERNAL_ID.
+if Application.get_env(:nucleus, :backends, [])[:m2m] ==
+     Nucleus.Backend.impl_for_mode!(:m2m, :real) do
+  cognito_role_arn =
+    System.get_env("COGNITO_ROLE_ARN") ||
+      raise "environment variable COGNITO_ROLE_ARN is missing (required when the :m2m boundary runs its real implementation)"
+
+  cognito_region =
+    System.get_env("COGNITO_REGION") ||
+      raise "environment variable COGNITO_REGION is missing (required when the :m2m boundary runs its real implementation)"
+
+  config :nucleus, Nucleus.M2M.Clients.Cognito,
+    role_arn: cognito_role_arn,
+    region: cognito_region,
+    external_id: System.get_env("COGNITO_STS_EXTERNAL_ID")
+end
+
+if user_pool_id = System.get_env("COGNITO_USER_POOL_ID") do
+  config :nucleus, Nucleus.M2M.Clients.Cognito, user_pool_id: user_pool_id
 end
 
 # Audit sink overrides. AUDIT_FORMAT is "json" or "text" (see

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,8 @@ config :nucleus, Nucleus.Mailer, adapter: Swoosh.Adapters.Test
 # different implementation set it themselves with Application.put_env/3.
 config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Local,
-  tenant_api: Nucleus.TenantApi.Local
+  tenant_api: Nucleus.TenantApi.Local,
+  m2m: Nucleus.M2M.Clients.Local
 
 # Deploy-time cluster/deployment segments of the Parameter Store path — see
 # config/dev.exs and lib/nucleus/secrets/path.ex.

--- a/docs/adr/0016-m2m-client-adapter.md
+++ b/docs/adr/0016-m2m-client-adapter.md
@@ -1,0 +1,189 @@
+# ADR-0016: M2M Client Adapter
+
+## Status
+
+Accepted — 2026-08-19
+
+Decided on [EN-10](https://github.com/dave-bell/nucleus/issues/33). Builds on
+`0002-backend-adapter-boundaries.md` (behaviour/real-local shape),
+`0003-shared-local-backend-seed.md` (`Nucleus.Backend.Seed`),
+`0007-secrets-store-adapter.md` (the `aws` package and credential-cache
+precedent this extends), and `0015-shared-aws-identity-seam.md` (the shared
+`Nucleus.Aws.*` seam this adapter consumes without adding to it).
+
+## Context
+
+The `:m2m` boundary is the Cognito App Clients analogue of `:secrets`'
+Parameter Store boundary — EN-3/EN-4's adapter pattern extended to a second
+AWS-touching boundary now that EN-9 generalised the credential/error
+machinery into `Nucleus.Aws.*`. Three decisions were resolved on the issue
+thread before implementation — the OAuth scope, the access token validity,
+and whether to accept N+1 on listing — each already recorded as its own
+issue comment per `ticket-decisions.md`; this ADR is their
+implementation-time record, not a restatement of their rationale (see the
+issue for that). Implementation itself surfaced a fourth, unplanned
+correction: the ticket's own design for `M2M-A09` (duplicate-client
+rejection) rested on a false premise about the Cognito API, discovered only
+by checking AWS's own API reference directly rather than trusting the
+vendored SDK's documentation-only typespecs.
+
+## Decision
+
+### Three-way struct split, secret dropped at the adapter's edge
+
+`Nucleus.M2M.Client` (list row), `ClientDetail` (describe), `ClientCredentials`
+(create/rotate only, `@derive {Inspect, except: [:client_secret]}`). Neither
+`Client` nor `ClientDetail` has a field for the secret — the same structural
+defence `Nucleus.Secrets.SecretRef` gives `SEC-A01`. `Cognito.to_detail/1`
+never references `"ClientSecret"` at all, rather than building an
+intermediate map from the full Cognito response and stripping the key
+afterward — there is no code path where a name bound to both the secret and
+the rest of the client's attributes exists.
+
+### Derived OAuth scope, no new config variable
+
+`"#{Nucleus.Scope.tenant_namespace()}/api"`. Accepted, not the ticket's own
+recommendation of a new `M2M_CLIENT_SCOPE` variable —
+`CreateUserPoolClient` itself rejects a scope absent from the pool
+(`ScopeDoesNotExistException`, mapped to `:not_configured`), so the
+fail-fast property the alternative was chosen for holds without a second
+config surface. New coupling: the pool's resource-server identifier must
+equal `TENANT_NAMESPACE` exactly, documented in `Platform-Operations.md`.
+
+([Decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5349941399))
+
+### Operator-chosen token validity, 5–60 minutes
+
+Not a fixed module constant. Cognito has no pool-level default to inherit —
+`AccessTokenValidity`/`TokenValidityUnits` exist only on the client, never
+the pool, in the pinned `aws` dependency's generated types.
+`ClientDetail.token_validity_seconds` stores seconds, not minutes —
+lossless for a client this feature did not create (Terraform or the
+console can set a validity Nucleus's own 5–60-minute range would truncate).
+`create_client/2`'s own input unit is minutes, the operator's unit;
+`Cognito` sets both `AccessTokenValidity` and `TokenValidityUnits` on every
+client it creates so the value is never ambiguous on read-back. A missing
+`AccessTokenValidity` on a client this feature did not create falls back to
+3600 seconds — Cognito's own undocumented-but-real pool default — rather
+than crashing.
+
+([Decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5349942648))
+
+### Bounded fan-out for listing, degrade-not-fail per row
+
+`ListUserPoolClients` returns no creation date at all
+(`user_pool_client_description` is `ClientId`/`ClientName`/`UserPoolId`
+only), so `list_clients/0` fans out one `DescribeUserPoolClient` per client
+via `Task.async_stream(max_concurrency: 10, timeout: :infinity)`. A
+per-client describe failure yields `created_date: nil, created_date_error:
+kind` for that one row; only a failure of the `ListUserPoolClients` call
+itself fails the whole operation. `Client` gained the `created_date_error`
+field for this; `created_date` and `created_date_error` are never both
+non-nil.
+
+([Decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5349943455))
+
+### `M2M-A09` removed — Cognito does not enforce client-name uniqueness
+
+Discovered during implementation, not decided on the issue beforehand. The
+ticket's plan assumed `CreateUserPoolClient` rejects a duplicate
+`ClientName`, which is what would have made `M2M-A09`'s rejection
+race-safe, and explicitly ruled out the only fallback (list-then-create) as
+racy. Verified against AWS's own `CreateUserPoolClient` API reference
+(`docs.aws.amazon.com/cognito-user-identity-pools/...`), not just the
+vendored `aws` dependency's documentation-only typespecs (which show the
+same absence): `ClientName`'s only documented constraint is length and a
+character pattern, and the operation's full Errors list
+(`FeatureUnavailableInTierException`, `InternalErrorException`,
+`InvalidOAuthFlowException`, `InvalidParameterException`,
+`LimitExceededException`, `NotAuthorizedException`,
+`OperationNotEnabledException`, `ResourceNotFoundException`,
+`ScopeDoesNotExistException`, `TooManyRequestsException`) contains nothing
+duplicate-name-shaped. `duplicate_provider_exception()` exists in `deps/aws`
+but belongs to the unrelated `CreateIdentityProvider` operation.
+
+`create_client/2` (`Cognito` and `Local`) therefore always creates, matching
+Cognito's real behaviour — `ClientId` (auto-generated) is the identifier
+that actually disambiguates two same-named clients, and it is already
+required on `M2M-A01`'s list. `M2M-Clients.md`'s `M2M-A09` is removed, not
+reimplemented, along with the `409` status on the create endpoint and the
+corresponding error/edge-case-matrix row; `M2M-A01` gained a note that
+`client_id`, not `client_name`, is the real identifier.
+
+([Decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5350191153))
+
+## Consequences
+
+### Positive
+
+- `Nucleus.M2M.Clients.Cognito` starts with a working, tested credential/error
+  seam from EN-9 and makes no new AWS-access decision of its own — only
+  Cognito's own error-code map (`ResourceNotFoundException`,
+  `ScopeDoesNotExistException`) is adapter-specific.
+- `create_client/2` is simpler than planned: no duplicate-name branch in
+  either implementation, no list-then-create race to reason about, and one
+  fewer `Nucleus.Backend.Error` kind this boundary needs to produce
+  correctly under concurrency.
+- `Nucleus.M2M.Clients.Local` genuinely models Cognito's two-secret rotation
+  window (a list per client, delete-oldest-if-two, append), so `M2M-S6`'s
+  "valid after one rotation, gone after two" assertions are meaningful
+  against the local implementation, not vacuous.
+
+### Negative
+
+- **Two tickets already planned around `M2M-A09` need a fresh pass before
+  implementation**: #37 (M2M-S4) deferred its own duplicate-name UX
+  affordance to #38, and #38 (M2M-S5) built roughly half its plan — audit
+  copy, form error handling, and its own test plan — around a server-side
+  rejection that no longer exists. Both are back-referenced on the deciding
+  comment; neither was actually implemented against the old plan, so no code
+  needs undoing, only re-planning.
+- **A tenant can end up with two (or more) app clients sharing a display
+  name**, indistinguishable to a human operator except by `client_id` and
+  creation date. This is Cognito's real behaviour, not a Nucleus gap, but it
+  is a UX surface M2M-S2/S3 (#35, #36) should keep in mind when rendering the
+  list and detail views.
+- **The vendored `aws` dependency's generated typespecs are not reliable
+  evidence for API-level constraints that aren't type shapes** — `aws`'s
+  documentation-only typespecs and AWS's own API reference agreed here, but
+  only the latter was authoritative. `docs/adr/0007-secrets-store-adapter.md`
+  already flagged this for response *shapes*; this ADR extends the same
+  caution to a request parameter's *semantic* constraints.
+
+## Alternatives considered
+
+**Reimplement `M2M-A09` as list-then-create.** Rejected — this is exactly the
+race the ticket's own plan ruled out, and rejecting it was correct; the
+premise that made a race-safe alternative possible was wrong, not the
+reasoning against the racy one.
+
+**Add an application-level uniqueness check (e.g., a per-tenant name index).**
+Rejected without serious consideration — Nucleus holds no data of its own
+(`docs/adr/0001-no-local-datastore.md`), and a check backed by nothing
+durable would not even be race-safe across two Nucleus processes, let alone
+against Terraform or the AWS console creating a client directly.
+
+**Keep `M2M-A09` as a purely advisory, client-side check (compare against
+the loaded list before submitting).** Not rejected — this is still available
+to M2M-S4 (#37) as a UX affordance, same as the ticket's plan already
+allowed for the pre-check. What is rejected is treating it as *enforcement*;
+it was never going to be race-safe either way.
+
+## References
+
+- EN-10 — [issue #33](https://github.com/dave-bell/nucleus/issues/33), the
+  deciding issue, including the full implementation plan and all four
+  resolved decisions
+- `docs/adr/0002-backend-adapter-boundaries.md` — the behaviour/real-local
+  shape and neutral error kinds this implementation fills in
+- `docs/adr/0003-shared-local-backend-seed.md` — `Nucleus.Backend.Seed`, read
+  and mutated directly by `Nucleus.M2M.Clients.Local`
+- `docs/adr/0007-secrets-store-adapter.md` — the `aws`-package and
+  credential-cache precedent this extends to a second AWS boundary
+- `docs/adr/0015-shared-aws-identity-seam.md` — `Nucleus.Aws.Credentials`/
+  `Nucleus.Aws.Error`, consumed here unmodified via `COGNITO_ROLE_ARN`/
+  `COGNITO_REGION` and session name `nucleus-m2m`
+- `docs/requirements/M2M-Clients.md` — amended in this ticket's PR: `M2M-A09`
+  removed, `M2M-A01` gains the `client_id`-is-the-identifier note
+- #37 (M2M-S4), #38 (M2M-S5) — back-referenced; both built part of their plan
+  on the now-removed `M2M-A09`

--- a/lib/nucleus/backend.ex
+++ b/lib/nucleus/backend.ex
@@ -14,23 +14,25 @@ defmodule Nucleus.Backend do
   |---|---|---|---|
   | `:secrets` | AWS SSM Parameter Store, in the tenant's account | `Nucleus.Secrets.Store.Aws` | `Nucleus.Secrets.Store.Local` |
   | `:tenant_api` | Tenant backing API (authoritative environment list) | `Nucleus.TenantApi.Http` | `Nucleus.TenantApi.Local` |
+  | `:m2m` | Cognito App Clients, in this tenant's user pool | `Nucleus.M2M.Clients.Cognito` | `Nucleus.M2M.Clients.Local` |
 
-  The behaviours and both implementations are delivered by EN-3 (`:tenant_api`)
-  and EN-4 (`:secrets`). This module is the shared scaffolding they plug into,
-  so the module names above are registered here before the modules exist.
+  The behaviours and both implementations are delivered by EN-3 (`:tenant_api`),
+  EN-4 (`:secrets`), and EN-10 (`:m2m`). This module is the shared scaffolding
+  they plug into, so the module names above are registered here before the
+  modules exist.
 
   Authentication is deliberately absent. There is no `:auth` boundary and no
   `AUTH_BACKEND` — auth is the actual security boundary and is never swappable.
 
   ## Selection
 
-      config :nucleus, :backends, secrets: Nucleus.Secrets.Store.Aws, tenant_api: Nucleus.TenantApi.Http
+      config :nucleus, :backends, secrets: Nucleus.Secrets.Store.Aws, tenant_api: Nucleus.TenantApi.Http, m2m: Nucleus.M2M.Clients.Cognito
 
-  `config/dev.exs` and `config/test.exs` override both to the local
-  implementations, so a fresh clone runs and its tests pass with no credentials
-  at all. `config/runtime.exs` allows a per-boundary override through
-  `SECRETS_BACKEND` and `TENANT_API_BACKEND`, each `"real"` (the default) or
-  `"local"`.
+  `config/dev.exs` and `config/test.exs` override all three to the local
+  implementations, so a fresh clone runs and its tests pass with no
+  credentials at all. `config/runtime.exs` allows a per-boundary override
+  through `SECRETS_BACKEND`, `TENANT_API_BACKEND`, and `M2M_BACKEND`, each
+  `"real"` (the default) or `"local"`.
 
   Selection is per boundary rather than one global switch because the pain it
   solves is per boundary: Parameter Store access needs a Terraform-provisioned
@@ -55,19 +57,20 @@ defmodule Nucleus.Backend do
 
   @impls %{
     secrets: %{real: Nucleus.Secrets.Store.Aws, local: Nucleus.Secrets.Store.Local},
-    tenant_api: %{real: Nucleus.TenantApi.Http, local: Nucleus.TenantApi.Local}
+    tenant_api: %{real: Nucleus.TenantApi.Http, local: Nucleus.TenantApi.Local},
+    m2m: %{real: Nucleus.M2M.Clients.Cognito, local: Nucleus.M2M.Clients.Local}
   }
 
   @boundaries Enum.sort(Map.keys(@impls))
 
-  @type boundary :: :secrets | :tenant_api
+  @type boundary :: :secrets | :tenant_api | :m2m
   @type mode :: :real | :local
 
   @doc """
   Every known boundary.
 
       iex> Nucleus.Backend.boundaries()
-      [:secrets, :tenant_api]
+      [:m2m, :secrets, :tenant_api]
   """
   @spec boundaries() :: [boundary()]
   def boundaries, do: @boundaries

--- a/lib/nucleus/m2m/client.ex
+++ b/lib/nucleus/m2m/client.ex
@@ -1,0 +1,29 @@
+defmodule Nucleus.M2M.Client do
+  @moduledoc """
+  One M2M client's row on the list, deliberately with no secret field.
+
+  `ListUserPoolClients` does not return a creation date at all — Cognito's
+  `user_pool_client_description` is `ClientId`/`ClientName`/`UserPoolId`, full
+  stop — so `Nucleus.M2M.Clients.Cognito.list_clients/0` fans out one
+  `DescribeUserPoolClient` per client to fill `created_date` in
+  ([Decision 6](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5349943455)).
+  That per-client describe can itself fail — the client was deleted between
+  the two calls, or the request was throttled — and a single bad row must not
+  take down the whole list. `created_date` and `created_date_error` carry
+  that: exactly one of them is non-nil for any given `Client`.
+
+  `client_id` is this client's real identifier, not `client_name` — Cognito
+  does not require client names to be unique, so two rows can share a name
+  (`M2M-A01`, wiki).
+  """
+
+  @enforce_keys [:client_id, :client_name]
+  defstruct [:client_id, :client_name, :created_date, :created_date_error]
+
+  @type t :: %__MODULE__{
+          client_id: String.t(),
+          client_name: String.t(),
+          created_date: DateTime.t() | nil,
+          created_date_error: Nucleus.Backend.Error.kind() | nil
+        }
+end

--- a/lib/nucleus/m2m/client_credentials.ex
+++ b/lib/nucleus/m2m/client_credentials.ex
@@ -1,0 +1,29 @@
+defmodule Nucleus.M2M.ClientCredentials do
+  @moduledoc """
+  A client's secret, shown exactly once — at creation or at rotation, and
+  **never** at any other time. Returned by `create_client/2` and
+  `rotate_secret/1`, and nothing else, ever.
+
+  Client secrets follow an AWS IAM-style security model: there is no
+  "retrieve an existing secret" operation, so the only two moments this
+  struct is ever built are the two moments a secret legitimately needs
+  revealing. Do not reuse this struct, or a field shaped like it, for any
+  other response.
+
+  `@derive {Inspect, except: [:client_secret]}` so an accidental `inspect/1`
+  in a log line or a crash report cannot print the secret — the same
+  discipline `Nucleus.M2M.Clients.Cognito`'s moduledoc requires of its own
+  logging, extended to cover a default `Inspect` implementation nobody
+  wrote on purpose.
+  """
+
+  @derive {Inspect, except: [:client_secret]}
+  @enforce_keys [:client_id, :client_name, :client_secret]
+  defstruct [:client_id, :client_name, :client_secret]
+
+  @type t :: %__MODULE__{
+          client_id: String.t(),
+          client_name: String.t(),
+          client_secret: String.t()
+        }
+end

--- a/lib/nucleus/m2m/client_detail.ex
+++ b/lib/nucleus/m2m/client_detail.ex
@@ -1,0 +1,34 @@
+defmodule Nucleus.M2M.ClientDetail do
+  @moduledoc """
+  One M2M client's detail view, deliberately with no secret field.
+
+  `DescribeUserPoolClient` returns the client secret in plaintext
+  (`"ClientSecret"` on `user_pool_client_type`) alongside everything else this
+  struct needs. `M2M-A03` forbids showing the secret on the detail view, and
+  this feature has no "retrieve an existing secret" operation at all, so the
+  secret is dropped at the Cognito adapter's edge — this struct simply has
+  nowhere to put it, the same structural defence `Nucleus.Secrets.SecretRef`
+  gives `SEC-A01`. Add a test asserting
+  `refute Map.has_key?(detail, :client_secret)` so a future struct merge
+  breaks loudly here rather than quietly on the detail view.
+
+  `token_validity_seconds` is seconds, not minutes, deliberately: it is the
+  unit Cognito's own `AccessTokenValidity` range is expressed in, and it
+  stays lossless for a client this feature didn't create (a Terraform-managed
+  client can have a 24-hour or a non-round-minute validity). The operator's
+  own input unit at creation is minutes
+  (`Nucleus.M2M.Clients.create_client/2`'s `token_validity_minutes`) — the
+  operator's unit, not this struct's storage unit.
+  """
+
+  @enforce_keys [:client_id, :client_name, :scope, :token_validity_seconds]
+  defstruct [:client_id, :client_name, :scope, :token_validity_seconds, :created_date]
+
+  @type t :: %__MODULE__{
+          client_id: String.t(),
+          client_name: String.t(),
+          scope: String.t(),
+          token_validity_seconds: pos_integer(),
+          created_date: DateTime.t() | nil
+        }
+end

--- a/lib/nucleus/m2m/clients.ex
+++ b/lib/nucleus/m2m/clients.ex
@@ -1,0 +1,157 @@
+defmodule Nucleus.M2M.Clients do
+  @moduledoc """
+  The boundary to Cognito App Clients configured for the `client_credentials`
+  OAuth flow — Nucleus's only supported way to create and rotate machine
+  credentials for a tenant's own APIs.
+
+  Two implementations, selected per boundary by `M2M_BACKEND` — see
+  `Nucleus.Backend`:
+
+  | Mode | Module | |
+  |---|---|---|
+  | `real` | `Nucleus.M2M.Clients.Cognito` | `aws` package against Cognito App Clients |
+  | `local` | `Nucleus.M2M.Clients.Local` | `priv/backends/local_seed.json`, via `Nucleus.Backend.Seed` |
+
+  ## Call through this module, not an implementation
+
+  Every function here resolves the implementation on every call, through
+  `Nucleus.Backend.impl_for/1`. Nothing outside this module should name
+  `Cognito` or `Local` directly.
+
+  ## No update callback and no delete callback
+
+  Wiki [M2M-Clients](https://github.com/dave-bell/nucleus/wiki/M2M-Clients):
+  clients "cannot be updated (beyond secret rotation) or deleted through this
+  feature." `M2M-A15` is explicit that renaming, reconfiguring, and deleting
+  are all unavailable — only secret rotation is offered. This is the same
+  deliberate omission `Nucleus.Secrets.Store`'s moduledoc documents for
+  deletion; do not add either callback here.
+
+  ## `describe_client/1` assumes a pre-validated, in-scope client ID
+
+  This callback applies **no tenant or deny-list filtering** of its own.
+  Those checks — is this ID well-formed, does it belong to this tenant's
+  namespace, is it on the reserved deny-list — are the caller's gate,
+  deliberately above this boundary, because they depend on `TENANT_NAMESPACE`
+  and `M2M_DENY_SUFFIXES`: application policy, not Cognito mechanics. A
+  caller that skips its own gate and hands this an out-of-scope ID gets
+  whatever Cognito itself says about that ID, not a `:not_found` this module
+  manufactured on its behalf.
+
+  ## No claim on client-name uniqueness
+
+  Cognito does not require `ClientName` to be unique within a pool, so
+  `create_client/2` always creates the client it is asked to — there is no
+  duplicate-name rejection here, and none is planned
+  (see the [decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5350191153)
+  removing `M2M-A09`). `client_id` is what actually identifies a client.
+  """
+
+  alias Nucleus.Backend
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.Client
+  alias Nucleus.M2M.ClientCredentials
+  alias Nucleus.M2M.ClientDetail
+
+  @boundary :m2m
+
+  @min_token_validity_minutes 5
+  @max_token_validity_minutes 60
+
+  @doc """
+  Every M2M client belonging to this tenant, unfiltered by tenant scope or
+  deny-list (`M2M-A01`'s filtering is the caller's job — see the moduledoc).
+
+  A per-client failure while filling in `created_date` degrades that one row
+  (`created_date: nil`, `created_date_error: kind`) rather than failing the
+  whole list — only a failure of the underlying list call itself does that.
+  """
+  @callback list_clients() :: {:ok, [Client.t()]} | {:error, Error.t()}
+
+  @doc """
+  One client's full detail, by `client_id` (`M2M-A03`).
+
+  Assumes a pre-validated, in-tenant client ID — see the moduledoc.
+  `{:error, %Error{kind: :not_found}}` when no such client exists.
+  """
+  @callback describe_client(client_id :: String.t()) ::
+              {:ok, ClientDetail.t()} | {:error, Error.t()}
+
+  @doc """
+  Creates a new client-credentials app client (`M2M-A08`).
+
+  `settings` carries `token_validity_minutes: pos_integer()` — a whole number
+  of minutes from #{@min_token_validity_minutes} to #{@max_token_validity_minutes}
+  inclusive (#{@min_token_validity_minutes} is Cognito's own documented floor
+  for `AccessTokenValidity`, 300 seconds; #{@max_token_validity_minutes} is
+  this feature's own ceiling). Outside that range, `{:error, %Error{kind:
+  :invalid}}` — a structural guard both implementations enforce themselves,
+  independent of M2M-S4's (#37) form validation.
+
+  Always creates, even when a client of the same name already exists —
+  Cognito does not enforce name uniqueness (see the moduledoc).
+  """
+  @callback create_client(client_name :: String.t(), settings :: keyword()) ::
+              {:ok, ClientCredentials.t()} | {:error, Error.t()}
+
+  @doc """
+  Issues a new secret for `client_id`, without changing the client ID itself
+  (`M2M-A11`). The old secret remains valid until the next rotation.
+
+  `{:error, %Error{kind: :not_found}}` when no such client exists.
+  """
+  @callback rotate_secret(client_id :: String.t()) ::
+              {:ok, ClientCredentials.t()} | {:error, Error.t()}
+
+  @doc """
+  Whether this boundary can reach the system behind it.
+  """
+  @callback health_check() :: :ok | {:error, Error.t()}
+
+  @doc """
+  The boundary name, for `Nucleus.Backend` and error construction.
+  """
+  @spec boundary() :: atom()
+  def boundary, do: @boundary
+
+  @doc """
+  The valid range for `create_client/2`'s `token_validity_minutes`, inclusive.
+  """
+  @spec token_validity_range() :: Range.t()
+  def token_validity_range, do: @min_token_validity_minutes..@max_token_validity_minutes
+
+  @doc """
+  Lists every M2M client through the configured implementation.
+  """
+  @spec list_clients() :: {:ok, [Client.t()]} | {:error, Error.t()}
+  def list_clients, do: impl().list_clients()
+
+  @doc """
+  Describes one client by `client_id` through the configured implementation.
+  """
+  @spec describe_client(String.t()) :: {:ok, ClientDetail.t()} | {:error, Error.t()}
+  def describe_client(client_id) when is_binary(client_id), do: impl().describe_client(client_id)
+
+  @doc """
+  Creates a client through the configured implementation.
+  """
+  @spec create_client(String.t(), keyword()) ::
+          {:ok, ClientCredentials.t()} | {:error, Error.t()}
+  def create_client(client_name, settings) when is_binary(client_name) and is_list(settings) do
+    impl().create_client(client_name, settings)
+  end
+
+  @doc """
+  Rotates `client_id`'s secret through the configured implementation.
+  """
+  @spec rotate_secret(String.t()) :: {:ok, ClientCredentials.t()} | {:error, Error.t()}
+  def rotate_secret(client_id) when is_binary(client_id), do: impl().rotate_secret(client_id)
+
+  @doc """
+  Checks the configured implementation can reach Cognito.
+  """
+  @spec health_check() :: :ok | {:error, Error.t()}
+  def health_check, do: impl().health_check()
+
+  defp impl, do: Backend.impl_for(@boundary)
+end

--- a/lib/nucleus/m2m/clients/cognito.ex
+++ b/lib/nucleus/m2m/clients/cognito.ex
@@ -1,0 +1,461 @@
+defmodule Nucleus.M2M.Clients.Cognito do
+  @moduledoc """
+  Cognito App Clients configured for the `client_credentials` OAuth flow, in
+  this tenant's own user pool, via an assumed role scoped to `cognito-idp`.
+
+  Built on the [`aws`](https://hex.pm/packages/aws) package against an
+  `%AWS.Client{}`, exactly like `Nucleus.Secrets.Store.Aws` — see
+  `docs/adr/0007-secrets-store-adapter.md` for why `aws` over `ex_aws`. Unlike
+  `Nucleus.Secrets.Store.Aws`, credential handling and AWS error
+  classification are **shared** machinery, extracted by EN-9
+  (`docs/adr/0015-shared-aws-identity-seam.md`): this module assembles the
+  `spec`/`ctx` `Nucleus.Aws.Credentials` and `Nucleus.Aws.Error` need from its
+  own config and holds no credential, client-construction, or generic
+  error-classification code of its own.
+
+  ## `COGNITO_ROLE_ARN`'s session is `nucleus-m2m`, deliberately
+
+  Not cosmetic: it is part of `Nucleus.Aws.CredentialCache`'s key
+  (`{role_arn, external_id, session_name}`) and it is what CloudTrail
+  attributes these `cognito-idp` calls to. If `COGNITO_ROLE_ARN` and
+  `TENANT_ROLE_ARN` are ever configured to the same role, the differing
+  session names mean two cache slots and one extra `AssumeRole` per hour —
+  traded deliberately for exact per-boundary CloudTrail attribution. See
+  `docs/adr/0015-shared-aws-identity-seam.md`.
+
+  ## Two facts about the Cognito API that drive this module's shape
+
+  Verified directly against the pinned `aws` dependency
+  (`deps/aws/lib/aws/generated/cognito_identity_provider.ex`):
+
+    * `DescribeUserPoolClient` returns the client secret in plaintext
+      (`"ClientSecret"`). It is dropped at this module's edge — `to_detail/1`
+      never references that key, so there is no separate "strip the secret"
+      step that could be skipped by accident.
+    * `ListUserPoolClients` returns no creation date at all
+      (`user_pool_client_description` is `ClientId`/`ClientName`/`UserPoolId`
+      only), so `list_clients/0` fans out one `DescribeUserPoolClient` per
+      client via `Task.async_stream/3`
+      ([Decision 6](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5349943455)).
+      A describe failure degrades that one row rather than the whole list.
+
+  ## No duplicate-name rejection
+
+  Cognito does not require `ClientName` to be unique — verified against AWS's
+  own `CreateUserPoolClient` API reference, whose error list contains nothing
+  duplicate-name-shaped. `create_client/2` always creates the client it is
+  asked to; see the
+  [decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5350191153)
+  removing `M2M-A09`.
+
+  ## Logging discipline — non-negotiable
+
+  Every logged line names the operation, the client ID, and the request ID —
+  never the request or response map, on any branch including failures.
+  `CreateUserPoolClient`'s response and `AddUserPoolClientSecret`'s response
+  both carry secret material, and `AddUserPoolClientSecret`'s *request* can
+  too (the optional `ClientSecret` input this module never sends). Same rule
+  `Nucleus.Secrets.Store.Aws` states about `PutParameter`.
+
+  ## Configuration
+
+  Read from `Application.get_env(:nucleus, __MODULE__, [])`, set by
+  `config/runtime.exs`:
+
+    * `:user_pool_id` (`COGNITO_USER_POOL_ID`) — no boot check; `nil` is
+      `{:error, %Error{kind: :not_configured}}`, never a crash.
+    * `:role_arn` (`COGNITO_ROLE_ARN`) — raises at boot when `:m2m` runs this
+      implementation; `nil` in `:dev`/`:test` (which never run that check) is
+      also `:not_configured`, never a crash.
+    * `:region` (`COGNITO_REGION`) — same boot behaviour as `:role_arn`. No
+      fallback to `AWS_REGION`.
+    * `:external_id` (`COGNITO_STS_EXTERNAL_ID`) — optional.
+    * `:plug` — the `Req.Test` seam, test-only.
+  """
+
+  @behaviour Nucleus.M2M.Clients
+
+  require Logger
+
+  alias Nucleus.Aws.Credentials
+  alias Nucleus.Aws.Error, as: AwsError
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.Client
+  alias Nucleus.M2M.ClientCredentials
+  alias Nucleus.M2M.ClientDetail
+  alias Nucleus.M2M.Clients
+
+  @session_name "nucleus-m2m"
+  @max_concurrency 10
+  @list_page_size 60
+
+  @cognito_codes %{
+    "ResourceNotFoundException" => :not_found,
+    "ScopeDoesNotExistException" => :not_configured
+  }
+
+  @impl Clients
+  def list_clients do
+    with {:ok, client, pool_id} <- client_and_pool(),
+         {:ok, descriptions} <- list_all(client, pool_id) do
+      {:ok, describe_all(client, pool_id, descriptions)}
+    end
+  end
+
+  @impl Clients
+  def describe_client(client_id) do
+    with {:ok, client, pool_id} <- client_and_pool() do
+      describe(client, pool_id, client_id)
+    end
+  end
+
+  @impl Clients
+  def create_client(client_name, settings) do
+    with {:ok, minutes} <- validate_token_validity(settings),
+         {:ok, client, pool_id} <- client_and_pool() do
+      do_create_client(client, pool_id, client_name, minutes)
+    end
+  end
+
+  @impl Clients
+  def rotate_secret(client_id) do
+    with {:ok, client, pool_id} <- client_and_pool() do
+      do_rotate_secret(client, pool_id, client_id)
+    end
+  end
+
+  @impl Clients
+  def health_check do
+    with {:ok, client, pool_id} <- client_and_pool(),
+         {:ok, _body} <- list_user_pool_clients(client, pool_id, 1, nil) do
+      :ok
+    end
+  end
+
+  # -- list_clients/0 -------------------------------------------------------
+
+  defp list_all(client, pool_id), do: list_all(client, pool_id, nil, [])
+
+  defp list_all(client, pool_id, next_token, acc) do
+    with {:ok, body} <- list_user_pool_clients(client, pool_id, @list_page_size, next_token) do
+      acc = acc ++ Map.get(body, "UserPoolClients", [])
+
+      case body["NextToken"] do
+        next_token when is_binary(next_token) and next_token != "" ->
+          list_all(client, pool_id, next_token, acc)
+
+        _no_more_pages ->
+          {:ok, acc}
+      end
+    end
+  end
+
+  defp list_user_pool_clients(client, pool_id, max_results, next_token) do
+    request_id = request_id()
+    Logger.info("m2m aws list_user_pool_clients request_id=#{request_id}")
+
+    input =
+      %{"UserPoolId" => pool_id, "MaxResults" => max_results}
+      |> maybe_put("NextToken", next_token)
+
+    client
+    |> AWS.CognitoIdentityProvider.list_user_pool_clients(input)
+    |> then(&AwsError.unwrap(client, &1))
+    |> AwsError.as_backend_result(cognito_ctx(), request_id)
+  end
+
+  defp describe_all(client, pool_id, descriptions) do
+    descriptions
+    |> Task.async_stream(&describe_for_list(client, pool_id, &1),
+      max_concurrency: @max_concurrency,
+      timeout: :infinity
+    )
+    |> Enum.map(fn {:ok, row} -> row end)
+  end
+
+  defp describe_for_list(client, pool_id, %{"ClientId" => client_id, "ClientName" => client_name}) do
+    case describe(client, pool_id, client_id) do
+      {:ok, %ClientDetail{created_date: created_date}} ->
+        %Client{
+          client_id: client_id,
+          client_name: client_name,
+          created_date: created_date,
+          created_date_error: nil
+        }
+
+      {:error, %Error{kind: kind}} ->
+        %Client{
+          client_id: client_id,
+          client_name: client_name,
+          created_date: nil,
+          created_date_error: kind
+        }
+    end
+  end
+
+  # -- describe_client/1, and list_clients/0's per-row describe ------------
+
+  defp describe(client, pool_id, client_id) do
+    request_id = request_id()
+
+    Logger.info(
+      "m2m aws describe_user_pool_client client_id=#{client_id} request_id=#{request_id}"
+    )
+
+    client
+    |> AWS.CognitoIdentityProvider.describe_user_pool_client(%{
+      "UserPoolId" => pool_id,
+      "ClientId" => client_id
+    })
+    |> then(&AwsError.unwrap(client, &1))
+    |> AwsError.as_backend_result(cognito_ctx(), request_id)
+    |> case do
+      {:ok, %{"UserPoolClient" => user_pool_client}} -> {:ok, to_detail(user_pool_client)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  # Never references "ClientSecret" — the struct this builds has no field for
+  # it, and this function has no reason to look at it either.
+  defp to_detail(%{"ClientId" => client_id, "ClientName" => client_name} = user_pool_client) do
+    %ClientDetail{
+      client_id: client_id,
+      client_name: client_name,
+      scope: user_pool_client |> Map.get("AllowedOAuthScopes", []) |> Enum.join(" "),
+      token_validity_seconds: token_validity_seconds(user_pool_client),
+      created_date: epoch_to_datetime(user_pool_client["CreationDate"])
+    }
+  end
+
+  # A client this feature created always has both set (see do_create_client/4).
+  # A client created outside this feature (Terraform, the console) can omit
+  # AccessTokenValidity entirely — that is the pool's own default, one hour.
+  defp token_validity_seconds(%{"AccessTokenValidity" => value} = user_pool_client)
+       when is_number(value) do
+    unit = user_pool_client |> Map.get("TokenValidityUnits") |> access_token_unit()
+    trunc(value) * seconds_per_unit(unit)
+  end
+
+  defp token_validity_seconds(_user_pool_client), do: 3600
+
+  defp access_token_unit(%{"AccessToken" => unit}) when is_binary(unit), do: unit
+  defp access_token_unit(_other), do: "hours"
+
+  defp seconds_per_unit("seconds"), do: 1
+  defp seconds_per_unit("minutes"), do: 60
+  defp seconds_per_unit("hours"), do: 3600
+  defp seconds_per_unit("days"), do: 86_400
+  defp seconds_per_unit(_unrecognised), do: 3600
+
+  # -- create_client/2 -------------------------------------------------------
+
+  defp validate_token_validity(settings) do
+    range = Clients.token_validity_range()
+    minutes = Keyword.get(settings, :token_validity_minutes)
+
+    if is_integer(minutes) and minutes in range do
+      {:ok, minutes}
+    else
+      {:error,
+       invalid_error(
+         "token_validity_minutes must be a whole number of minutes from " <>
+           "#{range.first} to #{range.last} inclusive, got: #{inspect(minutes)}"
+       )}
+    end
+  end
+
+  defp do_create_client(client, pool_id, client_name, minutes) do
+    request_id = request_id()
+
+    Logger.info(
+      "m2m aws create_user_pool_client client_name=#{client_name} request_id=#{request_id}"
+    )
+
+    input = %{
+      "UserPoolId" => pool_id,
+      "ClientName" => client_name,
+      "GenerateSecret" => true,
+      "AllowedOAuthFlows" => ["client_credentials"],
+      "AllowedOAuthFlowsUserPoolClient" => true,
+      "AllowedOAuthScopes" => [scope()],
+      "AccessTokenValidity" => minutes,
+      "TokenValidityUnits" => %{"AccessToken" => "minutes"}
+    }
+
+    client
+    |> AWS.CognitoIdentityProvider.create_user_pool_client(input)
+    |> then(&AwsError.unwrap(client, &1))
+    |> AwsError.as_backend_result(cognito_ctx(), request_id)
+    |> case do
+      {:ok,
+       %{
+         "UserPoolClient" => %{
+           "ClientId" => client_id,
+           "ClientName" => returned_name,
+           "ClientSecret" => client_secret
+         }
+       }} ->
+        {:ok,
+         %ClientCredentials{
+           client_id: client_id,
+           client_name: returned_name,
+           client_secret: client_secret
+         }}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp scope, do: "#{Nucleus.Scope.tenant_namespace()}/api"
+
+  # -- rotate_secret/1 -------------------------------------------------------
+  #
+  # Delete-then-add, never the reverse: adding first hits Cognito's two-secret
+  # cap and fails, and if the add fails after a delete, the client is left
+  # with exactly the secret that was already current — degraded, not broken.
+
+  defp do_rotate_secret(client, pool_id, client_id) do
+    with {:ok, %ClientDetail{client_name: client_name}} <- describe(client, pool_id, client_id),
+         {:ok, secrets} <- list_secrets(client, pool_id, client_id),
+         :ok <- maybe_delete_oldest(client, pool_id, client_id, secrets) do
+      do_add_secret(client, pool_id, client_id, client_name)
+    end
+  end
+
+  defp list_secrets(client, pool_id, client_id) do
+    request_id = request_id()
+
+    Logger.info(
+      "m2m aws list_user_pool_client_secrets client_id=#{client_id} request_id=#{request_id}"
+    )
+
+    client
+    |> AWS.CognitoIdentityProvider.list_user_pool_client_secrets(%{
+      "UserPoolId" => pool_id,
+      "ClientId" => client_id
+    })
+    |> then(&AwsError.unwrap(client, &1))
+    |> AwsError.as_backend_result(cognito_ctx(), request_id)
+    |> case do
+      {:ok, body} -> {:ok, Map.get(body, "ClientSecrets", [])}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp maybe_delete_oldest(client, pool_id, client_id, secrets) when length(secrets) >= 2 do
+    oldest = Enum.min_by(secrets, & &1["ClientSecretCreateDate"])
+    delete_secret(client, pool_id, client_id, oldest["ClientSecretId"])
+  end
+
+  defp maybe_delete_oldest(_client, _pool_id, _client_id, _secrets), do: :ok
+
+  defp delete_secret(client, pool_id, client_id, client_secret_id) do
+    request_id = request_id()
+
+    Logger.info(
+      "m2m aws delete_user_pool_client_secret client_id=#{client_id} request_id=#{request_id}"
+    )
+
+    client
+    |> AWS.CognitoIdentityProvider.delete_user_pool_client_secret(%{
+      "UserPoolId" => pool_id,
+      "ClientId" => client_id,
+      "ClientSecretId" => client_secret_id
+    })
+    |> then(&AwsError.unwrap(client, &1))
+    |> AwsError.as_backend_result(cognito_ctx(), request_id)
+    |> case do
+      {:ok, _body} -> :ok
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  # Deliberately never sends the optional "ClientSecret" input — letting AWS
+  # generate the value means the secret exists nowhere in this process before
+  # AWS has already generated it, for no benefit.
+  defp do_add_secret(client, pool_id, client_id, client_name) do
+    request_id = request_id()
+
+    Logger.info(
+      "m2m aws add_user_pool_client_secret client_id=#{client_id} request_id=#{request_id}"
+    )
+
+    client
+    |> AWS.CognitoIdentityProvider.add_user_pool_client_secret(%{
+      "UserPoolId" => pool_id,
+      "ClientId" => client_id
+    })
+    |> then(&AwsError.unwrap(client, &1))
+    |> AwsError.as_backend_result(cognito_ctx(), request_id)
+    |> case do
+      {:ok, %{"ClientSecretDescriptor" => %{"ClientSecretValue" => secret_value}}} ->
+        {:ok,
+         %ClientCredentials{
+           client_id: client_id,
+           client_name: client_name,
+           client_secret: secret_value
+         }}
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  # -- STS / credentials ------------------------------------------------------
+
+  defp client_and_pool do
+    with {:ok, pool_id} <- required(pool_id(), "COGNITO_USER_POOL_ID"),
+         {:ok, role_arn} <- required(role_arn(), "COGNITO_ROLE_ARN"),
+         {:ok, region} <- required(region(), "COGNITO_REGION"),
+         {:ok, %{client: client}} <- Credentials.fetch(spec(role_arn, region)) do
+      {:ok, client, pool_id}
+    end
+  end
+
+  defp spec(role_arn, region) do
+    %{
+      boundary: Clients.boundary(),
+      role_arn: role_arn,
+      region: region,
+      external_id: external_id(),
+      session_name: @session_name,
+      http_client_opts: Keyword.take(config(), [:plug])
+    }
+  end
+
+  defp cognito_ctx do
+    %{
+      boundary: Clients.boundary(),
+      cache_key: Credentials.cache_key(spec(role_arn(), region())),
+      codes: @cognito_codes,
+      transport_message: "the Cognito user pool is unreachable"
+    }
+  end
+
+  # -- Shape helpers ------------------------------------------------------
+
+  defp epoch_to_datetime(nil), do: nil
+  defp epoch_to_datetime(epoch) when is_integer(epoch), do: DateTime.from_unix!(epoch)
+  defp epoch_to_datetime(epoch) when is_float(epoch), do: DateTime.from_unix!(trunc(epoch))
+  defp epoch_to_datetime(_other), do: nil
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp required(value, _var) when is_binary(value) and value != "", do: {:ok, value}
+  defp required(_value, var), do: {:error, not_configured("#{var} is missing or blank")}
+
+  defp not_configured(message), do: error(:not_configured, message)
+  defp invalid_error(message), do: error(:invalid, message)
+  defp error(kind, message), do: Error.new(kind, Clients.boundary(), message, %{})
+
+  defp request_id, do: 8 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  defp pool_id, do: config()[:user_pool_id]
+  defp role_arn, do: config()[:role_arn]
+  defp region, do: config()[:region]
+  defp external_id, do: config()[:external_id]
+  defp config, do: Application.get_env(:nucleus, __MODULE__, [])
+end

--- a/lib/nucleus/m2m/clients/cognito.ex
+++ b/lib/nucleus/m2m/clients/cognito.ex
@@ -191,6 +191,29 @@ defmodule Nucleus.M2M.Clients.Cognito do
           created_date_error: kind
         }
     end
+  rescue
+    # Only a failure of ListUserPoolClients itself should fail list_clients/0
+    # — an unexpected response shape from one client's describe (a future
+    # Cognito API change, say) must degrade that row exactly like a
+    # classified AWS error does, not crash this Task and its caller.
+    #
+    # Logs the exception's module only, never its message: a MatchError from
+    # to_detail/1's pattern match carries the *full* Cognito response —
+    # ClientSecret included — in its `term` field, and Exception.message/1
+    # would print that verbatim. The logging-discipline rule above forbids
+    # that on every branch, including this one.
+    error ->
+      Logger.warning(
+        "m2m aws describe_user_pool_client unexpected failure client_id=#{client_id} " <>
+          "exception=#{inspect(error.__struct__)}"
+      )
+
+      %Client{
+        client_id: client_id,
+        client_name: client_name,
+        created_date: nil,
+        created_date_error: :unavailable
+      }
   end
 
   # -- describe_client/1, and list_clients/0's per-row describe ------------

--- a/lib/nucleus/m2m/clients/local.ex
+++ b/lib/nucleus/m2m/clients/local.ex
@@ -1,0 +1,258 @@
+defmodule Nucleus.M2M.Clients.Local do
+  @moduledoc """
+  Cognito App Clients served from `priv/backends/local_seed.json`.
+
+  A real implementation of `Nucleus.M2M.Clients`, not a test double — the
+  same module serves `mix phx.server` in development and the test suite. A
+  fresh clone needs no Terraform-provisioned role to exercise this feature at
+  all.
+
+  ## State lives in `Nucleus.Backend.Seed`, not a second `Agent`
+
+  Reads and writes go through `Seed.read/1` and `Seed.update/2`, keyed on
+  this boundary's `"m2m"` section — the same reasoning
+  `Nucleus.Secrets.Store.Local` documents for its own `"secrets"` section: a
+  second process offering the same "hold state, offer get/update" shape
+  would be a competing local-state mechanism for no benefit.
+
+  ## The seed section's shape
+
+  A map keyed by `client_id`, not a list — `client_id` is the real
+  identifier (Cognito does not require `client_name` to be unique, so two
+  entries can carry the same name):
+
+      {
+        "m2m": {
+          "<client_id>": {
+            "client_name": "...",
+            "scope": "...",
+            "token_validity_seconds": 900,
+            "created_date": "2026-06-01T12:00:00Z",
+            "secrets": [{"value": "...", "created_date": "..."}]
+          }
+        }
+      }
+
+  `list_clients/0` and `describe_client/1` return every entry exactly as
+  seeded, **unfiltered** — deny-list matching and tenant-namespace scoping
+  are M2M-S1's job, deliberately above this boundary (see
+  `Nucleus.M2M.Clients`'s moduledoc). A local implementation that quietly
+  filtered here would hide a bug in that gate rather than exposing it.
+
+  ## `rotate_secret/1` actually models two secrets
+
+  `secrets` is a list, oldest first once sorted by `created_date`: rotation
+  drops the oldest when two already exist, then appends a freshly generated
+  one, matching Cognito's own "up to two active secrets" model exactly (see
+  `Nucleus.M2M.Clients.Cognito`'s moduledoc). Returning a fresh random string
+  with no memory of the previous one would make M2M-S6's "the previous
+  secret is still valid after one rotation, gone after two" assertions
+  vacuous against this implementation.
+
+  ## No duplicate-name rejection
+
+  `create_client/2` always creates, matching `Cognito`'s real behaviour —
+  see the
+  [decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5350191153)
+  removing `M2M-A09`. `client_id` is generated fresh on every call, so two
+  calls with the same `client_name` produce two distinct clients, same as a
+  real pool would.
+
+  ## Faults come first
+
+  Every callback calls `Nucleus.Backend.Faults.maybe_fault/1` before doing
+  anything else, so `LOCAL_FORCE_ERROR=unavailable` makes this boundary's
+  failure paths testable without a real Cognito outage.
+
+  ## Fixtures, not a real pool
+
+  `client_id` and `client_secret` are generated locally — there is no real
+  Cognito user pool behind this implementation, so nothing here needs to
+  resemble AWS's own ID format beyond "plausible enough to copy and paste."
+  """
+
+  @behaviour Nucleus.M2M.Clients
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Faults
+  alias Nucleus.Backend.Seed
+  alias Nucleus.M2M.Client
+  alias Nucleus.M2M.ClientCredentials
+  alias Nucleus.M2M.ClientDetail
+  alias Nucleus.M2M.Clients
+
+  @impl Clients
+  def list_clients do
+    with :ok <- Faults.maybe_fault(Clients.boundary()),
+         {:ok, entries} <- entries() do
+      {:ok, entries |> Enum.map(&to_client/1) |> Enum.sort_by(& &1.client_name)}
+    end
+  end
+
+  @impl Clients
+  def describe_client(client_id) do
+    with :ok <- Faults.maybe_fault(Clients.boundary()),
+         {:ok, entries} <- entries(),
+         {:ok, entry} <- fetch_entry(entries, client_id) do
+      {:ok, to_detail(client_id, entry)}
+    end
+  end
+
+  @impl Clients
+  def create_client(client_name, settings) do
+    with :ok <- Faults.maybe_fault(Clients.boundary()),
+         {:ok, minutes} <- validate_token_validity(settings) do
+      {:ok, put_new_entry(client_name, minutes)}
+    end
+  end
+
+  @impl Clients
+  def rotate_secret(client_id) do
+    with :ok <- Faults.maybe_fault(Clients.boundary()),
+         {:ok, entries} <- entries(),
+         {:ok, entry} <- fetch_entry(entries, client_id) do
+      {:ok, rotate_entry(client_id, entry)}
+    end
+  end
+
+  @impl Clients
+  def health_check do
+    with :ok <- Faults.maybe_fault(Clients.boundary()),
+         {:ok, _entries} <- entries() do
+      :ok
+    end
+  end
+
+  # -- Reads ------------------------------------------------------------
+
+  defp entries do
+    case Seed.read(Clients.boundary()) do
+      %{} = entries ->
+        {:ok, entries}
+
+      nil ->
+        {:error,
+         error(:not_configured, ~s(the backend seed has no "m2m" section), %{
+           seed_path: Seed.default_path()
+         })}
+
+      other ->
+        {:error,
+         error(:not_configured, ~s(the seed's "m2m" section is not a map), %{
+           section: inspect(other)
+         })}
+    end
+  end
+
+  defp fetch_entry(entries, client_id) do
+    case Map.get(entries, client_id) do
+      %{} = entry -> {:ok, entry}
+      _absent -> {:error, error(:not_found, "no such client", %{client_id: client_id})}
+    end
+  end
+
+  defp to_client({client_id, entry}) do
+    %Client{
+      client_id: client_id,
+      client_name: entry["client_name"],
+      created_date: parse_datetime(entry["created_date"]),
+      created_date_error: nil
+    }
+  end
+
+  defp to_detail(client_id, entry) do
+    %ClientDetail{
+      client_id: client_id,
+      client_name: entry["client_name"],
+      scope: entry["scope"],
+      token_validity_seconds: entry["token_validity_seconds"],
+      created_date: parse_datetime(entry["created_date"])
+    }
+  end
+
+  # -- create_client/2 ---------------------------------------------------
+
+  defp validate_token_validity(settings) do
+    range = Clients.token_validity_range()
+    minutes = Keyword.get(settings, :token_validity_minutes)
+
+    if is_integer(minutes) and minutes in range do
+      {:ok, minutes}
+    else
+      {:error,
+       error(
+         :invalid,
+         "token_validity_minutes must be a whole number of minutes from " <>
+           "#{range.first} to #{range.last} inclusive, got: #{inspect(minutes)}"
+       )}
+    end
+  end
+
+  defp put_new_entry(client_name, minutes) do
+    client_id = generate_client_id()
+    secret = generate_secret()
+    now = DateTime.utc_now()
+
+    entry = %{
+      "client_name" => client_name,
+      "scope" => "#{Nucleus.Scope.tenant_namespace()}/api",
+      "token_validity_seconds" => minutes * 60,
+      "created_date" => DateTime.to_iso8601(now),
+      "secrets" => [%{"value" => secret, "created_date" => DateTime.to_iso8601(now)}]
+    }
+
+    Seed.update(Clients.boundary(), fn m2m ->
+      m2m = m2m || %{}
+      Map.put(m2m, client_id, entry)
+    end)
+
+    %ClientCredentials{client_id: client_id, client_name: client_name, client_secret: secret}
+  end
+
+  # -- rotate_secret/1 ----------------------------------------------------
+  #
+  # Mirrors Cognito's own sequence: delete the oldest secret if two already
+  # exist (never if only one does), then append a freshly generated one — so
+  # the previous secret survives exactly one rotation, never two.
+  defp rotate_entry(client_id, entry) do
+    now = DateTime.utc_now()
+    new_secret = %{"value" => generate_secret(), "created_date" => DateTime.to_iso8601(now)}
+
+    kept =
+      case Map.get(entry, "secrets", []) do
+        [_, _ | _] = secrets -> secrets |> Enum.sort_by(& &1["created_date"]) |> Enum.drop(1)
+        secrets -> secrets
+      end
+
+    updated_entry = Map.put(entry, "secrets", kept ++ [new_secret])
+
+    Seed.update(Clients.boundary(), fn m2m ->
+      m2m = m2m || %{}
+      Map.put(m2m, client_id, updated_entry)
+    end)
+
+    %ClientCredentials{
+      client_id: client_id,
+      client_name: entry["client_name"],
+      client_secret: new_secret["value"]
+    }
+  end
+
+  # -- Shape helpers ------------------------------------------------------
+
+  defp generate_client_id, do: 13 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+  defp generate_secret, do: 32 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  defp parse_datetime(iso8601) when is_binary(iso8601) do
+    case DateTime.from_iso8601(iso8601) do
+      {:ok, datetime, _offset} -> datetime
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp parse_datetime(_other), do: nil
+
+  defp error(kind, message, details \\ %{}) do
+    Error.new(kind, Clients.boundary(), message, details)
+  end
+end

--- a/priv/backends/local_seed.json
+++ b/priv/backends/local_seed.json
@@ -69,5 +69,79 @@
         "last_modified": "2026-05-20T08:00:00Z"
       }
     }
+  },
+  "m2m": {
+    "4f2a9c1e7b3d8f0a1c2e3f4a5b6c7d8e": {
+      "client_name": "local-control-plane-OPS-1001-billing-sync",
+      "scope": "local/api",
+      "token_validity_seconds": 900,
+      "created_date": "2026-05-01T09:00:00Z",
+      "secrets": [
+        {
+          "value": "b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a6789",
+          "created_date": "2026-05-01T09:00:00Z"
+        }
+      ]
+    },
+    "7a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d": {
+      "client_name": "local-control-plane-OPS-1002-inventory-export",
+      "scope": "local/api",
+      "token_validity_seconds": 1800,
+      "created_date": "2026-06-15T14:30:00Z",
+      "secrets": [
+        {
+          "value": "c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b",
+          "created_date": "2026-06-15T14:30:00Z"
+        }
+      ]
+    },
+    "9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a": {
+      "client_name": "local-control-plane-OPS-1003-reporting",
+      "scope": "local/api",
+      "token_validity_seconds": 3600,
+      "created_date": "2026-07-01T00:00:00Z",
+      "secrets": [
+        {
+          "value": "d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c",
+          "created_date": "2026-07-01T00:00:00Z"
+        }
+      ]
+    },
+    "1c2d3e4f5a67890b1c2d3e4f5a67890b": {
+      "client_name": "local-control-plane-OPS-1004-webhook-relay",
+      "scope": "local/api",
+      "token_validity_seconds": 450,
+      "created_date": "2026-07-10T08:15:00Z",
+      "secrets": [
+        {
+          "value": "e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d",
+          "created_date": "2026-07-10T08:15:00Z"
+        }
+      ]
+    },
+    "2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b": {
+      "client_name": "local-control-plane-OPS-1005-legacy-sync-internal",
+      "scope": "local/api",
+      "token_validity_seconds": 900,
+      "created_date": "2026-04-20T10:00:00Z",
+      "secrets": [
+        {
+          "value": "f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e",
+          "created_date": "2026-04-20T10:00:00Z"
+        }
+      ]
+    },
+    "3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c": {
+      "client_name": "other-tenant-control-plane-OPS-2001-partner-feed",
+      "scope": "other-tenant/api",
+      "token_validity_seconds": 1800,
+      "created_date": "2026-03-11T11:00:00Z",
+      "secrets": [
+        {
+          "value": "a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f",
+          "created_date": "2026-03-11T11:00:00Z"
+        }
+      ]
+    }
   }
 }

--- a/test/nucleus/backend_test.exs
+++ b/test/nucleus/backend_test.exs
@@ -29,8 +29,8 @@ defmodule Nucleus.BackendTest do
 
   describe "boundaries/0" do
     @tag :unit
-    test "covers secrets and tenant_api, and no auth boundary" do
-      assert Backend.boundaries() == [:secrets, :tenant_api]
+    test "covers secrets, tenant_api, and m2m, and no auth boundary" do
+      assert Backend.boundaries() == [:m2m, :secrets, :tenant_api]
       refute :auth in Backend.boundaries()
     end
   end
@@ -53,7 +53,7 @@ defmodule Nucleus.BackendTest do
       error = assert_raise ArgumentError, fn -> Backend.impl_for(unknown) end
 
       assert error.message =~ "unknown backend boundary: :nomad"
-      assert error.message =~ "Known boundaries: [:secrets, :tenant_api]"
+      assert error.message =~ "Known boundaries: [:m2m, :secrets, :tenant_api]"
     end
 
     @tag :unit
@@ -110,6 +110,7 @@ defmodule Nucleus.BackendTest do
     test "matches the documented variable names" do
       assert Backend.env_var(:secrets) == "SECRETS_BACKEND"
       assert Backend.env_var(:tenant_api) == "TENANT_API_BACKEND"
+      assert Backend.env_var(:m2m) == "M2M_BACKEND"
     end
   end
 
@@ -128,6 +129,7 @@ defmodule Nucleus.BackendTest do
       assert log =~ "LOCAL BACKENDS ACTIVE"
       assert log =~ "secrets -> Nucleus.Secrets.Store.Local (SECRETS_BACKEND=local)"
       assert log =~ "tenant_api -> Nucleus.TenantApi.Local (TENANT_API_BACKEND=local)"
+      assert log =~ "m2m -> Nucleus.M2M.Clients.Local (M2M_BACKEND=local)"
     end
 
     @tag :unit

--- a/test/nucleus/m2m/clients/cognito_test.exs
+++ b/test/nucleus/m2m/clients/cognito_test.exs
@@ -232,6 +232,45 @@ defmodule Nucleus.M2M.Clients.CognitoTest do
       assert %{created_date: nil, created_date_error: :unavailable} = by_id["throttled-id"]
     end
 
+    test "an unexpected DescribeUserPoolClient response shape degrades that row, not the whole list" do
+      stub_with(%{
+        "ListUserPoolClients" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "UserPoolClients" => [
+              user_pool_client_description("good-id", "good-client"),
+              user_pool_client_description("malformed-id", "malformed-client")
+            ]
+          })
+        end,
+        "DescribeUserPoolClient" => fn conn, raw_body ->
+          case Jason.decode!(raw_body) do
+            %{"ClientId" => "good-id"} ->
+              respond_json(conn, 200, %{
+                "UserPoolClient" => user_pool_client(%{"ClientId" => "good-id"})
+              })
+
+            %{"ClientId" => "malformed-id"} ->
+              # A response missing "UserPoolClient" entirely — something no
+              # documented Cognito behaviour produces, but the per-row
+              # fan-out must survive it without taking the whole list down.
+              respond_json(conn, 200, %{})
+          end
+        end
+      })
+
+      log =
+        capture_log(fn ->
+          assert {:ok, clients} = Cognito.list_clients()
+          by_id = Map.new(clients, &{&1.client_id, &1})
+
+          assert %{created_date: %DateTime{}, created_date_error: nil} = by_id["good-id"]
+          assert %{created_date: nil, created_date_error: :unavailable} = by_id["malformed-id"]
+        end)
+
+      refute log =~ "ClientSecret"
+      refute log =~ "super-secret-value"
+    end
+
     test "a failing ListUserPoolClients call fails the whole list" do
       stub_with(%{
         "ListUserPoolClients" => fn conn, _body ->

--- a/test/nucleus/m2m/clients/cognito_test.exs
+++ b/test/nucleus/m2m/clients/cognito_test.exs
@@ -1,0 +1,724 @@
+defmodule Nucleus.M2M.Clients.CognitoTest do
+  # Credentials are cached in :persistent_term (global to the node), and
+  # configuration is application-global, so these cannot run concurrently.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Nucleus.Aws.CredentialCache
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.Clients.Cognito
+
+  @moduletag :capture_log
+
+  @stub __MODULE__
+  @role_arn "arn:aws:iam::123456789012:role/CognitoRole"
+  @region "us-east-1"
+  @pool_id "us-east-1_EXAMPLE"
+  @cache_key {@role_arn, nil, "nucleus-m2m"}
+  @secrets_cache_key {"arn:aws:iam::123456789012:role/TenantRole", nil, "nucleus-secrets"}
+
+  setup do
+    original_cognito = Application.get_env(:nucleus, Cognito)
+    original_access_key = System.get_env("AWS_ACCESS_KEY_ID")
+    original_secret_key = System.get_env("AWS_SECRET_ACCESS_KEY")
+    original_session_token = System.get_env("AWS_SESSION_TOKEN")
+
+    System.put_env("AWS_ACCESS_KEY_ID", "AKIAOWNEXAMPLE")
+    System.put_env("AWS_SECRET_ACCESS_KEY", "ownsecretexample")
+    System.delete_env("AWS_SESSION_TOKEN")
+
+    Application.put_env(:nucleus, Cognito,
+      role_arn: @role_arn,
+      region: @region,
+      external_id: nil,
+      user_pool_id: @pool_id,
+      plug: {Req.Test, @stub}
+    )
+
+    CredentialCache.clear(@cache_key)
+    CredentialCache.clear(@secrets_cache_key)
+
+    on_exit(fn ->
+      Application.put_env(:nucleus, Cognito, original_cognito)
+      restore_env("AWS_ACCESS_KEY_ID", original_access_key)
+      restore_env("AWS_SECRET_ACCESS_KEY", original_secret_key)
+      restore_env("AWS_SESSION_TOKEN", original_session_token)
+      CredentialCache.clear(@cache_key)
+      CredentialCache.clear(@secrets_cache_key)
+    end)
+
+    :ok
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
+
+  # -- Stub plumbing ----------------------------------------------------
+
+  defp stub_with(overrides) do
+    handlers = Map.merge(default_sts_handlers(), overrides)
+
+    Req.Test.stub(@stub, fn conn ->
+      {:ok, raw_body, conn} = Plug.Conn.read_body(conn)
+      action = action_of(conn, raw_body)
+
+      case Map.fetch(handlers, action) do
+        {:ok, handler} -> handler.(conn, raw_body)
+        :error -> flunk("unstubbed AWS action: #{inspect(action)}")
+      end
+    end)
+  end
+
+  defp action_of(conn, raw_body) do
+    case Plug.Conn.get_req_header(conn, "x-amz-target") do
+      [target] -> target |> String.split(".") |> List.last()
+      [] -> raw_body |> URI.decode_query() |> Map.get("Action")
+    end
+  end
+
+  defp default_sts_handlers do
+    %{
+      "AssumeRole" => fn conn, _body -> respond_xml(conn, 200, assume_role_xml()) end,
+      "GetCallerIdentity" => fn conn, _body ->
+        respond_xml(conn, 200, get_caller_identity_xml())
+      end
+    }
+  end
+
+  defp respond_xml(conn, status, body) do
+    conn |> Plug.Conn.put_resp_content_type("text/xml") |> Plug.Conn.resp(status, body)
+  end
+
+  defp respond_json(conn, status, data) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/x-amz-json-1.1")
+    |> Plug.Conn.resp(status, Jason.encode!(data))
+  end
+
+  defp aws_error(conn, status, type, message \\ "boom") do
+    conn
+    |> Plug.Conn.put_resp_header("x-amzn-errortype", type)
+    |> respond_json(status, %{"__type" => type, "message" => message})
+  end
+
+  defp assume_role_xml(opts \\ []) do
+    expiration =
+      Keyword.get_lazy(opts, :expiration, fn ->
+        DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.to_iso8601()
+      end)
+
+    access_key_id = Keyword.get(opts, :access_key_id, "ASIAASSUMEDEXAMPLE")
+
+    """
+    <AssumeRoleResponse>
+      <AssumeRoleResult>
+        <Credentials>
+          <AccessKeyId>#{access_key_id}</AccessKeyId>
+          <SecretAccessKey>assumedsecretexample</SecretAccessKey>
+          <SessionToken>assumedsessiontokenexample</SessionToken>
+          <Expiration>#{expiration}</Expiration>
+        </Credentials>
+        <AssumedRoleUser>
+          <Arn>arn:aws:sts::123456789012:assumed-role/CognitoRole/nucleus-m2m</Arn>
+          <AssumedRoleId>AROAEXAMPLE:nucleus-m2m</AssumedRoleId>
+        </AssumedRoleUser>
+      </AssumeRoleResult>
+      <ResponseMetadata>
+        <RequestId>req-assume-role</RequestId>
+      </ResponseMetadata>
+    </AssumeRoleResponse>
+    """
+  end
+
+  defp get_caller_identity_xml do
+    """
+    <GetCallerIdentityResponse>
+      <GetCallerIdentityResult>
+        <Arn>arn:aws:sts::123456789012:assumed-role/CognitoRole/nucleus-m2m</Arn>
+        <UserId>AROAEXAMPLE:nucleus-m2m</UserId>
+        <Account>123456789012</Account>
+      </GetCallerIdentityResult>
+      <ResponseMetadata>
+        <RequestId>req-get-caller-identity</RequestId>
+      </ResponseMetadata>
+    </GetCallerIdentityResponse>
+    """
+  end
+
+  defp user_pool_client_description(client_id, client_name) do
+    %{"ClientId" => client_id, "ClientName" => client_name, "UserPoolId" => @pool_id}
+  end
+
+  defp user_pool_client(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "ClientId" => "client123",
+        "ClientName" => "acme-control-plane-OPS-1-test",
+        "ClientSecret" => "super-secret-value",
+        "CreationDate" => 1_700_000_000,
+        "AllowedOAuthScopes" => ["acme/api"],
+        "AccessTokenValidity" => 15,
+        "TokenValidityUnits" => %{"AccessToken" => "minutes"}
+      },
+      overrides
+    )
+  end
+
+  # -- list_clients/0 -------------------------------------------------------
+
+  describe "list_clients/0" do
+    test "follows NextToken and consumes both pages" do
+      stub_with(%{
+        "ListUserPoolClients" => fn conn, raw_body ->
+          case Jason.decode!(raw_body) do
+            %{"NextToken" => "page-2"} ->
+              respond_json(conn, 200, %{
+                "UserPoolClients" => [user_pool_client_description("id-two", "client-two")]
+              })
+
+            _first_page ->
+              respond_json(conn, 200, %{
+                "UserPoolClients" => [user_pool_client_description("id-one", "client-one")],
+                "NextToken" => "page-2"
+              })
+          end
+        end,
+        "DescribeUserPoolClient" => fn conn, raw_body ->
+          %{"ClientId" => client_id} = Jason.decode!(raw_body)
+
+          respond_json(conn, 200, %{
+            "UserPoolClient" => user_pool_client(%{"ClientId" => client_id})
+          })
+        end
+      })
+
+      assert {:ok, clients} = Cognito.list_clients()
+      assert Enum.map(clients, & &1.client_id) |> Enum.sort() == ["id-one", "id-two"]
+    end
+
+    test "a per-client DescribeUserPoolClient failure degrades that row, not the whole list" do
+      stub_with(%{
+        "ListUserPoolClients" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "UserPoolClients" => [
+              user_pool_client_description("good-id", "good-client"),
+              user_pool_client_description("deleted-id", "deleted-client"),
+              user_pool_client_description("throttled-id", "throttled-client")
+            ]
+          })
+        end,
+        "DescribeUserPoolClient" => fn conn, raw_body ->
+          case Jason.decode!(raw_body) do
+            %{"ClientId" => "good-id"} ->
+              respond_json(conn, 200, %{
+                "UserPoolClient" => user_pool_client(%{"ClientId" => "good-id"})
+              })
+
+            %{"ClientId" => "deleted-id"} ->
+              aws_error(conn, 400, "ResourceNotFoundException")
+
+            %{"ClientId" => "throttled-id"} ->
+              aws_error(conn, 400, "ThrottlingException")
+          end
+        end
+      })
+
+      assert {:ok, clients} = Cognito.list_clients()
+      by_id = Map.new(clients, &{&1.client_id, &1})
+
+      assert %{created_date: %DateTime{}, created_date_error: nil} = by_id["good-id"]
+      assert %{created_date: nil, created_date_error: :not_found} = by_id["deleted-id"]
+      assert %{created_date: nil, created_date_error: :unavailable} = by_id["throttled-id"]
+    end
+
+    test "a failing ListUserPoolClients call fails the whole list" do
+      stub_with(%{
+        "ListUserPoolClients" => fn conn, _body ->
+          aws_error(conn, 500, "InternalErrorException")
+        end
+      })
+
+      assert {:error, %Error{kind: :unavailable}} = Cognito.list_clients()
+    end
+  end
+
+  # -- describe_client/1 -----------------------------------------------------
+
+  describe "describe_client/1" do
+    for {unit, raw, expected_seconds} <- [
+          {"seconds", 450, 450},
+          {"minutes", 15, 900},
+          {"hours", 1, 3600},
+          {"days", 1, 86_400}
+        ] do
+      test "normalises TokenValidityUnits #{unit} to seconds" do
+        stub_with(%{
+          "DescribeUserPoolClient" => fn conn, _body ->
+            respond_json(conn, 200, %{
+              "UserPoolClient" =>
+                user_pool_client(%{
+                  "AccessTokenValidity" => unquote(raw),
+                  "TokenValidityUnits" => %{"AccessToken" => unquote(unit)}
+                })
+            })
+          end
+        })
+
+        assert {:ok, detail} = Cognito.describe_client("client123")
+        assert detail.token_validity_seconds == unquote(expected_seconds)
+      end
+    end
+
+    test "60 minutes, 1 hour, and 3600 seconds all normalise to 3600" do
+      for {raw, unit} <- [{60, "minutes"}, {1, "hours"}, {3600, "seconds"}] do
+        stub_with(%{
+          "DescribeUserPoolClient" => fn conn, _body ->
+            respond_json(conn, 200, %{
+              "UserPoolClient" =>
+                user_pool_client(%{
+                  "AccessTokenValidity" => raw,
+                  "TokenValidityUnits" => %{"AccessToken" => unit}
+                })
+            })
+          end
+        })
+
+        assert {:ok, detail} = Cognito.describe_client("client123")
+        assert detail.token_validity_seconds == 3600
+      end
+    end
+
+    test "a missing AccessTokenValidity falls back to the pool default (3600) without crashing" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          user_pool_client =
+            user_pool_client()
+            |> Map.delete("AccessTokenValidity")
+            |> Map.delete("TokenValidityUnits")
+
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client})
+        end
+      })
+
+      assert {:ok, detail} = Cognito.describe_client("client123")
+      assert detail.token_validity_seconds == 3600
+    end
+
+    test "never includes a :client_secret key" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end
+      })
+
+      assert {:ok, detail} = Cognito.describe_client("client123")
+      refute Map.has_key?(detail, :client_secret)
+    end
+
+    test "ResourceNotFoundException maps to :not_found" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          aws_error(conn, 400, "ResourceNotFoundException")
+        end
+      })
+
+      assert {:error, %Error{kind: :not_found}} = Cognito.describe_client("missing")
+    end
+
+    test "ScopeDoesNotExistException maps to :not_configured" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          aws_error(conn, 400, "ScopeDoesNotExistException")
+        end
+      })
+
+      assert {:error, %Error{kind: :not_configured}} = Cognito.describe_client("client123")
+    end
+  end
+
+  # -- create_client/2 -------------------------------------------------------
+
+  describe "create_client/2" do
+    test "sends client_credentials, AllowedOAuthFlowsUserPoolClient: true, GenerateSecret: true, and the derived scope" do
+      test_pid = self()
+
+      stub_with(%{
+        "CreateUserPoolClient" => fn conn, raw_body ->
+          decoded = Jason.decode!(raw_body)
+          send(test_pid, {:create_user_pool_client, decoded})
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end
+      })
+
+      assert {:ok, credentials} = Cognito.create_client("acme-client", token_validity_minutes: 15)
+      assert credentials.client_secret == "super-secret-value"
+
+      assert_received {:create_user_pool_client,
+                       %{
+                         "AllowedOAuthFlows" => ["client_credentials"],
+                         "AllowedOAuthFlowsUserPoolClient" => true,
+                         "GenerateSecret" => true,
+                         "AllowedOAuthScopes" => [scope]
+                       }}
+
+      assert scope == "#{Nucleus.Scope.tenant_namespace()}/api"
+    end
+
+    test "sends AccessTokenValidity and TokenValidityUnits: minutes from the operator's input" do
+      test_pid = self()
+
+      stub_with(%{
+        "CreateUserPoolClient" => fn conn, raw_body ->
+          send(test_pid, {:create_user_pool_client, Jason.decode!(raw_body)})
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end
+      })
+
+      assert {:ok, _credentials} =
+               Cognito.create_client("acme-client", token_validity_minutes: 42)
+
+      assert_received {:create_user_pool_client,
+                       %{
+                         "AccessTokenValidity" => 42,
+                         "TokenValidityUnits" => %{"AccessToken" => "minutes"}
+                       }}
+    end
+
+    test "rejects token_validity_minutes of 4 or 61 as :invalid, with no HTTP call" do
+      test_pid = self()
+
+      stub_with(%{
+        "CreateUserPoolClient" => fn _conn, _body -> send(test_pid, :unexpected_call) end
+      })
+
+      assert {:error, %Error{kind: :invalid}} =
+               Cognito.create_client("acme-client", token_validity_minutes: 4)
+
+      assert {:error, %Error{kind: :invalid}} =
+               Cognito.create_client("acme-client", token_validity_minutes: 61)
+
+      refute_received :unexpected_call
+    end
+
+    test "accepts the boundary values 5 and 60" do
+      stub_with(%{
+        "CreateUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end
+      })
+
+      assert {:ok, _} = Cognito.create_client("acme-client", token_validity_minutes: 5)
+      assert {:ok, _} = Cognito.create_client("acme-client", token_validity_minutes: 60)
+    end
+
+    test "a duplicate name is accepted, matching Cognito's real behaviour" do
+      stub_with(%{
+        "CreateUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end
+      })
+
+      assert {:ok, _first} = Cognito.create_client("acme-client", token_validity_minutes: 15)
+      assert {:ok, _second} = Cognito.create_client("acme-client", token_validity_minutes: 15)
+    end
+
+    test "ScopeDoesNotExistException maps to :not_configured" do
+      stub_with(%{
+        "CreateUserPoolClient" => fn conn, _body ->
+          aws_error(conn, 400, "ScopeDoesNotExistException")
+        end
+      })
+
+      assert {:error, %Error{kind: :not_configured}} =
+               Cognito.create_client("acme-client", token_validity_minutes: 15)
+    end
+
+    test "missing COGNITO_USER_POOL_ID is :not_configured, with no HTTP call attempted" do
+      Application.put_env(:nucleus, Cognito,
+        role_arn: @role_arn,
+        region: @region,
+        user_pool_id: nil,
+        plug: {Req.Test, @stub}
+      )
+
+      test_pid = self()
+
+      stub_with(%{
+        "AssumeRole" => fn _conn, _body -> send(test_pid, :assume_role_called) end
+      })
+
+      assert {:error, %Error{kind: :not_configured}} =
+               Cognito.create_client("acme-client", token_validity_minutes: 15)
+
+      refute_received :assume_role_called
+    end
+  end
+
+  # -- rotate_secret/1 -------------------------------------------------------
+
+  describe "rotate_secret/1" do
+    test "with one existing secret, issues no delete" do
+      test_pid = self()
+
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end,
+        "ListUserPoolClientSecrets" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "ClientSecrets" => [
+              %{"ClientSecretId" => "secret-1", "ClientSecretCreateDate" => 1_700_000_000}
+            ]
+          })
+        end,
+        "DeleteUserPoolClientSecret" => fn _conn, _body -> send(test_pid, :delete_called) end,
+        "AddUserPoolClientSecret" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "ClientSecretDescriptor" => %{
+              "ClientSecretId" => "secret-2",
+              "ClientSecretCreateDate" => 1_700_000_100,
+              "ClientSecretValue" => "new-secret-value"
+            }
+          })
+        end
+      })
+
+      assert {:ok, credentials} = Cognito.rotate_secret("client123")
+      assert credentials.client_id == "client123"
+      assert credentials.client_secret == "new-secret-value"
+      refute_received :delete_called
+    end
+
+    test "with two existing secrets, deletes the one with the older ClientSecretCreateDate" do
+      test_pid = self()
+
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end,
+        "ListUserPoolClientSecrets" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "ClientSecrets" => [
+              %{"ClientSecretId" => "newer", "ClientSecretCreateDate" => 1_700_000_200},
+              %{"ClientSecretId" => "older", "ClientSecretCreateDate" => 1_700_000_000}
+            ]
+          })
+        end,
+        "DeleteUserPoolClientSecret" => fn conn, raw_body ->
+          send(test_pid, {:delete_called, Jason.decode!(raw_body)})
+          respond_json(conn, 200, %{})
+        end,
+        "AddUserPoolClientSecret" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "ClientSecretDescriptor" => %{
+              "ClientSecretId" => "secret-3",
+              "ClientSecretCreateDate" => 1_700_000_300,
+              "ClientSecretValue" => "newest-secret-value"
+            }
+          })
+        end
+      })
+
+      assert {:ok, _credentials} = Cognito.rotate_secret("client123")
+      assert_received {:delete_called, %{"ClientSecretId" => "older"}}
+    end
+
+    test "on an unknown client, ResourceNotFoundException maps to :not_found" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          aws_error(conn, 400, "ResourceNotFoundException")
+        end
+      })
+
+      assert {:error, %Error{kind: :not_found}} = Cognito.rotate_secret("missing")
+    end
+  end
+
+  # -- health_check/0 --------------------------------------------------------
+
+  describe "health_check/0" do
+    test "is :ok when Cognito answers" do
+      stub_with(%{
+        "ListUserPoolClients" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClients" => []})
+        end
+      })
+
+      assert Cognito.health_check() == :ok
+    end
+
+    test "is :unavailable on a transport error" do
+      stub_with(%{
+        "ListUserPoolClients" => fn conn, _body -> Req.Test.transport_error(conn, :timeout) end
+      })
+
+      assert {:error, %Error{kind: :unavailable}} = Cognito.health_check()
+    end
+  end
+
+  # -- Error mapping shared across operations ------------------------------
+
+  describe "error mapping" do
+    for code <- ~w(ExpiredToken ExpiredTokenException InvalidClientTokenId RequestExpired) do
+      test "#{code} on DescribeUserPoolClient maps to :auth_expired and clears only this boundary's cache slot" do
+        CredentialCache.put(@secrets_cache_key, %{sentinel: :untouched})
+
+        stub_with(%{
+          "DescribeUserPoolClient" => fn conn, _body -> aws_error(conn, 400, unquote(code)) end
+        })
+
+        assert {:error, %Error{kind: :auth_expired}} = Cognito.describe_client("client123")
+        assert CredentialCache.get(@cache_key) == nil
+        assert CredentialCache.get(@secrets_cache_key) == %{sentinel: :untouched}
+      end
+    end
+
+    test "throttling maps to :unavailable" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          aws_error(conn, 400, "ThrottlingException")
+        end
+      })
+
+      assert {:error, %Error{kind: :unavailable}} = Cognito.describe_client("client123")
+    end
+
+    test "a 500 maps to :unavailable" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          aws_error(conn, 500, "InternalErrorException")
+        end
+      })
+
+      assert {:error, %Error{kind: :unavailable}} = Cognito.describe_client("client123")
+    end
+
+    test "a transport error maps to :unavailable" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          Req.Test.transport_error(conn, :econnrefused)
+        end
+      })
+
+      assert {:error, %Error{kind: :unavailable}} = Cognito.describe_client("client123")
+    end
+
+    test "an unset COGNITO_ROLE_ARN is :not_configured, with no request attempted" do
+      Application.put_env(:nucleus, Cognito,
+        role_arn: nil,
+        region: @region,
+        user_pool_id: @pool_id,
+        plug: {Req.Test, @stub}
+      )
+
+      test_pid = self()
+
+      stub_with(%{
+        "AssumeRole" => fn _conn, _body -> send(test_pid, :assume_role_called) end
+      })
+
+      assert {:error, %Error{kind: :not_configured}} = Cognito.describe_client("client123")
+      refute_received :assume_role_called
+    end
+
+    test "unset AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY is :not_configured" do
+      System.delete_env("AWS_ACCESS_KEY_ID")
+      System.delete_env("AWS_SECRET_ACCESS_KEY")
+
+      assert {:error, %Error{kind: :not_configured}} = Cognito.describe_client("client123")
+    end
+  end
+
+  # -- Credential caching --------------------------------------------------
+
+  describe "credential caching" do
+    test "AssumeRole is called once across two operations, within the credential lifetime" do
+      test_pid = self()
+
+      stub_with(%{
+        "AssumeRole" => fn conn, _body ->
+          send(test_pid, :assume_role_called)
+          respond_xml(conn, 200, assume_role_xml())
+        end,
+        "DescribeUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end
+      })
+
+      assert {:ok, _} = Cognito.describe_client("client123")
+      assert {:ok, _} = Cognito.describe_client("client123")
+
+      assert_received :assume_role_called
+      refute_received :assume_role_called
+    end
+  end
+
+  # -- Logging discipline ---------------------------------------------------
+
+  describe "logging discipline" do
+    test "a successful create_client/2 never logs the secret" do
+      stub_with(%{
+        "CreateUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "UserPoolClient" => user_pool_client(%{"ClientSecret" => "leak-me-please"})
+          })
+        end
+      })
+
+      log =
+        capture_log(fn ->
+          assert {:ok, credentials} =
+                   Cognito.create_client("acme-client", token_validity_minutes: 15)
+
+          assert credentials.client_secret == "leak-me-please"
+        end)
+
+      refute log =~ "leak-me-please"
+    end
+
+    test "a failed create_client/2 never logs the secret" do
+      stub_with(%{
+        "CreateUserPoolClient" => fn conn, _body ->
+          aws_error(conn, 500, "InternalErrorException")
+        end
+      })
+
+      log =
+        capture_log(fn ->
+          assert {:error, %Error{kind: :unavailable}} =
+                   Cognito.create_client("acme-client", token_validity_minutes: 15)
+        end)
+
+      refute log =~ "InternalErrorException" && log =~ "ClientSecret"
+    end
+
+    test "a successful rotate_secret/1 never logs the secret" do
+      stub_with(%{
+        "DescribeUserPoolClient" => fn conn, _body ->
+          respond_json(conn, 200, %{"UserPoolClient" => user_pool_client()})
+        end,
+        "ListUserPoolClientSecrets" => fn conn, _body ->
+          respond_json(conn, 200, %{"ClientSecrets" => []})
+        end,
+        "AddUserPoolClientSecret" => fn conn, _body ->
+          respond_json(conn, 200, %{
+            "ClientSecretDescriptor" => %{
+              "ClientSecretId" => "secret-x",
+              "ClientSecretCreateDate" => 1_700_000_000,
+              "ClientSecretValue" => "rotate-leak-me-please"
+            }
+          })
+        end
+      })
+
+      log =
+        capture_log(fn ->
+          assert {:ok, credentials} = Cognito.rotate_secret("client123")
+          assert credentials.client_secret == "rotate-leak-me-please"
+        end)
+
+      refute log =~ "rotate-leak-me-please"
+    end
+  end
+end

--- a/test/nucleus/m2m/clients/contract_test.exs
+++ b/test/nucleus/m2m/clients/contract_test.exs
@@ -1,0 +1,128 @@
+defmodule Nucleus.M2M.Clients.ContractTest do
+  @moduledoc """
+  The same assertions against every implementation of the `:m2m` boundary.
+
+  `Local` always runs, mutations included. `Cognito` runs read-only
+  assertions only, and only when `TEST_COGNITO_ROLE_ARN` and
+  `TEST_COGNITO_USER_POOL_ID` name a real, disposable test pool — tagged
+  `:external`, excluded by default in `test_helper.exs`, so a fresh clone
+  with no AWS access still goes green.
+
+  Mutation assertions run against `Local` only — this suite must never create
+  or rotate a real Cognito app client.
+  """
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Aws.CredentialCache
+  alias Nucleus.Backend.Seed
+  alias Nucleus.M2M.Clients.Cognito
+  alias Nucleus.M2M.Clients.Local
+  alias NucleusTest.M2MClientsContract, as: Contract
+
+  @default_settings [token_validity_minutes: 15]
+
+  describe "Nucleus.M2M.Clients.Local" do
+    setup do
+      on_exit(&Seed.reset/0)
+      :ok
+    end
+
+    test "list_clients/0 returns fully-formed Clients, none carrying a secret" do
+      Contract.assert_list_clients_shape(Local)
+    end
+
+    test "describe_client/1 on an unknown ID is :not_found" do
+      Contract.assert_describe_client_not_found(Local)
+    end
+
+    test "describe_client/1 returns a fully-formed ClientDetail with no secret" do
+      {:ok, [client | _]} = Local.list_clients()
+      Contract.assert_describe_client_shape(Local, client.client_id)
+    end
+
+    test "health_check/0 is :ok" do
+      Contract.assert_health_check(Local)
+    end
+
+    test "create_client/2 returns credentials with a non-empty secret" do
+      Contract.assert_create_client_returns_credentials(
+        Local,
+        unique("contract-client"),
+        @default_settings
+      )
+    end
+
+    test "create_client/2 allows a duplicate name, with a distinct client_id" do
+      Contract.assert_create_client_allows_duplicate_name(
+        Local,
+        unique("contract-dup"),
+        @default_settings
+      )
+    end
+
+    test "create_client/2 rejects an out-of-range token_validity_minutes" do
+      Contract.assert_create_client_rejects_invalid_validity(Local, unique("contract-invalid"))
+    end
+
+    test "rotate_secret/1 returns a new secret for the same client_id" do
+      Contract.assert_rotate_secret_roundtrips(
+        Local,
+        unique("contract-rotate"),
+        @default_settings
+      )
+    end
+
+    test "rotate_secret/1 on an unknown ID is :not_found" do
+      Contract.assert_rotate_secret_not_found(Local)
+    end
+  end
+
+  describe "Nucleus.M2M.Clients.Cognito" do
+    @describetag :external
+
+    setup do
+      role_arn =
+        System.get_env("TEST_COGNITO_ROLE_ARN") ||
+          flunk("TEST_COGNITO_ROLE_ARN must be set to run the external contract tests")
+
+      pool_id =
+        System.get_env("TEST_COGNITO_USER_POOL_ID") ||
+          flunk("TEST_COGNITO_USER_POOL_ID must be set to run the external contract tests")
+
+      region = System.get_env("COGNITO_REGION") || "us-east-1"
+      cache_key = {role_arn, nil, "nucleus-m2m"}
+
+      original = Application.get_env(:nucleus, Cognito)
+
+      Application.put_env(:nucleus, Cognito,
+        role_arn: role_arn,
+        region: region,
+        external_id: nil,
+        user_pool_id: pool_id
+      )
+
+      CredentialCache.clear(cache_key)
+
+      on_exit(fn ->
+        Application.put_env(:nucleus, Cognito, original)
+        CredentialCache.clear(cache_key)
+      end)
+
+      :ok
+    end
+
+    test "list_clients/0 returns fully-formed Clients, none carrying a secret" do
+      Contract.assert_list_clients_shape(Cognito)
+    end
+
+    test "describe_client/1 on an unknown ID is :not_found" do
+      Contract.assert_describe_client_not_found(Cognito)
+    end
+
+    test "health_check/0 is :ok" do
+      Contract.assert_health_check(Cognito)
+    end
+  end
+
+  defp unique(prefix), do: "#{prefix}-#{System.unique_integer([:positive])}"
+end

--- a/test/nucleus/m2m/clients/local_test.exs
+++ b/test/nucleus/m2m/clients/local_test.exs
@@ -1,0 +1,220 @@
+defmodule Nucleus.M2M.Clients.LocalTest do
+  # Fault injection is read from the OS environment, which is global to the node.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Seed
+  alias Nucleus.M2M.Client
+  alias Nucleus.M2M.ClientCredentials
+  alias Nucleus.M2M.ClientDetail
+  alias Nucleus.M2M.Clients.Local
+
+  @default_settings [token_validity_minutes: 15]
+
+  setup do
+    on_exit(&Seed.reset/0)
+    :ok
+  end
+
+  defp force_error(kind) do
+    System.put_env("LOCAL_FORCE_ERROR", kind)
+    on_exit(fn -> System.delete_env("LOCAL_FORCE_ERROR") end)
+  end
+
+  describe "the seeded fixtures" do
+    test "the deny-listed-suffix fixture is returned unfiltered — filtering is M2M-S1's job" do
+      assert {:ok, clients} = Local.list_clients()
+      assert Enum.any?(clients, &String.ends_with?(&1.client_name, "-internal"))
+    end
+
+    test "the out-of-tenant-prefix fixture is returned unfiltered" do
+      assert {:ok, clients} = Local.list_clients()
+      assert Enum.any?(clients, &String.starts_with?(&1.client_name, "other-tenant-"))
+    end
+
+    test "list_clients/0 returns clients with varied created_date values" do
+      assert {:ok, clients} = Local.list_clients()
+      dates = clients |> Enum.map(& &1.created_date) |> Enum.uniq()
+      assert length(dates) > 1
+    end
+
+    test "a client with an exactly-one-hour validity (3600 seconds) is seeded" do
+      assert {:ok, clients} = Local.list_clients()
+
+      assert Enum.find_value(clients, fn %Client{client_id: id} ->
+               case Local.describe_client(id) do
+                 {:ok, %ClientDetail{token_validity_seconds: 3600}} -> id
+                 _other -> nil
+               end
+             end)
+    end
+
+    test "a client with a non-round-minute validity (450 seconds) is seeded" do
+      assert {:ok, clients} = Local.list_clients()
+
+      assert Enum.find_value(clients, fn %Client{client_id: id} ->
+               case Local.describe_client(id) do
+                 {:ok, %ClientDetail{token_validity_seconds: 450}} -> id
+                 _other -> nil
+               end
+             end)
+    end
+
+    test "no client in the list carries a :client_secret key" do
+      assert {:ok, clients} = Local.list_clients()
+      refute Enum.any?(clients, &Map.has_key?(&1, :client_secret))
+    end
+  end
+
+  describe "describe_client/1" do
+    test "an unknown client ID is :not_found" do
+      assert {:error, %Error{kind: :not_found}} = Local.describe_client("no-such-client")
+    end
+
+    test "returns no :client_secret key" do
+      assert {:ok, [%Client{client_id: id} | _]} = Local.list_clients()
+      assert {:ok, detail} = Local.describe_client(id)
+      refute Map.has_key?(detail, :client_secret)
+    end
+  end
+
+  describe "create_client/2" do
+    test "always creates, even with a name that already exists — no M2M-A09" do
+      assert {:ok, first} = Local.create_client("dup-client", @default_settings)
+      assert {:ok, second} = Local.create_client("dup-client", @default_settings)
+      refute first.client_id == second.client_id
+    end
+
+    test "rejects a token_validity_minutes outside 5..60" do
+      assert {:error, %Error{kind: :invalid}} =
+               Local.create_client("bad-client", token_validity_minutes: 4)
+
+      assert {:error, %Error{kind: :invalid}} =
+               Local.create_client("bad-client", token_validity_minutes: 61)
+
+      assert {:error, %Error{kind: :invalid}} =
+               Local.create_client("bad-client", token_validity_minutes: "15")
+    end
+
+    test "accepts the boundary values 5 and 60" do
+      assert {:ok, _} = Local.create_client("boundary-client-a", token_validity_minutes: 5)
+      assert {:ok, _} = Local.create_client("boundary-client-b", token_validity_minutes: 60)
+    end
+
+    test "the returned credentials round-trip through describe_client/1" do
+      assert {:ok, %ClientCredentials{client_id: client_id, client_name: "new-client"}} =
+               Local.create_client("new-client", @default_settings)
+
+      assert {:ok, %ClientDetail{client_name: "new-client", token_validity_seconds: 900}} =
+               Local.describe_client(client_id)
+    end
+  end
+
+  describe "rotate_secret/1" do
+    test "returns a new secret for the same client_id" do
+      assert {:ok, created} = Local.create_client("rotate-client", @default_settings)
+      assert {:ok, rotated} = Local.rotate_secret(created.client_id)
+
+      assert rotated.client_id == created.client_id
+      refute rotated.client_secret == created.client_secret
+    end
+
+    test "on an unknown client ID is :not_found" do
+      assert {:error, %Error{kind: :not_found}} = Local.rotate_secret("no-such-client")
+    end
+
+    test "genuinely retains exactly one previous secret, never two" do
+      assert {:ok, created} = Local.create_client("two-secret-client", @default_settings)
+      assert {:ok, rotated_once} = Local.rotate_secret(created.client_id)
+
+      secrets_after_one_rotation = seeded_secrets(created.client_id)
+      assert length(secrets_after_one_rotation) == 2
+
+      values_after_one_rotation = Enum.map(secrets_after_one_rotation, & &1["value"])
+      assert created.client_secret in values_after_one_rotation
+      assert rotated_once.client_secret in values_after_one_rotation
+
+      assert {:ok, rotated_twice} = Local.rotate_secret(created.client_id)
+
+      secrets_after_two_rotations = seeded_secrets(created.client_id)
+      assert length(secrets_after_two_rotations) == 2
+
+      values_after_two_rotations = Enum.map(secrets_after_two_rotations, & &1["value"])
+      refute created.client_secret in values_after_two_rotations
+      assert rotated_once.client_secret in values_after_two_rotations
+      assert rotated_twice.client_secret in values_after_two_rotations
+    end
+
+    defp seeded_secrets(client_id) do
+      Seed.read(:m2m) |> get_in([client_id, "secrets"])
+    end
+  end
+
+  describe "health_check/0" do
+    test "is :ok" do
+      assert Local.health_check() == :ok
+    end
+  end
+
+  describe "state resets between tests" do
+    test "part one: creates a client" do
+      assert {:ok, _credentials} = Local.create_client("reset-probe", @default_settings)
+      assert {:ok, [_ | _]} = Local.list_clients()
+    end
+
+    test "part two: the previous test's client is gone" do
+      assert {:ok, clients} = Local.list_clients()
+      refute Enum.any?(clients, &(&1.client_name == "reset-probe"))
+    end
+  end
+
+  describe "fault injection" do
+    @kinds Error.kinds()
+
+    test "LOCAL_FORCE_ERROR=auth_expired surfaces on every one of the five callbacks" do
+      force_error("auth_expired")
+
+      assert {:error, %Error{kind: :auth_expired}} = Local.list_clients()
+      assert {:error, %Error{kind: :auth_expired}} = Local.describe_client("any")
+      assert {:error, %Error{kind: :auth_expired}} = Local.create_client("any", @default_settings)
+      assert {:error, %Error{kind: :auth_expired}} = Local.rotate_secret("any")
+      assert {:error, %Error{kind: :auth_expired}} = Local.health_check()
+    end
+
+    test "every declared Error kind is a valid LOCAL_FORCE_ERROR value" do
+      for kind <- @kinds do
+        force_error(Atom.to_string(kind))
+        assert {:error, %Error{kind: ^kind}} = Local.health_check()
+        System.delete_env("LOCAL_FORCE_ERROR")
+      end
+    end
+  end
+
+  describe "the empty-tenant path (M2M-A02's local equivalent)" do
+    test "an empty section is {:ok, []}, not an error" do
+      Seed.write(:m2m, %{})
+
+      assert {:ok, []} = Local.list_clients()
+    end
+  end
+
+  describe "a broken seed section" do
+    test "reads as :not_configured when the section is absent" do
+      Seed.write(:m2m, nil)
+
+      assert {:error, %Error{kind: :not_configured}} = Local.list_clients()
+    end
+
+    test "reads as :not_configured when the section is not a map" do
+      Seed.write(:m2m, "not a map")
+
+      assert {:error, %Error{kind: :not_configured}} = Local.list_clients()
+    end
+
+    test "fails health_check/0" do
+      Seed.write(:m2m, nil)
+
+      assert {:error, %Error{kind: :not_configured}} = Local.health_check()
+    end
+  end
+end

--- a/test/support/m2m_clients_contract.ex
+++ b/test/support/m2m_clients_contract.ex
@@ -1,0 +1,134 @@
+defmodule NucleusTest.M2MClientsContract do
+  @moduledoc """
+  Assertions every `Nucleus.M2M.Clients` implementation must satisfy.
+
+  Plain functions, not a `__using__` macro — same pattern as
+  `NucleusTest.SecretsStoreContract`, so the assertions are literally shared
+  between `Local` and `Cognito` rather than generated twice.
+
+  Mutation assertions here are called against `Local` from
+  `test/nucleus/m2m/clients/contract_test.exs` unconditionally, and against
+  `Cognito` only under `@describetag :external` against a real, disposable
+  test pool — this suite must never mutate a real tenant's user pool clients
+  otherwise.
+  """
+
+  import ExUnit.Assertions
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.Client
+  alias Nucleus.M2M.ClientCredentials
+  alias Nucleus.M2M.ClientDetail
+
+  # -- Read assertions ---------------------------------------------------
+
+  @doc """
+  Every element of `impl.list_clients()` is a fully-formed `%Client{}`, and
+  none carries a `:client_secret` key — the structural guard `M2M-A01`
+  depends on, asserted at the contract level so both implementations are
+  held to it.
+  """
+  def assert_list_clients_shape(impl) do
+    assert {:ok, clients} = impl.list_clients()
+    assert is_list(clients)
+
+    for client <- clients do
+      assert %Client{} = client
+      assert is_binary(client.client_id) and client.client_id != ""
+      assert is_binary(client.client_name) and client.client_name != ""
+      refute Map.has_key?(client, :client_secret)
+    end
+
+    clients
+  end
+
+  @doc """
+  `describe_client/1` on an unknown-but-well-formed client ID is `:not_found`,
+  never a crash or a different kind.
+  """
+  def assert_describe_client_not_found(impl) do
+    assert {:error, %Error{kind: :not_found}} = impl.describe_client(unique("missing-client"))
+  end
+
+  @doc """
+  `describe_client/1` returns a fully-formed `%ClientDetail{}` for `client_id`,
+  with no `:client_secret` key — the same structural guard as
+  `assert_list_clients_shape/1`, for the detail view this time.
+  """
+  def assert_describe_client_shape(impl, client_id) do
+    assert {:ok, %ClientDetail{} = detail} = impl.describe_client(client_id)
+    assert detail.client_id == client_id
+    assert is_binary(detail.client_name) and detail.client_name != ""
+    assert is_binary(detail.scope)
+    assert is_integer(detail.token_validity_seconds) and detail.token_validity_seconds > 0
+    refute Map.has_key?(detail, :client_secret)
+    detail
+  end
+
+  @doc """
+  `health_check/0` reports reachable.
+  """
+  def assert_health_check(impl) do
+    assert impl.health_check() == :ok
+  end
+
+  # -- Mutation assertions (Local only, or :external against a disposable pool) -
+
+  @doc """
+  `create_client/2` returns `ClientCredentials` with a non-empty secret.
+  """
+  def assert_create_client_returns_credentials(impl, client_name, settings) do
+    assert {:ok, %ClientCredentials{} = credentials} = impl.create_client(client_name, settings)
+    assert credentials.client_name == client_name
+    assert is_binary(credentials.client_id) and credentials.client_id != ""
+    assert is_binary(credentials.client_secret) and credentials.client_secret != ""
+    credentials
+  end
+
+  @doc """
+  Cognito does not require `client_name` to be unique
+  ([decision](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5350191153)
+  — `M2M-A09` removed): a second `create_client/2` call with the same name
+  succeeds too, and gets its own distinct `client_id`.
+  """
+  def assert_create_client_allows_duplicate_name(impl, client_name, settings) do
+    assert {:ok, first} = impl.create_client(client_name, settings)
+    assert {:ok, second} = impl.create_client(client_name, settings)
+    refute first.client_id == second.client_id
+  end
+
+  @doc """
+  `create_client/2` rejects a `token_validity_minutes` outside 5..60 with
+  `:invalid` — the structural guard independent of any form validation.
+  """
+  def assert_create_client_rejects_invalid_validity(impl, client_name) do
+    assert {:error, %Error{kind: :invalid}} =
+             impl.create_client(client_name, token_validity_minutes: 4)
+
+    assert {:error, %Error{kind: :invalid}} =
+             impl.create_client(client_name, token_validity_minutes: 61)
+  end
+
+  @doc """
+  `rotate_secret/1` returns a `ClientCredentials` whose `client_id` equals the
+  input and whose secret differs from the one `create_client/2` returned.
+  """
+  def assert_rotate_secret_roundtrips(impl, client_name, settings) do
+    assert {:ok, created} = impl.create_client(client_name, settings)
+    assert {:ok, rotated} = impl.rotate_secret(created.client_id)
+
+    assert rotated.client_id == created.client_id
+    refute rotated.client_secret == created.client_secret
+
+    {created, rotated}
+  end
+
+  @doc """
+  `rotate_secret/1` on an unknown client ID is `:not_found`.
+  """
+  def assert_rotate_secret_not_found(impl) do
+    assert {:error, %Error{kind: :not_found}} = impl.rotate_secret(unique("missing-client"))
+  end
+
+  defp unique(prefix), do: "#{prefix}-#{System.unique_integer([:positive])}"
+end


### PR DESCRIPTION
## What

Adds the `:m2m` backend boundary — `Nucleus.M2M.Clients`, its Cognito implementation, and a seeded local implementation — so Nucleus can create, describe, and rotate secrets for Cognito App Clients configured for the `client_credentials` OAuth flow. This is the EN-3/EN-4 adapter pattern extended to a second AWS-touching boundary, built on EN-9's shared `Nucleus.Aws.Credentials`/`Nucleus.Aws.Error` seam (#32), and it unblocks the seven M2M-S* feature slices (#34–#40) that will build the actual user-facing UI on top of it. It claims no `M2M-A*` requirement itself — `mix nucleus.trace` reports no new `action:` tags from this ticket, by design.

## How

- Three-way struct split — `Nucleus.M2M.Client` (list row), `ClientDetail` (describe), `ClientCredentials` (create/rotate only, `@derive {Inspect, except: [:client_secret]}`) — so the secret Cognito's `DescribeUserPoolClient` returns in plaintext has no field to leak through on the two structs that don't need it. `Cognito.to_detail/1` never binds a name to a map holding both the secret and the rest of the client's attributes.
- `Nucleus.M2M.Clients` behaviour with five callbacks (`list_clients/0`, `describe_client/1`, `create_client/2`, `rotate_secret/1`, `health_check/0`), dispatched through `Nucleus.Backend.impl_for(:m2m)` like every other boundary. No update, no delete — `M2M-A15` forbids both.
- `Nucleus.M2M.Clients.Cognito`: paginated `ListUserPoolClients` + one `DescribeUserPoolClient` per client via `Task.async_stream(max_concurrency: 10, timeout: :infinity)`, since `ListUserPoolClients` carries no creation date at all. A per-client describe failure degrades that one row (`created_date: nil, created_date_error: kind`) rather than failing the whole list. Token validity normalises to seconds across all four Cognito units. `create_client/2` derives the OAuth scope from `Nucleus.Scope.tenant_namespace()` and takes an operator-chosen `token_validity_minutes` (5–60, validated structurally in the behaviour). `rotate_secret/1` deletes the older of two secrets before adding a new one, never the reverse.
- `Nucleus.M2M.Clients.Local` over a new `"m2m"` `local_seed.json` section, modelling Cognito's two-secret rotation window honestly (a list per client, delete-oldest-if-two, append) and returning deny-listed/out-of-prefix fixtures unfiltered, since that filtering is M2M-S1's job, not this boundary's.
- New config: `COGNITO_ROLE_ARN` and `COGNITO_REGION` (no `AWS_REGION` fallback), both raising at boot when `:m2m` runs its real implementation, matching the existing `Nucleus.Secrets.Store.Aws` guard exactly. `:m2m` is registered in `Nucleus.Backend`'s boundary table and defaults to `Local` in dev/test.
- Contract test (`test/support/m2m_clients_contract.ex`) runs against `Local` always and against `Cognito` under `@describetag :external`, plus dedicated `cognito_test.exs` and `local_test.exs` suites.

Architecturally, this enables `M2M-A01`–`A17` for the downstream slices; it directly removes `M2M-A09` from the requirement (see below).

## Record

`docs/adr/0016-m2m-client-adapter.md` settles four decisions: the derived OAuth scope (no new config variable), operator-chosen token validity (5–60 minutes, stored in seconds), bounded fan-out with degrade-not-fail listing, and the mid-implementation removal of `M2M-A09`. `decisions-log.md` (row 16) and `business-tech-bridge.md` (the `M2M-Clients.md` row, now `A01`–`A17` minus `A09`, 16 actions) were updated alongside it. `living-notes.md` was deliberately left untouched — nothing on its open-questions or active-projects lists moved; the `M2M-A09` removal is a closed decision, fully captured in the ADR and the wiki edit.

## Divergence from the plan

The ticket's plan for `M2M-A09` ("reject creating a duplicate client") assumed `CreateUserPoolClient` rejects a duplicate `ClientName`, and explicitly ruled out the only fallback — list-then-create — as racy. During implementation this was checked directly against AWS's own `CreateUserPoolClient` API reference, not just the vendored `aws` dependency's documentation-only typespecs, and the assumption turned out to be false: Cognito enforces no uniqueness on `ClientName` at all. `ClientId`, auto-generated, is the real identifier, and it's already required on `M2M-A01`'s list.

Raised on the issue and resolved as a real-time decision ([comment](https://github.com/dave-bell/nucleus/issues/33#issuecomment-5350191153)): **`M2M-A09` is removed, not reimplemented.** `create_client/2` always creates, in both `Cognito` and `Local`, even against a duplicate name. The wiki (`docs/requirements/M2M-Clients.md`) is amended accordingly — `M2M-A09` deleted, the `409` status dropped from the create endpoint's contract, the corresponding error/edge-case-matrix row dropped, and `M2M-A01` gains a note that `client_id`, not `client_name`, is the client's real identifier. Two downstream tickets had already planned around the old behaviour and got back-reference comments: #37 (M2M-S4) had deferred a duplicate-name UX affordance to #38, and #38 (M2M-S5) built roughly half its plan — audit copy, form error handling, its own test plan — around a server-side rejection that no longer exists. Neither had been implemented yet, so nothing needs undoing, only re-planning before either proceeds.

## Addendum: review-driven fix

A code review caught a real bug in `list_clients/0`'s per-client fan-out (commit `5b3fea2`): it only degraded a row on a *classified* AWS error, but an unexpected `DescribeUserPoolClient` response shape would raise inside the `Task.async_stream` mapper and crash the whole call rather than becoming a degraded stream element. Fixed with a `rescue` that degrades the row the same way a classified error does — logging only the exception's module name, never its message, since a `MatchError` here would otherwise carry the full Cognito response, secret included, into the log line. Covered by a new test asserting the list survives a malformed describe response and that no secret value appears in the resulting log output.

## Verification

`mix precommit` passes: 610 tests (25 doctests, 585 tests), 14 skipped, 13 excluded — the `:external` tests requiring real AWS/Cognito credentials, not run in this environment.

Closes #33
