### PR TITLE
M2M-S1: Naming, validation, deny-list, and the client-resolution gate

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.9 | Updated: 2026-08-19 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.10 | Updated: 2026-08-19 -->
 
 # Business ↔ Tech Bridge
 
@@ -65,8 +65,14 @@ gated on the revealed secret matching by key (`SEC-A06`–`A08`, `docs/adr/0013-
 creates a new secret through a second, independently conditionally-rendered modal
 (`Nucleus.Secrets.Key`/`Nucleus.Secrets.create/4`, `SEC-A09`–`A13`) that closes whichever of the
 two modals is open before opening the other, and renders every fail-closed/empty/failed-reveal/
-failed-save/failed-create state. `SEC-A18` is `SEC-S7` and later. Every other row is
-unimplemented. These names are the agreed target so that
+failed-save/failed-create state. `SEC-A18` is `SEC-S7` and later. `M2M-A13`/`A14` are also now
+claimed and covered (M2M-S1/#34) — ahead of `NucleusWeb.M2MClientsLive`, which does not exist
+yet. `Nucleus.M2M.fetch/2` (`test/nucleus/m2m_test.exs`) is the context-layer gate every M2M
+action will mount through once that LiveView lands, the same relationship
+`Nucleus.Environments.fetch/2` has to `NucleusWeb.SecretsLive`; `M2M-S1` also delivers the pure
+naming/shape validators (`Nucleus.M2M.TicketId`/`Purpose`/`ClientId`/`ClientName`) and the
+`Nucleus.M2M.DenyList` boundary M2M-S2 onward reads, but claims no action beyond `A13`/`A14`
+itself. Every other row is unimplemented. These names are the agreed target so that
 work lands consistently — treat them as the convention to follow, and correct this table if a
 better structure emerges.
 

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.17 | Updated: 2026-08-19 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.18 | Updated: 2026-08-19 -->
 
 # Decisions Log
 
@@ -41,6 +41,7 @@ job and the row should point rather than paraphrase.
 | 14 | Secret creation — one consolidated `Nucleus.Secrets.Key.validate/1` (denylist, no casing rule, `Error.t()` shape matching `Value`), `create/4` relies on the store's atomic `:already_exists` refusal, and the creation modal is mutually exclusive with the reveal modal to structurally avoid ADR-0012's `focusStack` double-pop | 2026-08-19 | Decided | `docs/adr/0014-secret-creation-key-consolidation-and-modal-exclusion.md` |
 | 15 | Shared AWS identity seam — two independent role ARNs (`TENANT_ROLE_ARN`, EN-10's `COGNITO_ROLE_ARN`), credential cache keyed on `{role_arn, external_id, session_name}` not the caller, region parameterised now with the second variable and its wiki amendment deferred to EN-10 | 2026-08-19 | Decided | `docs/adr/0015-shared-aws-identity-seam.md` |
 | 16 | M2M client adapter — derived OAuth scope (no new config var), operator-chosen token validity (5–60 min, stored in seconds), bounded fan-out with degrade-not-fail listing; `M2M-A09` removed mid-implementation — Cognito does not enforce client-name uniqueness | 2026-08-19 | Decided | `docs/adr/0016-m2m-client-adapter.md` |
+| 17 | M2M naming, deny-list, and resolution gate — `M2M_DENY_SUFFIXES` defaults to the prototype's Terraform value (fail-closed, `none` sentinel), `ClientId` uses AWS's own `[\w+]+` pattern not a tighter one, tenancy is the full `{tenant}-control-plane-` prefix (pool shared across tenants), deny-list enforced at creation too — new wiki action `M2M-A18` | 2026-08-19 | Decided | `docs/adr/0017-m2m-naming-deny-list-and-resolution-gate.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -61,6 +61,13 @@ config :nucleus, Nucleus.Secrets.Path,
   cluster_name: "local-cluster",
   deployment_name: "local-deployment"
 
+# The M2M deny-list's default suffix set, hardcoded rather than sourced from
+# M2M_DENY_SUFFIXES — same TENANT_NAMESPACE precedent as above. This is the
+# prototype's actual Terraform value (M2M-S1 Decision 2), not a placeholder,
+# so a fresh clone exercises the deny-list against real values.
+config :nucleus, Nucleus.M2M.DenyList,
+  suffixes: ~w(-labops-ui -faas-api -faas-ui -device_grant -orange -nucleus)
+
 # Human-readable audit records for local development. AUD-A05 requires the
 # set of recorded events to be unchanged by the format — only the encoding
 # differs here, not which events are audited.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -201,6 +201,19 @@ if tenant_namespace = System.get_env("TENANT_NAMESPACE") do
   config :nucleus, Nucleus.Scope, tenant_namespace: tenant_namespace
 end
 
+# The M2M deny-list's reserved client-name suffixes (M2M-S1 Decision 2).
+# `Nucleus.M2M.DenyList.parse/1` is pure and already handles unset/blank
+# (`:unset`) and the `none` sentinel — only an `{:ok, suffixes}` result sets
+# the app-env key here. An absent key, not a raised boot error, is
+# `Nucleus.M2M.DenyList.suffixes/0`'s own `:not_configured` signal
+# (Nucleus.Secrets.Path's fail-closed-at-call-time precedent) — config/dev.exs
+# and config/test.exs hardcode the parsed default so neither ever reaches
+# this branch.
+case Nucleus.M2M.DenyList.parse(System.get_env("M2M_DENY_SUFFIXES")) do
+  {:ok, suffixes} -> config :nucleus, Nucleus.M2M.DenyList, suffixes: suffixes
+  :unset -> :ok
+end
+
 if config_env() == :dev do
   # Reload browser tabs when matching files change.
   config :nucleus, NucleusWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,6 +23,12 @@ config :nucleus, Nucleus.Secrets.Path,
   cluster_name: "local-cluster",
   deployment_name: "local-deployment"
 
+# The M2M deny-list's default suffix set — see config/dev.exs. Tests that
+# need to exercise the `:not_configured` fail-closed path override this
+# directly with `Application.put_env/3`.
+config :nucleus, Nucleus.M2M.DenyList,
+  suffixes: ~w(-labops-ui -faas-api -faas-ui -device_grant -orange -nucleus)
+
 # Tests assert on emitted audit records via Nucleus.Audit.Sink.Test's
 # registered process, rather than parsing :stderr.
 config :nucleus, Nucleus.Audit, sink: Nucleus.Audit.Sink.Test

--- a/docs/adr/0017-m2m-naming-deny-list-and-resolution-gate.md
+++ b/docs/adr/0017-m2m-naming-deny-list-and-resolution-gate.md
@@ -1,0 +1,226 @@
+# ADR-0017: M2M Client Naming, Deny-List, and the Resolution Gate
+
+## Status
+
+Accepted — 2026-08-19
+
+Decided on [M2M-S1](https://github.com/dave-bell/nucleus/issues/34). Builds on
+`0002-backend-adapter-boundaries.md` (the neutral `Nucleus.Backend.Error` kind
+vocabulary), `0009-environment-validation-ladder.md` (`SEC-S1`'s equivalent
+gate — the structure this ADR reuses one boundary over), and
+`0016-m2m-client-adapter.md` (EN-10's `Nucleus.M2M.Clients` boundary, which
+this ticket's gate sits above and which explicitly defers tenant/deny-list
+filtering to it).
+
+## Context
+
+Every other M2M action operates on "a client belonging to this tenant."
+`M2M-A13` requires a malformed client ID be rejected before any lookup;
+`M2M-A14` requires a client outside this tenant's namespace, or one on a
+reserved deny-list, be rejected as "not found" — never exposed. Unlike
+Secrets, which gates per-environment because the environment arrives on the
+URL, M2M has no environment: `TENANT_NAMESPACE` is fixed per deployment, so
+the gate here is about the client identifier and the client name, not a
+caller-supplied scope.
+
+Four questions were resolved on the issue thread before implementation
+started, all `needs-decision` before this ticket, all closed by the time
+work began:
+
+1. What suffix set does `M2M_DENY_SUFFIXES` default to — the wiki's config
+   reference named "a standard set of reserved suffixes" but enumerated it
+   nowhere.
+2. How tight should `Nucleus.M2M.ClientId`'s allowlist be — the ticket body's
+   own plan considered three widths and left the choice open.
+3. Is tenancy the `{tenant}-` prefix or the longer `{tenant}-control-plane-`
+   prefix — the shorter one is not collision-safe in a Cognito pool shared
+   across tenants.
+4. Is the deny-list enforced only at the list/detail gate, or at creation
+   too — EN-10's removal of `M2M-A09` (no client-name-uniqueness check)
+   means nothing else in the system would catch a reserved name at creation
+   time.
+
+## Decision
+
+### The `M2M_DENY_SUFFIXES` default is the prototype's Terraform value
+
+`-labops-ui,-faas-api,-faas-ui,-device_grant,-orange,-nucleus` — hardcoded
+into `config/dev.exs` and `config/test.exs`, on the `TENANT_NAMESPACE =
+"local"` precedent, so a fresh clone boots with the deny-list exercised
+against real values rather than a placeholder. `M2M_DENY_SUFFIXES` moves from
+Optional to Required in `Platform-Operations.md`'s config reference, with the
+fail-closed and `none`-sentinel behaviour spelled out.
+
+`Nucleus.M2M.DenyList.parse/1` is pure: `nil`, `""`, whitespace-only, or a
+value that splits to nothing (`","`, `",,"`) all produce `:unset`.
+`suffixes/0` then returns `{:error, %Error{kind: :not_configured}}` — an
+absent value is far more likely to be a Terraform template rendering nothing
+than a deliberate "allow everything" choice, and a silently empty deny-list
+is exactly the failure `M2M-A14` exists to prevent. The literal value
+`"none"` (case-insensitive) is the one way to say "deny nothing" on purpose.
+Matching is case-insensitive — Nucleus-built names are lowercase by
+construction, but a Terraform- or console-created name may not be, and the
+fail-safe direction for a deny-list is to match more, not less.
+
+### `Nucleus.M2M.ClientId` uses AWS's own pattern, not a tighter one
+
+`~r/\A[A-Za-z0-9_+]{1,128}\z/`, anchored — AWS's documented `ClientId` shape
+(`[\w+]+`, 1–128 characters), not the tighter `[a-z0-9]{1,128}` the ticket's
+plan leaned toward, and not the exact `[a-z0-9]{26}` shape of every ID
+observed against this pool so far. A well-formed-but-nonexistent ID already
+returns `:not_found` from one `describe_client/1` call; guessing the pattern
+too tight risks every real client 400ing until a deploy, for a security
+property (rejecting hostile shapes) the wider pattern gives up nothing on —
+`..`, `/`, `\`, null bytes, whitespace, unicode lookalikes, and
+percent-encoding are all still rejected by construction, since none of those
+characters are in `[A-Za-z0-9_+]`.
+
+### Tenancy is the full `{tenant}-control-plane-` prefix, not `{tenant}-`
+
+The Cognito pool is shared across tenants today (one Nucleus instance per
+tenant, but one pool, per the infra plan). The shorter prefix is not
+collision-safe: tenant `acme` would match `acme-corp-nomad`, reading and
+offering secret rotation on another tenant's client — the exact defect
+`M2M-A14` exists to prevent. `{tenant}-control-plane-` does not have this
+problem: `acme-corp-control-plane-X` does not start with
+`acme-control-plane-`. Making the shorter prefix safe would require this
+deployment to enumerate sibling tenant namespaces, which it has no access to
+— `TENANT_NAMESPACE` is its own, singular, per `Platform-Operations.md`.
+
+`M2M-A01`'s wiki wording is amended: "belonging to this tenant" now means
+following the full naming convention, not merely starting with the tenant's
+short name. A consequence, deliberate: under this prefix, `Nucleus.M2M.DenyList`
+is narrower than `M2M-A14`'s prose implies — it can only ever catch a
+reserved name that *also* follows the control-plane convention. Five of the
+six configured suffixes (`-nucleus`, `-orange`, `-faas-api`, `-faas-ui`,
+`-labops-ui`) are reachable as an M2M `purpose` and matter for the creation
+guard below; `-device_grant` contains an underscore, which
+`Nucleus.M2M.Purpose`'s `[a-z0-9-]+` charset can never produce, so it matters
+only for the list/detail gate.
+
+If/when the infrastructure moves to one pool per tenant, this prefix check
+becomes redundant but stays harmless — removing it would *widen* the list to
+every client in that tenant's own pool, a requirement change, not a cleanup.
+
+### The deny-list is enforced at creation too — new wiki action `M2M-A18`
+
+Without this, an operator can pick purpose `nucleus` (a reserved suffix) and
+create `{tenant}-control-plane-{ticket}-nucleus`. EN-10's removal of
+`M2M-A09` means there is now no creation-time collision check of any kind to
+catch this incidentally — the client would be created with a real secret,
+then be invisible in the list and 404 on rotation via this same gate: the
+same "created but unreachable" failure `visible?/1` prevents on the read
+path, arriving instead through the write path, and worse, since a live
+secret would have no recovery route. `Nucleus.M2M.DenyList.denied?/1` is the
+predicate this needs, callable directly against `Nucleus.M2M.ClientName.build/2`'s
+output before `create_client/2` ever runs. This ticket owns the predicate and
+its own reserved-purpose test; #38 (M2M-S5) owns the form-facing 422
+rejection and claims `M2M-A18` itself.
+
+### `fetch/2`'s ordering, and the structurally-identical `:not_found` collapse
+
+`Nucleus.M2M.fetch/2` mirrors `Nucleus.Environments.fetch/2`'s ladder:
+validate the client ID (zero adapter calls on failure — the load-bearing
+test of this ticket, proven with a raising module swapped into the `:m2m`
+boundary rather than `LOCAL_FORCE_ERROR`, which is node-global and would be
+intercepted by whichever boundary runs first), then check the deny-list
+config is readable at all (fail closed, no adapter call on that branch
+either), then call `Clients.describe_client/1`, then check `visible?/1`
+(tenancy and deny-list together) on the result.
+
+`M2M-A14` requires an out-of-tenant or deny-listed client be "never exposed
+here" — step 4's failure manufactures `{:error, %Error{kind: :not_found,
+boundary: :m2m, message: "no such client", details: %{client_id:
+client_id}}}`, byte-for-byte the same shape `Nucleus.M2M.Clients.Local`
+itself returns for a client that genuinely does not exist. A distinct kind
+or a distinguishing detail key would itself confirm to the caller that the
+ID exists, which is exactly the information the requirement withholds.
+
+### `visible?/1` is the one shared predicate
+
+Used by this module's own step 4 and reserved for M2M-S2's list filter, so a
+future list-view fix cannot drift from this gate and leave a client invisible
+in the list but still rotatable by URL.
+
+### `ClientId.validate/1` returns `Error.t()` directly, not a bare atom
+
+The ticket's own plan text typed `Nucleus.M2M.ClientId.validate/1` as
+`:ok | {:error, atom()}`, matching `TicketId`/`Purpose`. Implemented instead
+to return `:ok | {:error, Nucleus.Backend.Error.t()}`, matching
+`Nucleus.Environments.validate_name/1`'s precedent. The two form validators
+(`TicketId`, `Purpose`) have no boundary concept — they validate a form
+field before `ClientName.build/2` ever runs, and M2M-S4's form needs a plain
+reason atom to map to per-field copy. `ClientId` exists specifically to gate
+the `:m2m` adapter boundary before `fetch/2` calls it, and has exactly one
+failure mode (does not match the pattern) rather than several distinct
+reasons a form would need to distinguish — returning the same `Error.t()`
+shape `fetch/2` needs anyway avoids `fetch/2` having to construct one from a
+bare atom on the way out.
+
+## Consequences
+
+### Positive
+
+- `Nucleus.M2M.fetch/2` is the one gate every M2M action mounts through, and
+  its zero-adapter-call guarantee is checked structurally (a raising fake),
+  not inferred from behaviour — matching ADR-0009's precedent exactly.
+- `Nucleus.M2M.DenyList.denied?/1` is safe to call standalone, ahead of
+  `Clients.create_client/2`, for M2M-S5's `M2M-A18` rejection — no second
+  copy of deny-list logic needs to exist for the write path.
+- Seed fixtures (`priv/backends/local_seed.json`) now isolate the prefix
+  branch and the deny-list branch of `fetch/2` step 4 individually — a
+  conforming-but-denied name and a non-conforming-but-not-denied name each
+  exist as their own fixture, so a bug in either branch cannot hide behind
+  the other always agreeing.
+
+### Negative
+
+- `Nucleus.M2M.DenyList.denied?/1`'s fail-closed default (`true` when
+  `suffixes/0` itself is unconfigured) is currently unreachable from
+  `fetch/2`, which always checks `suffixes/0` directly first and returns
+  before `visible?/1` is ever called on that branch. It exists only for
+  #38's standalone creation-time call, which has no equivalent earlier
+  check of its own — a reader tracing `fetch/2` alone would not discover
+  why this branch exists.
+- The M2M pool's shared-across-tenants shape (Decision 8's premise) is
+  itself a limitation this ADR narrows around rather than removes; moving to
+  one pool per tenant later makes the prefix check redundant, not wrong, and
+  that follow-up is not tracked as an open question here since it depends on
+  an infrastructure change outside this ticket's scope.
+
+## Alternatives considered
+
+**A three-character denylist or a tighter, length-exact `ClientId` pattern.**
+Rejected for the same reason ADR-0009 rejected a three-sequence denylist for
+environment names: an allowlist is strictly the stronger check, and a
+length-exact pattern risks a total feature outage on any AWS-side variation
+this deployment has not yet observed, for no security benefit over the
+wider pattern.
+
+**The shorter `{tenant}-` tenancy prefix.** Rejected — not collision-safe in
+a pool shared across tenants; see Decision 8 above.
+
+**Deferring the creation-time deny-list check to whenever #38 happens to
+write it, with no shared predicate.** Rejected — `M2M-A09`'s removal (EN-10)
+means no other check exists to catch a reserved-purpose creation
+incidentally, and a second, independently-written deny-list check in #38
+risks drifting from this one exactly the way `visible?/1` exists to prevent
+for the read path.
+
+## References
+
+- M2M-S1 (issue #34) — the deciding issue, including
+  [Decision 2](https://github.com/dave-bell/nucleus/issues/34#issuecomment-5350433802) (deny-list defaults),
+  [Decision 5](https://github.com/dave-bell/nucleus/issues/34#issuecomment-5350434771) (client ID pattern),
+  Decision 8 (tenancy prefix), and Decision 9 (`M2M-A18`)
+- `docs/adr/0009-environment-validation-ladder.md` — `SEC-S1`'s equivalent
+  gate, and the structure this ADR reuses
+- `docs/adr/0016-m2m-client-adapter.md` — EN-10's `Nucleus.M2M.Clients`
+  boundary, which explicitly defers tenant/deny-list filtering to this gate
+- `.opencode/context/project-intelligence/living-notes.md` — the
+  `LOCAL_FORCE_ERROR` node-global gotcha this ticket's zero-adapter-call test
+  works around the same way `SecretsLiveTest.FailingSecretsStore` does
+- Wiki [M2M-Clients](https://github.com/dave-bell/nucleus/wiki/M2M-Clients)
+  `M2M-A13`, `M2M-A14`, `M2M-A18`, the API-contract naming convention, and
+  the error/edge-case matrix
+</content>

--- a/lib/nucleus/m2m.ex
+++ b/lib/nucleus/m2m.ex
@@ -1,0 +1,116 @@
+defmodule Nucleus.M2M do
+  @moduledoc """
+  The fail-closed resolution gate every M2M client action mounts through
+  (`M2M-A13`, `M2M-A14`) — the same structure `Nucleus.Environments.fetch/2`
+  gives `SEC-S1`, one boundary over.
+
+  `NucleusWeb.M2MClientsLive` talks to this module, never to
+  `Nucleus.M2M.Clients` directly, so the gate cannot be bypassed — the same
+  rule `Nucleus.Secrets` states about `Nucleus.Secrets.Store`.
+
+  ## Note the asymmetry with Secrets
+
+  Secrets has a per-environment gate because the environment comes from the
+  URL. M2M has no environment: the tenant is fixed per deployment
+  (`TENANT_NAMESPACE`, one Nucleus instance per tenant, no runtime
+  switching), so this gate is about the *client identifier* and the *client
+  name*, not about a caller-supplied scope. `scope` is still accepted by
+  `fetch/2`, matching every other context function's call-site shape, but no
+  field of it is read here — tenancy comes from
+  `Nucleus.M2M.ClientName.prefix/0` (deployment config), and this function
+  emits no audit event (see below), so there is nothing here that needs the
+  caller's identity or token.
+
+  ## Strict ordering — the substance of both actions
+
+  1. `Nucleus.M2M.ClientId.validate/1` — on error, returns
+     `{:error, %Error{kind: :invalid}}` immediately. **No adapter call**
+     (`M2M-A13`) — asserted structurally in `test/nucleus/m2m_test.exs` via a
+     counting/raising module swapped in for the `:m2m` boundary, not merely
+     inferred from behaviour. `Nucleus.Backend.Faults`' `LOCAL_FORCE_ERROR` is
+     node-global (see `living-notes.md`) and cannot isolate this boundary's
+     fault from any other, so that test does not use it.
+  2. `Nucleus.M2M.DenyList.suffixes/0` — on `:not_configured`, returns it
+     unchanged (fail closed, Decision 2). No adapter call on this branch
+     either — an unreadable deny-list must not spend a request before
+     failing.
+  3. `Nucleus.M2M.Clients.describe_client/1` — any error
+     (`:not_found`, `:auth_expired`, `:unavailable`, ...) passes through
+     unchanged; this module manufactures none of its own error kinds here.
+  4. `visible?/1` on the result — `false` collapses to `{:error, %Error{kind:
+     :not_found}}`, **structurally identical** to the error
+     `Nucleus.M2M.Clients.describe_client/1` itself returns for a genuinely
+     nonexistent client (same message, same details shape). `M2M-A14`
+     requires a deny-listed or out-of-tenant client be "never exposed here" —
+     a distinct error kind or a distinguishing detail would itself confirm
+     to the caller that the ID exists, which is exactly the information the
+     requirement withholds.
+
+  ## `visible?/1` is the one shared predicate
+
+  Used by both this module's own step 4 and M2M-S2's list filter, so a
+  future list-view fix cannot drift from this gate and leave a client
+  invisible in the list but still rotatable by URL — the two-copies failure
+  mode this predicate exists to prevent. `Nucleus.M2M.DenyList.denied?/1`
+  also backs the creation-time guard (`M2M-A18`, #38) directly, since a
+  not-yet-created client has no `Client.t()`/`ClientDetail.t()` for
+  `visible?/1` to take.
+
+  ## No audit event
+
+  The wiki's audit table has three M2M events and none of them is a lookup
+  or a rejection. `m2m_client_viewed` belongs to M2M-S3, on the detail view,
+  not here — this function is also called by the rotation path, and
+  emitting here would log a spurious "viewed" on every rotation.
+  """
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.Client
+  alias Nucleus.M2M.ClientDetail
+  alias Nucleus.M2M.ClientId
+  alias Nucleus.M2M.ClientName
+  alias Nucleus.M2M.Clients
+  alias Nucleus.M2M.DenyList
+  alias Nucleus.Scope
+
+  @boundary :m2m
+
+  @doc """
+  Validates, resolves, and gates `client_id` to this tenant's client detail.
+
+  Strict order — see the module doc. `scope` is accepted for call-site
+  symmetry with every other context function but is not read by this
+  function; see the module doc for why.
+  """
+  @spec fetch(client_id :: term(), scope :: Scope.t()) ::
+          {:ok, ClientDetail.t()} | {:error, Error.t()}
+  def fetch(client_id, %Scope{} = _scope) do
+    with :ok <- ClientId.validate(client_id),
+         {:ok, _suffixes} <- DenyList.suffixes(),
+         {:ok, detail} <- Clients.describe_client(client_id) do
+      if visible?(detail) do
+        {:ok, detail}
+      else
+        not_found(client_id)
+      end
+    end
+  end
+
+  @doc """
+  Whether `client` belongs to this tenant and is not on the reserved
+  deny-list — the shared predicate behind this module's `fetch/2` (step 4)
+  and M2M-S2's list filter.
+
+  Accepts either a `Nucleus.M2M.Client.t()` (the list row) or a
+  `Nucleus.M2M.ClientDetail.t()` (this module's own resolved struct) — both
+  carry a `client_name`, the only field this check needs.
+  """
+  @spec visible?(Client.t() | ClientDetail.t()) :: boolean()
+  def visible?(%{client_name: client_name}) when is_binary(client_name) do
+    ClientName.in_tenant?(client_name) and not DenyList.denied?(client_name)
+  end
+
+  defp not_found(client_id) do
+    {:error, Error.new(:not_found, @boundary, "no such client", %{client_id: client_id})}
+  end
+end

--- a/lib/nucleus/m2m/client_id.ex
+++ b/lib/nucleus/m2m/client_id.ex
@@ -1,0 +1,76 @@
+defmodule Nucleus.M2M.ClientId do
+  @moduledoc """
+  Shape validation for a Cognito App Client's `client_id` — the identifier
+  `M2M-A13` requires be rejected, before any lookup, when malformed.
+
+  Pure, allowlist-based, matching `Nucleus.Environments.validate_name/1`'s
+  reasoning (`SEC-S1`'s equivalent gate): a positive charset check rejects
+  path traversal, injection, and hostile encodings by construction, rather
+  than trying to enumerate what to reject.
+
+  ## AWS's own pattern, not a tighter one — M2M-S1 Decision 5
+
+  The pattern is `~r/\\A[A-Za-z0-9_+]{1,128}\\z/`, anchored — AWS's own
+  documented `ClientId` shape (`[\\w+]+`, 1–128 characters), **not** the
+  tighter `~r/\\A[a-z0-9]{1,128}\\z/` or the exact
+  `~r/\\A[a-z0-9]{26}\\z/` this ticket's body originally considered. Real
+  Cognito client IDs observed so far are 26 lowercase alphanumerics, but
+  that is an observation of one pool, not a contract AWS documents anywhere.
+  Widening to uppercase, `_`, and `+` costs nothing: a well-formed-but-
+  nonexistent ID already returns `:not_found` from one `describe_client/1`
+  call, while guessing the format too tight risks a total feature outage —
+  every existing client 400s — until a deploy. See
+  [Decision 5](https://github.com/dave-bell/nucleus/issues/34#issuecomment-5350434771).
+
+  This is still an anchored allowlist: `..`, `/`, `\\`, null bytes,
+  whitespace, unicode lookalikes, and percent-encoding are all rejected by
+  construction, since none of those characters are in `[A-Za-z0-9_+]`.
+  """
+
+  alias Nucleus.Backend.Error
+
+  @boundary :m2m
+  @max_length 128
+  @pattern ~r/\A[A-Za-z0-9_+]{1,#{@max_length}}\z/
+
+  @doc """
+  The maximum number of characters a client ID may contain.
+  """
+  @spec max_length() :: pos_integer()
+  def max_length, do: @max_length
+
+  @doc """
+  Validates `client_id`'s shape against AWS's own `ClientId` pattern.
+
+  Pure — performs no I/O and calls no adapter. Returns `:ok` or
+  `{:error, %Nucleus.Backend.Error{kind: :invalid}}`. Accepts `term()`, not
+  just `String.t()` — a client ID arriving from a URL path segment has not
+  been shown to be a string yet.
+
+      iex> Nucleus.M2M.ClientId.validate("4f2a9c1e7b3d8f0a1c2e3f4a5b6c7d8e")
+      :ok
+
+      iex> {:error, error} = Nucleus.M2M.ClientId.validate("../etc")
+      iex> error.kind
+      :invalid
+
+      iex> {:error, error} = Nucleus.M2M.ClientId.validate(nil)
+      iex> error.kind
+      :invalid
+  """
+  @spec validate(term()) :: :ok | {:error, Error.t()}
+  def validate(client_id) when is_binary(client_id) do
+    if Regex.match?(@pattern, client_id) do
+      :ok
+    else
+      invalid(client_id)
+    end
+  end
+
+  def validate(client_id), do: invalid(client_id)
+
+  defp invalid(client_id) do
+    {:error,
+     Error.new(:invalid, @boundary, "invalid client ID", %{client_id: inspect(client_id)})}
+  end
+end

--- a/lib/nucleus/m2m/client_name.ex
+++ b/lib/nucleus/m2m/client_name.ex
@@ -1,0 +1,84 @@
+defmodule Nucleus.M2M.ClientName do
+  @moduledoc """
+  The one place an M2M client name is built and recognised.
+
+  `{tenant}-control-plane-{ticket_id}-{purpose}` — `Platform-Operations.md`
+  confirms `TENANT_NAMESPACE` is "used for Nomad/M2M naming and audit
+  records," so `Nucleus.Scope.tenant_namespace/0` is the right source here,
+  not a new configuration surface.
+
+  ## This module assumes pre-validated input
+
+  `build/2` does not validate `ticket_id` or `purpose` — see
+  `Nucleus.M2M.TicketId` and `Nucleus.M2M.Purpose` for that, enforced
+  *before* this is called (the same note `Nucleus.Secrets.Path`'s moduledoc
+  carries, so nothing mistakes this for a sanitiser). It concatenates its
+  arguments verbatim.
+
+  ## Every construction site goes through here
+
+  Nothing outside this module builds an M2M client name by hand —
+  `rg 'ClientName.build'` finding every call site is the point. The gate
+  (`Nucleus.M2M.fetch/2`) and the eventual list filter (M2M-S2) both need the
+  tenant prefix and must not construct it independently, so it is exposed as
+  `prefix/0` rather than inlined wherever `in_tenant?/1` is checked.
+
+  ## Tenancy is the full prefix, not `{tenant}-` — M2M-S1 Decision 8
+
+  The Cognito user pool is shared across tenants today (one Nucleus instance
+  per tenant, but one pool). The shorter `{tenant}-` prefix is not
+  collision-safe in a shared pool: tenant `acme` would match
+  `acme-corp-nomad`, reading and offering secret rotation on another
+  tenant's client — the exact defect `M2M-A14` exists to prevent.
+  `{tenant}-control-plane-` does not have this problem:
+  `acme-corp-control-plane-X` does not start with `acme-control-plane-`. See
+  [Decision 8](https://github.com/dave-bell/nucleus/issues/34#issuecomment-5350436093).
+  """
+
+  @doc """
+  Builds the client name for `ticket_id`/`purpose`, tenant read at call time.
+
+  Assumes both arguments are already validated (see the module doc).
+
+      iex> Application.put_env(:nucleus, Nucleus.Scope, tenant_namespace: "acme")
+      iex> Nucleus.M2M.ClientName.build("OPS-1234", "nightly-sync")
+      "acme-control-plane-OPS-1234-nightly-sync"
+  """
+  @spec build(ticket_id :: String.t(), purpose :: String.t()) :: String.t()
+  def build(ticket_id, purpose) when is_binary(ticket_id) and is_binary(purpose) do
+    prefix() <> ticket_id <> "-" <> purpose
+  end
+
+  @doc """
+  The tenant prefix every M2M client name built by this module carries,
+  read at call time — `"{tenant}-control-plane-"`.
+
+      iex> Application.put_env(:nucleus, Nucleus.Scope, tenant_namespace: "acme")
+      iex> Nucleus.M2M.ClientName.prefix()
+      "acme-control-plane-"
+  """
+  @spec prefix() :: String.t()
+  def prefix, do: Nucleus.Scope.tenant_namespace() <> "-control-plane-"
+
+  @doc """
+  Whether `client_name` belongs to this tenant — a `String.starts_with?/2`
+  check against `prefix/0`, not a substring check, so
+  `"x-{tenant}-control-plane-..."` (the prefix appearing later in the
+  string) is correctly `false`.
+
+      iex> Application.put_env(:nucleus, Nucleus.Scope, tenant_namespace: "acme")
+      iex> Nucleus.M2M.ClientName.in_tenant?("acme-control-plane-OPS-1-x")
+      true
+
+      iex> Application.put_env(:nucleus, Nucleus.Scope, tenant_namespace: "acme")
+      iex> Nucleus.M2M.ClientName.in_tenant?("other-tenant-control-plane-OPS-1-x")
+      false
+
+      iex> Nucleus.M2M.ClientName.in_tenant?("")
+      false
+  """
+  @spec in_tenant?(client_name :: String.t()) :: boolean()
+  def in_tenant?(client_name) when is_binary(client_name) do
+    String.starts_with?(client_name, prefix())
+  end
+end

--- a/lib/nucleus/m2m/deny_list.ex
+++ b/lib/nucleus/m2m/deny_list.ex
@@ -1,0 +1,183 @@
+defmodule Nucleus.M2M.DenyList do
+  @moduledoc """
+  The reserved-suffix deny-list `M2M-A01`, `M2M-A14`, and `M2M-A18` all share
+  — clients whose name ends with a configured suffix are reserved for
+  internal system use and are never listed, resolved, or creatable through
+  this feature.
+
+  Per [Decision 2](https://github.com/dave-bell/nucleus/issues/34#issuecomment-5350433802).
+
+  ## `parse/1` is pure, `suffixes/0` reads config at call time
+
+  `parse/1` turns a raw `M2M_DENY_SUFFIXES` string (or `nil`) into either
+  `{:ok, [String.t()]}` or `:unset`, with no I/O. `suffixes/0` is the
+  call-time read — `config/runtime.exs` calls `parse/1` once at boot and
+  only sets the app-env key on `{:ok, _}`, so an absent key is this module's
+  own `:not_configured` signal, matching `Nucleus.Secrets.Path`'s and
+  ADR-0009's fail-closed precedent. Reading at call time, not compile time,
+  means both `config/runtime.exs` and a test's `Application.put_env/3`
+  override take effect — the same pattern `Nucleus.Backend.impl_for/1` uses.
+
+  ## Unset or blank fails closed; `none` is the explicit opt-out
+
+  `nil`, `""`, whitespace-only, or a value that splits to nothing (`","`,
+  `",,"`) all parse to `:unset` — `suffixes/0` then returns
+  `{:error, %Error{kind: :not_configured}}` rather than silently treating an
+  unset deny-list as an empty one. `M2M_DENY_SUFFIXES=""` is far more likely
+  to be a Terraform template rendering nothing than a deliberate choice, and
+  a silently empty deny-list is exactly the widening failure this module
+  exists to prevent. The literal value `"none"` (case-insensitive) is the
+  one way to say "deny nothing" on purpose.
+
+  ## No regex built from configuration
+
+  `denied?/1` downcases both the configured suffix and the client name, then
+  checks with `String.ends_with?/2` — literal suffix matching, never a
+  regex compiled from an operator-supplied string. An operator-supplied
+  suffix containing regex metacharacters (`"-a.b"`) would either crash a
+  regex-based check or match far more than intended; a literal check treats
+  every character literally by construction.
+
+  ## Under Decision 8, this is a reserved-*purpose* list, not a general
+  reserved-name list
+
+  With `Nucleus.M2M.ClientName`'s full `{tenant}-control-plane-` prefix
+  (Decision 8), this list can only ever catch a reserved name that *also*
+  follows the control-plane naming convention — it no longer needs to guard
+  against arbitrary platform-internal client names, since the prefix check
+  already excludes those. Five of the six configured suffixes
+  (`-nucleus`, `-orange`, `-faas-api`, `-faas-ui`, `-labops-ui`) are reachable
+  as an M2M `purpose` and matter for the creation guard (`M2M-A18`,
+  Decision 9); `-device_grant` contains an underscore, which
+  `Nucleus.M2M.Purpose`'s `[a-z0-9-]+` charset can never produce — it can
+  only ever match a name Nucleus did not build, so it matters only for the
+  list/detail gate, never for creation.
+  """
+
+  alias Nucleus.Backend.Error
+
+  @boundary :m2m
+  @none_sentinel "none"
+
+  @doc """
+  Parses a raw `M2M_DENY_SUFFIXES` value.
+
+  Pure — no I/O, no config read. `nil`, `""`, whitespace-only, or a value
+  that splits to nothing all return `:unset`. The literal value `"none"`
+  (case-insensitive) returns `{:ok, []}` — an explicit, deliberate empty
+  deny-list. Otherwise: split on `,`, trim each entry, drop empties,
+  downcase, and return `{:ok, [String.t()]}`.
+
+      iex> Nucleus.M2M.DenyList.parse(nil)
+      :unset
+
+      iex> Nucleus.M2M.DenyList.parse("")
+      :unset
+
+      iex> Nucleus.M2M.DenyList.parse(",,")
+      :unset
+
+      iex> Nucleus.M2M.DenyList.parse("none")
+      {:ok, []}
+
+      iex> Nucleus.M2M.DenyList.parse("NONE")
+      {:ok, []}
+
+      iex> Nucleus.M2M.DenyList.parse("-orange,-nucleus")
+      {:ok, ["-orange", "-nucleus"]}
+
+      iex> Nucleus.M2M.DenyList.parse(" -orange , -NUCLEUS ")
+      {:ok, ["-orange", "-nucleus"]}
+  """
+  @spec parse(String.t() | nil) :: {:ok, [String.t()]} | :unset
+  def parse(nil), do: :unset
+
+  def parse(value) when is_binary(value) do
+    trimmed = String.trim(value)
+
+    cond do
+      trimmed == "" ->
+        :unset
+
+      String.downcase(trimmed) == @none_sentinel ->
+        {:ok, []}
+
+      true ->
+        suffixes =
+          value
+          |> String.split(",")
+          |> Enum.map(&String.trim/1)
+          |> Enum.reject(&(&1 == ""))
+          |> Enum.map(&String.downcase/1)
+
+        if suffixes == [], do: :unset, else: {:ok, suffixes}
+    end
+  end
+
+  @doc """
+  The configured deny-list, read from `Application.get_env/3` at call time.
+
+  `{:error, %Nucleus.Backend.Error{kind: :not_configured}}` when
+  `config/runtime.exs` never called `parse/1` successfully — i.e. when
+  `M2M_DENY_SUFFIXES` is unset or blank in this environment. Never falls
+  back to an empty list on its own; that fallback would silently widen
+  `M2M-A01`/`M2M-A14` from "reserved clients are hidden" to "reserved
+  clients are shown," exactly the failure Decision 2 exists to prevent.
+  """
+  @spec suffixes() :: {:ok, [String.t()]} | {:error, Error.t()}
+  def suffixes do
+    case Application.get_env(:nucleus, __MODULE__, []) |> Keyword.get(:suffixes) do
+      list when is_list(list) ->
+        {:ok, list}
+
+      _absent ->
+        {:error,
+         Error.new(:not_configured, @boundary, "M2M_DENY_SUFFIXES is not configured", %{})}
+    end
+  end
+
+  @doc """
+  Whether `client_name` ends with a configured reserved suffix.
+
+  Case-insensitive: downcases both the configured suffix and `client_name`
+  before `String.ends_with?/2`, so a Terraform- or console-created name that
+  is not lowercase by construction (unlike every Nucleus-built name) is
+  still caught — the fail-safe direction for a deny-list is to match more,
+  not less.
+
+  Fails closed on unconfigured suffixes too: if `suffixes/0` itself returns
+  `:not_configured`, this returns `true` rather than silently treating an
+  unreadable deny-list as an empty one. In practice `Nucleus.M2M.fetch/2`
+  never reaches this branch — it checks `suffixes/0` directly, first, and
+  returns `:not_configured` before ever calling this — but `denied?/1` is
+  also exposed standalone for the creation-time guard (`M2M-A18`, #38),
+  which has no equivalent earlier check of its own.
+
+      iex> Application.put_env(:nucleus, Nucleus.M2M.DenyList, suffixes: ["-nucleus", "-orange"])
+      iex> Nucleus.M2M.DenyList.denied?("local-control-plane-OPS-1042-nucleus")
+      true
+
+      iex> Application.put_env(:nucleus, Nucleus.M2M.DenyList, suffixes: ["-nucleus", "-orange"])
+      iex> Nucleus.M2M.DenyList.denied?("local-control-plane-OPS-1042-NUCLEUS")
+      true
+
+      iex> Application.put_env(:nucleus, Nucleus.M2M.DenyList, suffixes: ["-nucleus"])
+      iex> Nucleus.M2M.DenyList.denied?("local-control-plane-OPS-1042-billing")
+      false
+
+      iex> Application.put_env(:nucleus, Nucleus.M2M.DenyList, suffixes: [])
+      iex> Nucleus.M2M.DenyList.denied?("local-control-plane-OPS-1042-nucleus")
+      false
+  """
+  @spec denied?(client_name :: String.t()) :: boolean()
+  def denied?(client_name) when is_binary(client_name) do
+    case suffixes() do
+      {:ok, suffixes} ->
+        downcased_name = String.downcase(client_name)
+        Enum.any?(suffixes, &String.ends_with?(downcased_name, &1))
+
+      {:error, _not_configured} ->
+        true
+    end
+  end
+end

--- a/lib/nucleus/m2m/purpose.ex
+++ b/lib/nucleus/m2m/purpose.ex
@@ -1,0 +1,70 @@
+defmodule Nucleus.M2M.Purpose do
+  @moduledoc """
+  Shape validation for the purpose half of an M2M client name
+  (`{tenant}-control-plane-{ticket_id}-{purpose}`).
+
+  Pure, matching `Nucleus.M2M.TicketId`'s role and reasoning — see that
+  module's doc for why this is a separate concern from
+  `Nucleus.M2M.ClientId` (the *resulting* client's identifier, not an input
+  to building its name).
+
+  ## Hyphen placement gets its own reasons
+
+  `M2M-A06` calls out leading/trailing hyphen placement separately from the
+  charset rule, and "purpose cannot start with a hyphen" is far more
+  actionable form feedback than "purpose contains invalid characters" — so
+  `:leading_hyphen` and `:trailing_hyphen` are distinct from `:charset`,
+  checked in a fixed order (empty, too long, charset, leading hyphen,
+  trailing hyphen) so a purpose violating more than one rule always reports
+  the same reason, deterministically.
+
+  A double hyphen (`"nightly--sync"`) is accepted — `[a-z0-9-]+` allows it,
+  and the requirement only forbids leading/trailing hyphens, not internal
+  runs of them. Tightening beyond that is a rule this module does not add.
+  """
+
+  @max_length 32
+  @charset ~r/\A[a-z0-9-]+\z/
+
+  @type reason :: :empty | :too_long | :charset | :leading_hyphen | :trailing_hyphen
+
+  @doc """
+  The maximum number of characters a purpose may contain.
+  """
+  @spec max_length() :: pos_integer()
+  def max_length, do: @max_length
+
+  @doc """
+  Validates `purpose`'s shape: lowercase letters, digits, and hyphens only
+  (`[a-z0-9-]+`), no leading or trailing hyphen, at most #{@max_length}
+  characters.
+
+  Accepts `term()`, not just `String.t()` — a purpose arriving from a
+  client-controlled form param has not been shown to be a string yet.
+
+      iex> Nucleus.M2M.Purpose.validate("nightly-sync")
+      :ok
+
+      iex> Nucleus.M2M.Purpose.validate("-sync")
+      {:error, :leading_hyphen}
+
+      iex> Nucleus.M2M.Purpose.validate("Nightly-Sync")
+      {:error, :charset}
+
+      iex> Nucleus.M2M.Purpose.validate(nil)
+      {:error, :empty}
+  """
+  @spec validate(term()) :: :ok | {:error, reason()}
+  def validate(purpose) when is_binary(purpose) do
+    cond do
+      String.trim(purpose) == "" -> {:error, :empty}
+      String.length(purpose) > @max_length -> {:error, :too_long}
+      not Regex.match?(@charset, purpose) -> {:error, :charset}
+      String.starts_with?(purpose, "-") -> {:error, :leading_hyphen}
+      String.ends_with?(purpose, "-") -> {:error, :trailing_hyphen}
+      true -> :ok
+    end
+  end
+
+  def validate(_not_a_binary), do: {:error, :empty}
+end

--- a/lib/nucleus/m2m/ticket_id.ex
+++ b/lib/nucleus/m2m/ticket_id.ex
@@ -1,0 +1,74 @@
+defmodule Nucleus.M2M.TicketId do
+  @moduledoc """
+  Shape validation for the ticket ID half of an M2M client name
+  (`{tenant}-control-plane-{ticket_id}-{purpose}`).
+
+  Pure — no I/O, cannot be skipped by a network fault, and cheap enough to
+  run before anything else, matching `Nucleus.Environments.validate_name/1`'s
+  role in `SEC-S1`'s ladder. `Nucleus.M2M.fetch/2` does not call this module
+  directly (a client ID and a ticket ID are different values — see
+  `Nucleus.M2M.ClientId`), but the M2M-S4 creation form does, before
+  `Nucleus.M2M.ClientName.build/2` ever concatenates one into a name.
+
+  ## Anchored, allowlist, uppercase-only — all deliberate
+
+  The pattern is `[A-Z]+-\\d+`, **anchored** (`\\A...\\z`). Unanchored,
+  `"OPS-1234; DROP"` would match — anchoring is the whole point of the
+  regex, not an incidental detail.
+
+  Case is not normalised. `"ops-1234"` is rejected, not silently upcased —
+  silently accepting and rewriting input the requirement describes as
+  invalid would mean `M2M-A07`'s live preview shows a client name built from
+  a ticket ID the user did not actually type.
+
+  ## Distinct reason atoms, not one generic message
+
+  `M2M-A05` requires the creation form to indicate the *specific* problem, so
+  a single `:invalid` atom cannot carry the difference between "wrong shape"
+  and "too long." Checked in a fixed order — empty, then too long, then
+  format — so an input violating more than one rule always reports the same
+  reason, deterministically.
+  """
+
+  @max_length 20
+  @pattern ~r/\A[A-Z]+-\d+\z/
+
+  @type reason :: :empty | :too_long | :format
+
+  @doc """
+  The maximum number of characters a ticket ID may contain.
+  """
+  @spec max_length() :: pos_integer()
+  def max_length, do: @max_length
+
+  @doc """
+  Validates `ticket_id`'s shape: letters, a hyphen, then digits
+  (`[A-Z]+-\\d+`, anchored), at most #{@max_length} characters.
+
+  Accepts `term()`, not just `String.t()` — a ticket ID arriving from a
+  client-controlled form param has not been shown to be a string yet.
+
+      iex> Nucleus.M2M.TicketId.validate("OPS-1234")
+      :ok
+
+      iex> Nucleus.M2M.TicketId.validate("ops-1234")
+      {:error, :format}
+
+      iex> Nucleus.M2M.TicketId.validate("")
+      {:error, :empty}
+
+      iex> Nucleus.M2M.TicketId.validate(nil)
+      {:error, :empty}
+  """
+  @spec validate(term()) :: :ok | {:error, reason()}
+  def validate(ticket_id) when is_binary(ticket_id) do
+    cond do
+      String.trim(ticket_id) == "" -> {:error, :empty}
+      String.length(ticket_id) > @max_length -> {:error, :too_long}
+      not Regex.match?(@pattern, ticket_id) -> {:error, :format}
+      true -> :ok
+    end
+  end
+
+  def validate(_not_a_binary), do: {:error, :empty}
+end

--- a/priv/backends/local_seed.json
+++ b/priv/backends/local_seed.json
@@ -142,6 +142,42 @@
           "created_date": "2026-03-11T11:00:00Z"
         }
       ]
+    },
+    "5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e": {
+      "client_name": "local-control-plane-OPS-1042-nucleus",
+      "scope": "local/api",
+      "token_validity_seconds": 900,
+      "created_date": "2026-08-01T10:00:00Z",
+      "secrets": [
+        {
+          "value": "b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e",
+          "created_date": "2026-08-01T10:00:00Z"
+        }
+      ]
+    },
+    "6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f": {
+      "client_name": "acme-control-plane-OPS-1043-sync",
+      "scope": "acme/api",
+      "token_validity_seconds": 900,
+      "created_date": "2026-08-02T10:00:00Z",
+      "secrets": [
+        {
+          "value": "c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f",
+          "created_date": "2026-08-02T10:00:00Z"
+        }
+      ]
+    },
+    "7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a": {
+      "client_name": "local-labops-ui",
+      "scope": "local/api",
+      "token_validity_seconds": 3600,
+      "created_date": "2026-01-15T08:00:00Z",
+      "secrets": [
+        {
+          "value": "d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a",
+          "created_date": "2026-01-15T08:00:00Z"
+        }
+      ]
     }
   }
 }

--- a/test/nucleus/m2m/client_id_test.exs
+++ b/test/nucleus/m2m/client_id_test.exs
@@ -1,0 +1,58 @@
+defmodule Nucleus.M2M.ClientIdTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.ClientId
+
+  describe "validate/1 — M2M-A13 shape (AWS's own pattern, Decision 5)" do
+    @tag :unit
+    test "accepts a real-shaped 26-character lowercase ID" do
+      assert ClientId.validate(String.duplicate("a", 26)) == :ok
+    end
+
+    @tag :unit
+    test "accepts uppercase — superseded by Decision 5" do
+      assert ClientId.validate("ABCDEF") == :ok
+    end
+
+    @tag :unit
+    test "accepts underscore and plus — AWS's own [\\w+]+ pattern" do
+      assert ClientId.validate("abc_def") == :ok
+      assert ClientId.validate("abc+def") == :ok
+    end
+
+    @tag :unit
+    test "rejects empty, nil, and non-binary input" do
+      for input <- ["", nil, :abc] do
+        assert {:error, %Error{kind: :invalid}} = ClientId.validate(input)
+      end
+    end
+
+    @tag :unit
+    test "rejects path traversal, slashes, and hostile shapes" do
+      hostile = [
+        "../etc",
+        "abc/def",
+        "abc\\def",
+        "ab\0c",
+        "abc def",
+        "%2e%2e",
+        "abc\uFF0Fdef"
+      ]
+
+      for client_id <- hostile do
+        assert {:error, %Error{kind: :invalid}} = ClientId.validate(client_id)
+      end
+    end
+
+    @tag :unit
+    test "rejects a 129-character ID" do
+      assert {:error, %Error{kind: :invalid}} = ClientId.validate(String.duplicate("a", 129))
+    end
+
+    @tag :unit
+    test "accepts a 128-character ID exactly" do
+      assert ClientId.validate(String.duplicate("a", 128)) == :ok
+    end
+  end
+end

--- a/test/nucleus/m2m/client_name_test.exs
+++ b/test/nucleus/m2m/client_name_test.exs
@@ -1,0 +1,70 @@
+defmodule Nucleus.M2M.ClientNameTest do
+  # Mutates the node-global Nucleus.Scope tenant_namespace config.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.M2M.ClientName
+
+  setup do
+    original = Application.get_env(:nucleus, Nucleus.Scope, [])
+    on_exit(fn -> Application.put_env(:nucleus, Nucleus.Scope, original) end)
+    :ok
+  end
+
+  defp put_tenant(tenant) do
+    Application.put_env(:nucleus, Nucleus.Scope, tenant_namespace: tenant)
+  end
+
+  describe "build/2" do
+    @tag :unit
+    test "produces {tenant}-control-plane-{ticket_id}-{purpose} for the configured tenant" do
+      put_tenant("acme")
+
+      assert ClientName.build("OPS-1234", "nightly-sync") ==
+               "acme-control-plane-OPS-1234-nightly-sync"
+    end
+
+    @tag :unit
+    test "reads the tenant at call time, not at compile time" do
+      put_tenant("acme")
+      assert ClientName.build("OPS-1", "x") == "acme-control-plane-OPS-1-x"
+
+      put_tenant("other")
+      assert ClientName.build("OPS-1", "x") == "other-control-plane-OPS-1-x"
+    end
+  end
+
+  describe "prefix/0" do
+    @tag :unit
+    test "is {tenant}-control-plane-" do
+      put_tenant("acme")
+      assert ClientName.prefix() == "acme-control-plane-"
+    end
+  end
+
+  describe "in_tenant?/1" do
+    @tag :unit
+    test "true for a name built by build/2" do
+      put_tenant("acme")
+      name = ClientName.build("OPS-1234", "nightly-sync")
+      assert ClientName.in_tenant?(name)
+    end
+
+    @tag :unit
+    test "false for another tenant's name" do
+      put_tenant("acme")
+      refute ClientName.in_tenant?("other-tenant-control-plane-OPS-1-x")
+    end
+
+    @tag :unit
+    test "false for an empty string" do
+      put_tenant("acme")
+      refute ClientName.in_tenant?("")
+    end
+
+    @tag :unit
+    test "is not fooled by the prefix appearing later in the string" do
+      put_tenant("acme")
+      refute ClientName.in_tenant?("x-acme-control-plane-OPS-1-x")
+    end
+  end
+end

--- a/test/nucleus/m2m/deny_list_test.exs
+++ b/test/nucleus/m2m/deny_list_test.exs
@@ -1,0 +1,118 @@
+defmodule Nucleus.M2M.DenyListTest do
+  # Mutates the node-global Nucleus.M2M.DenyList suffixes config.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.DenyList
+
+  setup do
+    original = Application.get_env(:nucleus, DenyList, [])
+    on_exit(fn -> Application.put_env(:nucleus, DenyList, original) end)
+    :ok
+  end
+
+  defp put_suffixes(suffixes) do
+    Application.put_env(:nucleus, DenyList, suffixes: suffixes)
+  end
+
+  defp unconfigure do
+    Application.put_env(:nucleus, DenyList, [])
+  end
+
+  describe "parse/1 — pure" do
+    @tag :unit
+    test "nil, blank, and all-empty-after-split values are :unset" do
+      for value <- [nil, "", "   ", ",", ",,"] do
+        assert DenyList.parse(value) == :unset
+      end
+    end
+
+    @tag :unit
+    test "the literal sentinel none (case-insensitive) is an explicit empty list" do
+      assert DenyList.parse("none") == {:ok, []}
+      assert DenyList.parse("NONE") == {:ok, []}
+      assert DenyList.parse("None") == {:ok, []}
+    end
+
+    @tag :unit
+    test "the real Terraform value parses to the six-entry trimmed, downcased list" do
+      raw = "-labops-ui,-faas-api,-faas-ui,-device_grant,-orange,-nucleus"
+
+      assert DenyList.parse(raw) ==
+               {:ok,
+                ["-labops-ui", "-faas-api", "-faas-ui", "-device_grant", "-orange", "-nucleus"]}
+    end
+
+    @tag :unit
+    test "entries with stray spaces parse the same as without" do
+      assert DenyList.parse(" -orange , -nucleus ") == {:ok, ["-orange", "-nucleus"]}
+    end
+
+    @tag :unit
+    test "entries are downcased" do
+      assert DenyList.parse("-NUCLEUS,-Orange") == {:ok, ["-nucleus", "-orange"]}
+    end
+  end
+
+  describe "suffixes/0 — call-time config read" do
+    @tag :unit
+    test "returns the configured list" do
+      put_suffixes(["-nucleus", "-orange"])
+      assert DenyList.suffixes() == {:ok, ["-nucleus", "-orange"]}
+    end
+
+    @tag :unit
+    test "unset or blank configuration returns :not_configured" do
+      unconfigure()
+
+      assert {:error, %Error{kind: :not_configured}} = DenyList.suffixes()
+    end
+  end
+
+  describe "denied?/1" do
+    @tag :unit
+    test "configured suffixes match on the end of a name only, never in the middle" do
+      put_suffixes(["-nucleus"])
+
+      refute DenyList.denied?("local-control-plane-OPS-1-nucleus-sync")
+      assert DenyList.denied?("local-control-plane-OPS-1-nucleus")
+    end
+
+    @tag :unit
+    test "matching is case-insensitive" do
+      put_suffixes(["-nucleus"])
+
+      assert DenyList.denied?("local-control-plane-OPS-1-NUCLEUS")
+      assert DenyList.denied?("LOCAL-CONTROL-PLANE-OPS-1-nucleus")
+    end
+
+    @tag :unit
+    test "a suffix containing regex metacharacters is treated literally" do
+      put_suffixes(["-a.b"])
+
+      assert DenyList.denied?("client-a.b")
+      refute DenyList.denied?("client-axb")
+    end
+
+    @tag :unit
+    test "matches a conforming name built from a reserved purpose — the creation-guard case (Decision 9, §9)" do
+      put_suffixes([
+        "-labops-ui",
+        "-faas-api",
+        "-faas-ui",
+        "-device_grant",
+        "-orange",
+        "-nucleus"
+      ])
+
+      assert DenyList.denied?("local-control-plane-OPS-1042-nucleus")
+    end
+
+    @tag :unit
+    test "an explicitly empty list denies nothing" do
+      put_suffixes([])
+
+      refute DenyList.denied?("local-control-plane-OPS-1042-nucleus")
+    end
+  end
+end

--- a/test/nucleus/m2m/purpose_test.exs
+++ b/test/nucleus/m2m/purpose_test.exs
@@ -1,0 +1,56 @@
+defmodule Nucleus.M2M.PurposeTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.M2M.Purpose
+
+  describe "validate/1 — M2M-A06 shape" do
+    @tag :unit
+    test "accepts well-formed purposes" do
+      for purpose <- ["nightly-sync", "a", "sync2", "a-b-c", String.duplicate("a", 32)] do
+        assert Purpose.validate(purpose) == :ok
+      end
+    end
+
+    @tag :unit
+    test "accepts a double hyphen — the requirement only forbids leading/trailing" do
+      assert Purpose.validate("nightly--sync") == :ok
+    end
+
+    @tag :unit
+    test "rejects a purpose one character past the 32-character boundary" do
+      assert Purpose.validate(String.duplicate("a", 33)) == {:error, :too_long}
+    end
+
+    @tag :unit
+    test "rejects empty, whitespace-only, and non-binary input as :empty" do
+      for input <- ["", "   ", nil, :sync] do
+        assert Purpose.validate(input) == {:error, :empty}
+      end
+    end
+
+    @tag :unit
+    test "rejects an invalid charset as :charset" do
+      for purpose <- ["Nightly-Sync", "nightly sync", "nightly_sync"] do
+        assert Purpose.validate(purpose) == {:error, :charset}
+      end
+    end
+
+    @tag :unit
+    test "rejects a leading hyphen as :leading_hyphen" do
+      assert Purpose.validate("-sync") == {:error, :leading_hyphen}
+    end
+
+    @tag :unit
+    test "rejects a trailing hyphen as :trailing_hyphen" do
+      assert Purpose.validate("sync-") == {:error, :trailing_hyphen}
+    end
+
+    @tag :unit
+    test "reports the same reason deterministically for a purpose violating charset and length" do
+      purpose = String.duplicate("A", 33)
+
+      assert Purpose.validate(purpose) == {:error, :too_long}
+      assert Purpose.validate(purpose) == {:error, :too_long}
+    end
+  end
+end

--- a/test/nucleus/m2m/ticket_id_test.exs
+++ b/test/nucleus/m2m/ticket_id_test.exs
@@ -1,0 +1,59 @@
+defmodule Nucleus.M2M.TicketIdTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.M2M.TicketId
+
+  describe "validate/1 — M2M-A05 shape" do
+    @tag :unit
+    test "accepts well-formed ticket IDs" do
+      for ticket_id <- ["OPS-1234", "A-1", "SUPPORT-99999", String.duplicate("A", 17) <> "-1"] do
+        assert TicketId.validate(ticket_id) == :ok
+      end
+    end
+
+    @tag :unit
+    test "accepts a ticket ID exactly at the 20-character boundary" do
+      ticket_id = "OPS-" <> String.duplicate("1", 16)
+      assert String.length(ticket_id) == 20
+      assert TicketId.validate(ticket_id) == :ok
+    end
+
+    @tag :unit
+    test "rejects a ticket ID one character past the 20-character boundary" do
+      ticket_id = "OPS-" <> String.duplicate("1", 17)
+      assert String.length(ticket_id) == 21
+      assert TicketId.validate(ticket_id) == {:error, :too_long}
+    end
+
+    @tag :unit
+    test "rejects empty, whitespace-only, and non-binary input as :empty" do
+      for input <- ["", "   ", nil, :ops] do
+        assert TicketId.validate(input) == {:error, :empty}
+      end
+    end
+
+    @tag :unit
+    test "rejects malformed shapes as :format" do
+      malformed = [
+        "ops-1234",
+        "OPS1234",
+        "OPS-",
+        "-1234",
+        "OPS-12a4",
+        "OPS-1234; DROP",
+        "OPS-1234\n",
+        "OPS-1234-EXTRA"
+      ]
+
+      for ticket_id <- malformed do
+        assert TicketId.validate(ticket_id) == {:error, :format}
+      end
+    end
+
+    @tag :unit
+    test "anchoring rejects trailing junk after a valid shape" do
+      assert TicketId.validate("OPS-1234; DROP") == {:error, :format}
+      assert TicketId.validate("OPS-1234\n") == {:error, :format}
+    end
+  end
+end

--- a/test/nucleus/m2m_test.exs
+++ b/test/nucleus/m2m_test.exs
@@ -1,0 +1,210 @@
+defmodule Nucleus.M2MTest do
+  # Backend swap (`ExplodingM2MClients`, `use_backend/1`) mutates node-global
+  # state (`Nucleus.Backend.Seed`, `:nucleus, :backends`); composed with
+  # `Nucleus.AuditCase` the same way `Nucleus.SecretsTest` does, both pinned
+  # to `async: false` to match `Nucleus.BackendCase`'s constraint.
+  use Nucleus.BackendCase, async: false
+  use Nucleus.AuditCase, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M
+  alias Nucleus.M2M.ClientDetail
+  alias Nucleus.M2M.DenyList
+  alias Nucleus.Scope
+
+  @scope %Scope{tenant: "local", user: %{email: "a@b.com", username: nil}}
+
+  # Seeded in priv/backends/local_seed.json under TENANT_NAMESPACE = "local".
+  @valid_client_id "4f2a9c1e7b3d8f0a1c2e3f4a5b6c7d8e"
+  @denied_client_id "5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e"
+  @out_of_tenant_client_id "6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f"
+  @nonexistent_client_id String.duplicate("f", 32)
+
+  defmodule ExplodingM2MClients do
+    @moduledoc """
+    A `Nucleus.M2M.Clients` implementation that raises if it is ever called —
+    swapped in for the tests that assert `M2M-A13`'s "zero adapter calls"
+    guarantee. `Nucleus.Backend.Faults`' `LOCAL_FORCE_ERROR` is node-global
+    (see `living-notes.md`) and cannot isolate an `:m2m`-boundary fault from
+    any other boundary's local implementation, so this swap — the same
+    technique `Nucleus.EnvironmentsTest.ExplodingTenantApi` and
+    `Nucleus.SecretsTest.ExplodingSecretsStore` use — is the only way to make
+    this guarantee structurally checkable.
+    """
+    @behaviour Nucleus.M2M.Clients
+
+    @impl Nucleus.M2M.Clients
+    def list_clients, do: raise("list_clients/0 was called — zero adapter calls expected")
+
+    @impl Nucleus.M2M.Clients
+    def describe_client(_client_id),
+      do: raise("describe_client/1 was called — zero adapter calls expected")
+
+    @impl Nucleus.M2M.Clients
+    def create_client(_client_name, _settings), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def rotate_secret(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def health_check, do: raise("should not be called")
+  end
+
+  defmodule FailingM2MClients do
+    @moduledoc """
+    A `Nucleus.M2M.Clients` implementation whose `describe_client/1` always
+    returns a controllable `Nucleus.Backend.Error`, for asserting that
+    `Nucleus.M2M.fetch/2` passes a given error kind through unchanged.
+    """
+    @behaviour Nucleus.M2M.Clients
+
+    @impl Nucleus.M2M.Clients
+    def list_clients, do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def describe_client(_client_id) do
+      kind = Application.get_env(:nucleus, __MODULE__, :unavailable)
+      {:error, Error.new(kind, :m2m, "forced for test", %{})}
+    end
+
+    @impl Nucleus.M2M.Clients
+    def create_client(_client_name, _settings), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def rotate_secret(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_backend(module) do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+    Application.put_env(:nucleus, :backends, Keyword.put(original, :m2m, module))
+  end
+
+  defp unconfigure_deny_list do
+    original = Application.get_env(:nucleus, DenyList, [])
+    on_exit(fn -> Application.put_env(:nucleus, DenyList, original) end)
+    Application.put_env(:nucleus, DenyList, [])
+  end
+
+  describe "fetch/2 — M2M-A13 malformed client ID" do
+    @tag action: "M2M-A13"
+    @tag :unit
+    test "every malformed ID returns kind: :invalid" do
+      malformed = [
+        "",
+        nil,
+        :abc,
+        "../etc",
+        "abc/def",
+        "abc\\def",
+        "ab\0c",
+        "abc def",
+        String.duplicate("a", 129),
+        "abc\uFF0Fdef",
+        "%2e%2e"
+      ]
+
+      for client_id <- malformed do
+        assert {:error, %Error{kind: :invalid}} = M2M.fetch(client_id, @scope)
+      end
+    end
+
+    @tag action: "M2M-A13"
+    test "a malformed ID results in zero calls to Clients.describe_client/1" do
+      use_backend(ExplodingM2MClients)
+
+      assert {:error, %Error{kind: :invalid}} = M2M.fetch("../etc", @scope)
+    end
+  end
+
+  describe "fetch/2 — M2M-A14 out-of-tenant and deny-listed clients" do
+    @tag action: "M2M-A14"
+    test "the seeded out-of-tenant fixture returns kind: :not_found" do
+      assert {:error, %Error{kind: :not_found}} = M2M.fetch(@out_of_tenant_client_id, @scope)
+    end
+
+    @tag action: "M2M-A14"
+    test "the seeded deny-listed fixture returns kind: :not_found" do
+      assert {:error, %Error{kind: :not_found}} = M2M.fetch(@denied_client_id, @scope)
+    end
+
+    @tag action: "M2M-A14"
+    test "deny-listed and genuinely nonexistent are structurally identical — never exposed here" do
+      {:error, deny_listed_error} = M2M.fetch(@denied_client_id, @scope)
+      {:error, nonexistent_error} = M2M.fetch(@nonexistent_client_id, @scope)
+
+      assert deny_listed_error.kind == nonexistent_error.kind
+      assert deny_listed_error.message == nonexistent_error.message
+      assert Map.keys(deny_listed_error.details) == Map.keys(nonexistent_error.details)
+    end
+
+    @tag action: "M2M-A14"
+    test "out-of-tenant and genuinely nonexistent are structurally identical — never exposed here" do
+      {:error, out_of_tenant_error} = M2M.fetch(@out_of_tenant_client_id, @scope)
+      {:error, nonexistent_error} = M2M.fetch(@nonexistent_client_id, @scope)
+
+      assert out_of_tenant_error.kind == nonexistent_error.kind
+      assert out_of_tenant_error.message == nonexistent_error.message
+      assert Map.keys(out_of_tenant_error.details) == Map.keys(nonexistent_error.details)
+    end
+  end
+
+  describe "fetch/2 — a valid in-tenant client" do
+    test "resolves to {:ok, %ClientDetail{}}" do
+      assert {:ok, %ClientDetail{} = detail} = M2M.fetch(@valid_client_id, @scope)
+      assert detail.client_id == @valid_client_id
+    end
+
+    test "the resolved struct has no :client_secret key" do
+      assert {:ok, detail} = M2M.fetch(@valid_client_id, @scope)
+      refute Map.has_key?(detail, :client_secret)
+    end
+  end
+
+  describe "fetch/2 — error pass-through" do
+    test ":auth_expired passes through unchanged" do
+      use_backend(FailingM2MClients)
+      Application.put_env(:nucleus, FailingM2MClients, :auth_expired)
+
+      assert {:error, %Error{kind: :auth_expired}} = M2M.fetch(@valid_client_id, @scope)
+    end
+
+    test ":unavailable passes through unchanged" do
+      use_backend(FailingM2MClients)
+      Application.put_env(:nucleus, FailingM2MClients, :unavailable)
+
+      assert {:error, %Error{kind: :unavailable}} = M2M.fetch(@valid_client_id, @scope)
+    end
+  end
+
+  describe "fetch/2 — unconfigured deny-list fails closed" do
+    test "returns :not_configured, with zero adapter calls" do
+      unconfigure_deny_list()
+      use_backend(ExplodingM2MClients)
+
+      assert {:error, %Error{kind: :not_configured}} = M2M.fetch(@valid_client_id, @scope)
+    end
+  end
+
+  describe "fetch/2 — no audit event" do
+    test "emits none of the three m2m_* events" do
+      assert {:ok, _detail} = M2M.fetch(@valid_client_id, @scope)
+      assert {:error, _} = M2M.fetch(@denied_client_id, @scope)
+      assert {:error, _} = M2M.fetch("bad id", @scope)
+
+      assert_no_audit_event(:m2m_client_viewed)
+      assert_no_audit_event(:m2m_client_created)
+      assert_no_audit_event(:m2m_secret_rotated)
+    end
+  end
+
+  describe "visible?/1 — the shared predicate" do
+    test "true for a resolved in-tenant, non-denied client" do
+      assert {:ok, detail} = M2M.fetch(@valid_client_id, @scope)
+      assert M2M.visible?(detail)
+    end
+  end
+end


### PR DESCRIPTION
## What

Every M2M action from M2M-S2 onward needs a single place to resolve a `client_id` to a client belonging to this tenant, without ever confirming the existence of a client that isn't. This PR builds that gate: `Nucleus.M2M.fetch/2`, backed by four pure naming/shape validators (`TicketId`, `Purpose`, `ClientId`, `ClientName`) and a configurable deny-list (`Nucleus.M2M.DenyList`). It implements **M2M-A13** (reject a malformed client ID before any lookup) and **M2M-A14** (an out-of-tenant or deny-listed client is indistinguishable from a nonexistent one) from `docs/requirements/M2M-Clients.md`, and contributes the shared predicate `Nucleus.M2M.DenyList.denied?/1` that **M2M-A18** (owned by #38/M2M-S5) will call at creation time.

## How

- `Nucleus.M2M.fetch/2` enforces a strict order — `ClientId.validate/1` → `DenyList.suffixes/0` → `Clients.describe_client/1` → `visible?/1` (tenancy + deny-list) — with steps 1 and 2 short-circuiting before any adapter call, and step 4 collapsing both "wrong tenant" and "denied" to the same `{:error, %Error{kind: :not_found}}` shape `Clients.describe_client/1` itself returns for a client that genuinely doesn't exist.
- `Nucleus.M2M.ClientName.prefix/0` fixes tenancy as the full `{tenant}-control-plane-` prefix (not the shorter `{tenant}-`), since the Cognito pool is shared across tenants and the short prefix would let `acme` match `acme-corp-nomad`.
- `Nucleus.M2M.DenyList.parse/1` is pure and fail-closed: unset, blank, or all-empty-after-split configuration is `:unset` (→ `:not_configured` from `suffixes/0`); the literal sentinel `"none"` (case-insensitive) is the only way to say "deny nothing." Matching is case-insensitive, literal (no regex built from operator-supplied config).
- `Nucleus.M2M.ClientId.validate/1` allows AWS's own documented `ClientId` shape, `~r/\A[A-Za-z0-9_+]{1,128}\z/`, rather than a tighter lowercase-only or exact-26-char pattern — still an anchored allowlist, so traversal, injection, null bytes, and unicode lookalikes are rejected by construction regardless.
- The zero-adapter-call guarantee for `M2M-A13` is proven structurally: `ExplodingM2MClients`, a `Nucleus.M2M.Clients` implementation that raises on every callback, is swapped into the `:m2m` backend slot for the malformed-ID test, rather than relying on `LOCAL_FORCE_ERROR` (node-global, and would be intercepted by whichever boundary runs first).
- `M2M-A14`'s "never exposed here" is proven with an explicit test asserting the deny-listed and out-of-tenant fixtures each produce a `Nucleus.Backend.Error` with the same `kind`, the same `message`, and the same `details` keys as the genuinely-nonexistent case.
- Seed fixtures added to `priv/backends/local_seed.json`'s `"m2m"` section isolate each branch individually: `local-control-plane-OPS-1042-nucleus` (deny-list branch alone, since `-nucleus` is a configured suffix), `acme-control-plane-OPS-1043-sync` (tenant-prefix branch alone), and `local-labops-ui` (excluded by both, documenting the overlap) — on top of the pre-existing fixtures already covering varied `created_date` and the 3600s/450s token-validity ladder.
- `fetch/2` emits no audit event, asserted explicitly against all three `m2m_*` events — the wiki's audit table has no lookup/rejection event, and `fetch/2` will also be called by the rotation path.

`M2M_DENY_SUFFIXES` moving from Optional to Required in `docs/requirements/Platform-Operations.md` was already landed in a prior commit on this branch (requirements submodule commit `a994520`); no further wiki changes were needed in this PR.

## Divergence from the plan

The ticket body's plan section typed `Nucleus.M2M.ClientId.validate/1` as `:ok | {:error, atom()}`, matching `TicketId`/`Purpose`. It's implemented instead as `:ok | {:error, Nucleus.Backend.Error.t()}`, matching `Nucleus.Environments.validate_name/1`'s established precedent. `TicketId` and `Purpose` do return bare reason atoms as specified — they're pure form validators with several distinct failure modes a future form needs to distinguish, with no boundary concept. `ClientId` exists specifically to gate the `:m2m` adapter boundary before `fetch/2` calls it, has exactly one failure mode, and returning the same `Error.t()` shape `fetch/2` needs anyway avoids `fetch/2` reconstructing one from a bare atom on the way out. This is recorded in ADR-0017.

## Record

`docs/adr/0017-m2m-naming-deny-list-and-resolution-gate.md` settles the four decisions resolved on the issue thread before implementation — the deny-list default/fail-closed/`none`-sentinel behaviour, the AWS-pattern widening for `ClientId`, the full-prefix tenancy rule, and enforcing the deny-list at creation too (new wiki action `M2M-A18`) — plus the `ClientId.validate/1` return-type divergence above. `decisions-log.md` gains row 17 pointing at it; `business-tech-bridge.md` marks `M2M-A13`/`A14` as claimed and covered, ahead of `NucleusWeb.M2MClientsLive`, which doesn't exist yet. `living-notes.md` was deliberately not touched — nothing on its Open Questions/Technical Debt/Active Projects lists pertained to these decisions, since all four were resolved directly on the issue thread before implementation rather than tracked there.

## Verification

`mix precommit` passed clean: `compile --warnings-as-errors`, `deps.unlock --unused`, `format`, and `test` — 663 tests passed (25 doctests, 638 tests), 14 skipped, 13 excluded, 0 failures. `mix nucleus.trace --feature M2M` shows exactly `M2M-A13`/`M2M-A14` covered, nothing else claimed. `mix test --only action:M2M-A13` and `mix test --only action:M2M-A14` both pass.

Out of scope, deliberately: any LiveView/route/navigation change, the M2M-S4 creation form, and #38/M2M-S5's own `M2M-A18` form-facing rejection — this ticket owns only the shared predicate (`Nucleus.M2M.DenyList.denied?/1`) and its own reserved-purpose unit test.

Closes #34
