### PR TITLE
M2M-S2: List the tenant's M2M clients, incl. empty state

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.10 | Updated: 2026-08-19 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.11 | Updated: 2026-08-20 -->
 
 # Business ↔ Tech Bridge
 
@@ -45,7 +45,7 @@ to cite from test names and bug reports.
 | `Environments.md` | `ENV-A01`–`A07` | 7 | `NucleusWeb.EnvironmentsLive` | `test/nucleus_web/live/environments_live_test.exs` |
 | `Data-Export-Configuration.md` | `DEX-A01`–`A14` | 14 | `NucleusWeb.DataExportLive` + Nomad Variables client | `test/nucleus_web/live/data_export_live_test.exs` |
 | `Secrets.md` | `SEC-A01`–`A18` | 18 | `NucleusWeb.SecretsLive` + SSM Parameter Store client | `test/nucleus_web/live/secrets_live_test.exs` |
-| `M2M-Clients.md` | `M2M-A01`–`A18`, minus `A09` | 17 | `NucleusWeb.M2MClientsLive` + Cognito client | `test/nucleus_web/live/m2m_clients_live_test.exs` |
+| `M2M-Clients.md` | `M2M-A01`–`A18`, minus `A09` | 17 | `NucleusWeb.M2MClientsLive.Index` + `.Show` + Cognito client | `test/nucleus_web/live/m2m_clients_live_test.exs` |
 | `Audit-and-Compliance.md` | `AUD-A01`–`A07` | 7 | `Nucleus.Audit` (emit-only; no local store — stateless constraint) | `test/nucleus/audit_test.exs` |
 | `API-Proxy.md` | `PRX-A01`–`A07` | 7 | Backing-API forwarding layer | `test/nucleus_web/proxy_test.exs` |
 | `Platform-Operations.md` | `OPS-A01`–`A13` | 13 | Health/readiness endpoints, config reference | `test/nucleus_web/ops_test.exs` |
@@ -66,15 +66,22 @@ creates a new secret through a second, independently conditionally-rendered moda
 (`Nucleus.Secrets.Key`/`Nucleus.Secrets.create/4`, `SEC-A09`–`A13`) that closes whichever of the
 two modals is open before opening the other, and renders every fail-closed/empty/failed-reveal/
 failed-save/failed-create state. `SEC-A18` is `SEC-S7` and later. `M2M-A13`/`A14` are also now
-claimed and covered (M2M-S1/#34) — ahead of `NucleusWeb.M2MClientsLive`, which does not exist
-yet. `Nucleus.M2M.fetch/2` (`test/nucleus/m2m_test.exs`) is the context-layer gate every M2M
-action will mount through once that LiveView lands, the same relationship
-`Nucleus.Environments.fetch/2` has to `NucleusWeb.SecretsLive`; `M2M-S1` also delivers the pure
-naming/shape validators (`Nucleus.M2M.TicketId`/`Purpose`/`ClientId`/`ClientName`) and the
-`Nucleus.M2M.DenyList` boundary M2M-S2 onward reads, but claims no action beyond `A13`/`A14`
-itself. Every other row is unimplemented. These names are the agreed target so that
-work lands consistently — treat them as the convention to follow, and correct this table if a
-better structure emerges.
+claimed and covered (M2M-S1/#34), and `M2M-A01`/`A02` join them (M2M-S2/#35):
+`NucleusWeb.M2MClientsLive.Index` (per Decision 7, two modules — `docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md`
+— not one module switching on `handle_params/3`) lists every visible client via
+`Nucleus.M2M.list/1`, streamed with `phx-update="stream"` and a separate `:client_count` assign,
+renders a `created_date_error` row as an explicit "unavailable" date rather than dropping it, and
+shows a create affordance outside the empty-state conditional so it stays visible in both states.
+`NucleusWeb.M2MClientsLive.Show` ships as a stub in this same ticket — route registered, shell
+only, no gate — so M2M-S3 replaces its body without touching the router or `Index`.
+`Nucleus.M2M.fetch/2` (`test/nucleus/m2m_test.exs`) is the context-layer gate every per-client M2M
+action mounts through, the same relationship `Nucleus.Environments.fetch/2` has to
+`NucleusWeb.SecretsLive`; `Nucleus.M2M.list/1` reuses its `visible?/1` predicate rather than a
+second copy, pinned by a test that a client hidden from the list also 404s via `fetch/2`. `M2M-S1`
+also delivers the pure naming/shape validators (`Nucleus.M2M.TicketId`/`Purpose`/`ClientId`/`ClientName`)
+and the `Nucleus.M2M.DenyList` boundary `list/1` reads. Every other row is unimplemented. These
+names are the agreed target so that work lands consistently — treat them as the convention to
+follow, and correct this table if a better structure emerges.
 
 
 Two conformance notes worth carrying forward, both recorded in

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.18 | Updated: 2026-08-19 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.19 | Updated: 2026-08-20 -->
 
 # Decisions Log
 
@@ -42,6 +42,7 @@ job and the row should point rather than paraphrase.
 | 15 | Shared AWS identity seam — two independent role ARNs (`TENANT_ROLE_ARN`, EN-10's `COGNITO_ROLE_ARN`), credential cache keyed on `{role_arn, external_id, session_name}` not the caller, region parameterised now with the second variable and its wiki amendment deferred to EN-10 | 2026-08-19 | Decided | `docs/adr/0015-shared-aws-identity-seam.md` |
 | 16 | M2M client adapter — derived OAuth scope (no new config var), operator-chosen token validity (5–60 min, stored in seconds), bounded fan-out with degrade-not-fail listing; `M2M-A09` removed mid-implementation — Cognito does not enforce client-name uniqueness | 2026-08-19 | Decided | `docs/adr/0016-m2m-client-adapter.md` |
 | 17 | M2M naming, deny-list, and resolution gate — `M2M_DENY_SUFFIXES` defaults to the prototype's Terraform value (fail-closed, `none` sentinel), `ClientId` uses AWS's own `[\w+]+` pattern not a tighter one, tenancy is the full `{tenant}-control-plane-` prefix (pool shared across tenants), deny-list enforced at creation too — new wiki action `M2M-A18` | 2026-08-19 | Decided | `docs/adr/0017-m2m-naming-deny-list-and-resolution-gate.md` |
+| 18 | M2M clients listing — two `Phoenix.LiveView` modules (`Index`/`Show`, the `phx.gen.live` split) not one switching on `handle_params/3`; `Nucleus.M2M.list/1` collapses the deny-list gate to one call, reusing `visible?/1`; row DOM ids are the plain `client_id` (already allowlist-safe, unlike Secrets' ARN hash); create button sits outside the empty-state conditional | 2026-08-20 | Decided | `docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -63,7 +64,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0016` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0018` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md
+++ b/docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md
@@ -1,0 +1,209 @@
+# ADR-0018: M2M Clients Listing — Context-Layer Gate Collapse, Two-Module Route Split, and Plain-ID DOM Ids
+
+## Status
+
+Accepted — 2026-08-20
+
+Decided on [M2M-S2](https://github.com/dave-bell/nucleus/issues/35). Builds on
+`0010-secrets-listing-gate-collapse-and-dom-ids.md` (the direct precedent this
+ADR follows one feature over), `0017-m2m-naming-deny-list-and-resolution-gate.md`
+(the `visible?/1` predicate this ticket's list filter reuses rather than
+duplicating), and `0006-application-shell-and-live-session-composition.md`
+(the `live_session` hook ordering both new routes inherit).
+
+## Context
+
+`M2M-A01` requires every visible M2M client be listed with its name, ID, and
+creation date; `M2M-A02` requires a clear empty state with a prominent create
+affordance. Three questions needed settling before implementation, one of
+them — the route shape — already closed on the issue thread as a
+`needs-decision` before work began; the other two surfaced during
+implementation itself, the same way ADR-0010 records questions SEC-S1's
+original plan left open or got wrong:
+
+1. **Route shape.** The ticket's own plan was modelled on `SEC-S1`
+   (`SecretsLive`, one module switching on `handle_params/3` across several
+   states of one route) applied to M2M's nested `/m2m/clients` +
+   `/m2m/clients/:client_id`. Whether that model actually fits a route that
+   is two distinct pages, not one page with several states, needed deciding
+   before either module could be written.
+2. **Row DOM ids.** `SecretsLive` hashes the ARN because a secret's natural
+   key (its `key`) can contain unicode, spaces, and dots with no defined CSS
+   sanitiser. Whether `Nucleus.M2M.Client.client_id` needs the same
+   treatment, or is DOM-safe as-is, was not decided by the ticket body.
+3. **The create affordance in the empty state.** `AGENTS.md`'s documented
+   `hidden only:block` trick for stream empty states only works when the
+   empty block is the stream comprehension's only sibling — `M2M-A02`
+   requires the create button stay visible in that same state, which breaks
+   the trick's precondition.
+
+## Decision
+
+### Two LiveView modules, not one switching on `handle_params/3`
+
+`NucleusWeb.M2MClientsLive.Index` (`/m2m/clients`) and
+`NucleusWeb.M2MClientsLive.Show` (`/m2m/clients/:client_id`) — the
+`phx.gen.live` module split (`deps/phoenix/priv/templates/phx.gen.live/{index,show}.ex.eex`,
+verified against the pinned 1.8.9 template, not assumed), not one module
+switching on `live_action`. Both live in the existing `:authenticated`
+`live_session`, inheriting `ScopeHook` then `EnvironmentsHook` in that fixed
+order, same as `SecretsLive`.
+
+The `SEC-S1` model fits a route serving several *states* of the same page,
+which patch between each other and need `handle_params/3` to re-validate on
+every patch. M2M's nested route is two distinct pages reached only by
+`navigate` — there is nothing to patch between, so nothing to re-validate.
+Following the split also removes a trap a single-module design would
+otherwise need a dedicated test to catch (patching back to `:index` needing
+`reset: true` or the stream returning empty), and avoids a modal-over-list
+detail view entirely, which matters because M2M-S6's one-time credentials
+panel (#39) opens *from* the detail view — a modal detail here would make
+that modal-over-modal, directly into ADR-0012's module-global `focusStack`
+double-pop hazard.
+
+Consequences of the split, both load-bearing for this ticket and the ones
+after it:
+
+- **`Show` resolves in `mount/3`, not `handle_params/3`.** Every navigation
+  to a different `client_id` is a fresh remount, so `phx.gen.live`'s own
+  `Show.mount/3` shape applies directly (`show.ex.eex:31`). This ticket ships
+  `Show` as a stub — `mount/3` renders the shell only, no gate, no
+  `Nucleus.M2M.fetch/2` call — so the route exists and compiles without
+  pulling M2M-S3's work forward.
+- **`Show` does not fetch the list.** `Cognito.list_clients/0` fans out one
+  `DescribeUserPoolClient` per client (`lib/nucleus/m2m/clients/cognito.ex:167-176`,
+  `max_concurrency: 10`); a modal-over-list detail would pay that whole
+  fan-out on every deep link for data it doesn't render. `Show` (M2M-S3) will
+  call `Nucleus.M2M.fetch/2` directly instead.
+- **The row control is a `<.link navigate={...}>`, not an event.** Explicit
+  `client_id` interpolation (`~p"/m2m/clients/#{client.client_id}"`), not
+  `~p"...#{client}"` — `Nucleus.M2M.Client` implements no `Phoenix.Param`,
+  and deriving one would put routing concerns in a data carrier that has
+  none today. No `handle_event` clause is needed for the row control.
+- **Shared error states are a real component, `NucleusWeb.M2MClientsLive.States`,
+  not a copy-paste starting point.** Two modules can't share markup by
+  accident. `Index` uses all three functions (`misconfigured/1`,
+  `unavailable/1`, `auth_expired/1`) this ticket adds; `Show` (M2M-S3) will
+  import the same module and add its own `#m2m-client-invalid-id`/
+  `#m2m-client-not-found`.
+
+### One call to `Nucleus.M2M.list/1`, gate included — mirrors `Secrets.list/2`
+
+`Nucleus.M2M.list/1` fails closed on `Nucleus.M2M.DenyList.suffixes/0` before
+ever calling `Nucleus.M2M.Clients.list_clients/0`, filters the result through
+`visible?/1` — the same predicate `Nucleus.M2M.fetch/2` already gates single
+reads with (`0017`) — and sorts case-insensitively by `client_name` with the
+raw name as a tiebreak (`Enum.sort_by(&{String.downcase(&1.client_name), &1.client_name})`),
+identical construction to `Nucleus.Secrets.list/2`. `NucleusWeb.M2MClientsLive.Index`
+calls only this function; there is exactly one place that can bypass the
+deny-list gate for a listing request, matching ADR-0010's own reasoning for
+collapsing `SecretsLive`'s two calls into one.
+
+A `Client` with `created_date_error` set (its own per-row
+`DescribeUserPoolClient` failed while listing — EN-10 / #33's Decision 6) is
+filtered and sorted like any other row and is not dropped; degrading that one
+row is `Clients.list_clients/0`'s job, not this function's.
+
+**Emits no audit event**, the same deliberate omission `Nucleus.Secrets.list/2`
+documents: the wiki's audit table has exactly three M2M events and listing
+is not among them. Unlike Data Export's `nomad_vars_listed`, listing here
+exposes no secret material — `Client.t()` has no secret field to begin
+with — so there is nothing sensitive to attribute.
+
+### Row DOM ids are the client ID directly, not a hash
+
+Unlike `SecretsLive`'s ARN-hash, `Nucleus.M2M.ClientId`'s allowlist
+(`~r/\A[A-Za-z0-9_+]{1,128}\z/`, `0017`) is already DOM-safe — there is no
+unicode, space, or dot case to sanitise around. `stream_configure(:clients,
+dom_id: &dom_id/1)` prefixes it (`"m2m-client-" <> client_id`) only to avoid
+an id that could start with a digit; every row also carries
+`data-client-id={client.client_id}`, so M2M-S3/S6 read the authoritative ID
+from an attribute rather than parsing it back out of the element id, matching
+the DOM-id contract the ticket tabulated.
+
+### The create affordance sits outside the empty-state conditional
+
+`#new-m2m-client-button` is rendered whenever `@status == :ok`, regardless of
+`@client_count`, rather than inside `<.empty_state>`'s `:action` slot or
+relying on the `hidden only:block` trick. `SecretsLive`'s own "New secret"
+button already follows this shape for the identical reason: the trick only
+applies when the empty block is the stream comprehension's only sibling, and
+a create button rendered alongside the empty state breaks that precondition.
+This ticket's plan independently reached the same conclusion `SEC-S2` did.
+
+## Consequences
+
+### Positive
+
+- `Nucleus.M2M.list/1` is the one place a list request can bypass the
+  deny-list gate; `NucleusWeb.M2MClientsLive.Index` has no second call site
+  to audit, matching ADR-0010's own positive consequence for `Secrets.list/2`.
+- `visible?/1` backs both `fetch/2` and `list/1` from one implementation, so
+  a client hidden from the list cannot remain rotatable by URL — pinned by a
+  dedicated test (`test/nucleus/m2m_test.exs`) rather than left to the two
+  call sites happening to agree.
+- `NucleusWeb.M2MClientsLive.States` gives M2M-S3 a written contract for its
+  own error states, instead of that ticket guessing markup independently the
+  way ADR-0010 gave `SEC-S3`–`S6` a DOM-id contract instead of four tickets
+  each guessing a sanitisation scheme.
+- No hash function exists for this feature to keep stable across a future
+  `stream_insert/3` (M2M-S5/S6) — the DOM id is just the ID, so there is
+  nothing to document as a liability the way ADR-0010 flags its own ARN hash.
+
+### Negative
+
+- `Show`'s stub carries no test of its own gate — none exists yet — so
+  M2M-S3 replacing the stub body is the first point that route is actually
+  exercised against a real, malformed, or out-of-tenant `client_id`. This
+  ticket's own test only asserts the stub mounts without crashing on a valid
+  ID reached by navigation.
+- The three collapsed error states (`:misconfigured`, `:unavailable`,
+  `:auth_expired`) fold `:not_found`, `:already_exists`, and `:invalid` into
+  `:unavailable` by default, on the reasoning that `Nucleus.M2M.list/1` has
+  no path that returns them today. If a future change to
+  `Nucleus.M2M.Clients.list_clients/0` starts returning one of those kinds
+  for a real reason, it will render as a generic "can't reach" message
+  rather than its own state until `Index`'s `case` is revisited — the same
+  trade `SecretsLive`'s exhaustive fallback already accepts.
+
+## Alternatives considered
+
+**One `M2MClientsLive` module, `handle_params/3` switching on `live_action`.**
+Rejected — modelled on `SEC-S1`'s single-route, multi-state shape, which does
+not describe M2M's two-distinct-pages shape; see Decision 1 above and
+`phx.gen.live`'s own precedent.
+
+**A modal-based detail view over the list, avoiding a second route
+entirely.** Rejected — pays `Cognito.list_clients/0`'s per-client describe
+fan-out on every deep link for data the detail view doesn't render, and
+collides with M2M-S6's credentials panel opening from the detail view
+(modal-over-modal, ADR-0012's `focusStack` hazard).
+
+**Hashing `client_id` for the row DOM id, matching `SecretsLive` exactly.**
+Rejected — `client_id`'s allowlist has no character `SecretsLive`'s hash was
+introduced to work around; hashing here would add an opaque id with no
+corresponding problem to solve.
+
+**Using `AGENTS.md`'s `hidden only:block` trick for the empty state.**
+Rejected — `M2M-A02` requires the create button visible in the empty state,
+which is not the stream comprehension's only sibling once that button is
+added; the trick's precondition does not hold here.
+
+## References
+
+- M2M-S2 (issue #35) — the deciding issue, including
+  [Decision 7](https://github.com/dave-bell/nucleus/issues/35#issuecomment-5350928640)
+  (route shape, decided before implementation started)
+- `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md` — the direct
+  precedent this ADR follows: one gated context call, DOM-id contract,
+  exhaustive error-kind handling
+- `docs/adr/0017-m2m-naming-deny-list-and-resolution-gate.md` — the
+  `visible?/1` predicate this ticket's list filter reuses
+- `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md` — the
+  `focusStack` hazard the two-module split avoids rather than works around
+- `deps/phoenix/priv/templates/phx.gen.live/{index,show}.ex.eex` — the
+  module-split precedent Decision 7 follows
+- `lib/nucleus/m2m/clients/cognito.ex:167-176` — the per-client describe
+  fan-out `Show` avoids paying on every deep link
+- Wiki [M2M-Clients](https://github.com/dave-bell/nucleus/wiki/M2M-Clients)
+  `M2M-A01`, `M2M-A02`, and the audit events table

--- a/lib/nucleus/m2m.ex
+++ b/lib/nucleus/m2m.ex
@@ -4,7 +4,7 @@ defmodule Nucleus.M2M do
   (`M2M-A13`, `M2M-A14`) — the same structure `Nucleus.Environments.fetch/2`
   gives `SEC-S1`, one boundary over.
 
-  `NucleusWeb.M2MClientsLive` talks to this module, never to
+  `NucleusWeb.M2MClientsLive.Index` and `.Show` talk to this module, never to
   `Nucleus.M2M.Clients` directly, so the gate cannot be bypassed — the same
   rule `Nucleus.Secrets` states about `Nucleus.Secrets.Store`.
 
@@ -108,6 +108,48 @@ defmodule Nucleus.M2M do
   @spec visible?(Client.t() | ClientDetail.t()) :: boolean()
   def visible?(%{client_name: client_name}) when is_binary(client_name) do
     ClientName.in_tenant?(client_name) and not DenyList.denied?(client_name)
+  end
+
+  @doc """
+  Every M2M client visible to this tenant — `M2M-A01`, `M2M-A02` (`M2M-S2`).
+
+  Same strict order as `fetch/2`, minus the per-ID steps that don't apply to
+  a list: deny-list config first (fail closed, no adapter call on
+  `:not_configured`), then the adapter call, then the shared `visible?/1`
+  filter — the same predicate `fetch/2` gates a single client through, so a
+  client hidden here cannot remain resolvable by URL (see the module doc).
+
+  A `Client` with `created_date_error` set (its per-row describe failed
+  while listing) is filtered and sorted like any other — it is
+  `Nucleus.M2M.Clients.list_clients/0`'s job to degrade that one row, not
+  this function's job to drop it.
+
+  Sorted case-insensitively by `client_name`, with the raw name as a
+  tiebreak so the order is total: `ListUserPoolClients` paginates with no
+  cross-page ordering guarantee, and the local implementation reads a
+  JSON-decoded map whose iteration order is not insertion order past 32
+  keys. Sorting here, not in the template, keeps the LiveView and its tests
+  free of that concern. Same construction as `Nucleus.Secrets.list/2`.
+
+  `scope` is accepted for call-site symmetry, unread — see the module doc's
+  "Note the asymmetry with Secrets".
+
+  **Emits no audit event.** The wiki's audit table has exactly three M2M
+  events and listing is not among them — unlike Data Export's
+  `nomad_vars_listed`, listing here exposes no secrets, so there is nothing
+  sensitive to attribute.
+  """
+  @spec list(scope :: Scope.t()) :: {:ok, [Client.t()]} | {:error, Error.t()}
+  def list(%Scope{} = _scope) do
+    with {:ok, _suffixes} <- DenyList.suffixes(),
+         {:ok, clients} <- Clients.list_clients() do
+      visible =
+        clients
+        |> Enum.filter(&visible?/1)
+        |> Enum.sort_by(&{String.downcase(&1.client_name), &1.client_name})
+
+      {:ok, visible}
+    end
   end
 
   defp not_found(client_id) do

--- a/lib/nucleus_web/components/layouts.ex
+++ b/lib/nucleus_web/components/layouts.ex
@@ -66,6 +66,8 @@ defmodule NucleusWeb.Layouts do
               NAV-A03 (active-section highlighting) is out of scope: these
               tenant-wide features don't exist yet, so they render as
               visibly disabled placeholders rather than dead links.
+              M2M Clients (M2M-S2, #35) is the first of these three to ship
+              a real view — replaced with a working link, not a placeholder.
             --%>
             <ul class="menu menu-sm p-0 group-data-[collapsed=true]:hidden">
               <li>
@@ -79,9 +81,9 @@ defmodule NucleusWeb.Layouts do
                 </span>
               </li>
               <li>
-                <span class="opacity-40 cursor-not-allowed" aria-disabled="true">
+                <.link navigate={~p"/m2m/clients"}>
                   M2M Clients
-                </span>
+                </.link>
               </li>
             </ul>
             <%!--

--- a/lib/nucleus_web/live/m2m_clients_live/index.ex
+++ b/lib/nucleus_web/live/m2m_clients_live/index.ex
@@ -1,0 +1,226 @@
+defmodule NucleusWeb.M2MClientsLive.Index do
+  @moduledoc """
+  Lists the tenant's M2M clients (`M2M-A01`), with a create-first-client
+  empty state (`M2M-A02`) — issue #35, M2M-S2.
+
+  ## No URL params to gate — `mount/3`, not `handle_params/3`
+
+  Unlike `NucleusWeb.SecretsLive`, this route carries no identifier (`/m2m/clients`,
+  no `:environment`/`:client_id` segment) — there is nothing a `<.link
+  patch={...}>` could change without a remount, so the initial (and only)
+  fetch happens in `mount/3` directly. `NucleusWeb.M2MClientsLive.Show`
+  (M2M-S3, #36) is the sibling route this ticket registers but does not
+  implement — see its own moduledoc for why it, too, has no
+  `handle_params/3`.
+
+  ## One call to `Nucleus.M2M.list/1`, gate included
+
+  `Nucleus.M2M.list/1` fails closed on `Nucleus.M2M.DenyList.suffixes/0`
+  before ever calling the adapter, filters through the shared `visible?/1`
+  predicate `Nucleus.M2M.fetch/2` also gates single-client reads with, and
+  sorts deterministically (case-insensitive `client_name`, raw name
+  tiebreak) — all in the context, not here. This module has nothing to
+  filter or sort; it only renders what comes back.
+
+  ## Every outcome gets its own assign and DOM id
+
+  `Nucleus.M2M.list/1` can succeed or fail with any
+  `Nucleus.Backend.Error.kinds/0` value — this `case` collapses them to
+  three states via `NucleusWeb.M2MClientsLive.States`, mirroring
+  `NucleusWeb.SecretsLive`'s exhaustive handling (`docs/adr/0010`):
+
+  | Outcome | `:status` | DOM id |
+  |---|---|---|
+  | `{:ok, clients}` | `:ok` | `#m2m-clients-table` / `#m2m-clients-empty` |
+  | `kind: :not_configured` | `:misconfigured` | `#m2m-clients-misconfigured` |
+  | `kind: :unavailable` | `:unavailable` | `#m2m-clients-unavailable` |
+  | `kind: :auth_expired` | `:auth_expired` | `#m2m-clients-auth-expired` |
+  | anything else (`:not_found`, `:already_exists`, `:invalid` — none of
+    which `list/1` has reason to return today) | `:unavailable` | `#m2m-clients-unavailable` |
+
+  Every branch keeps the shell intact (`<Layouts.app>`, `#tenant-identifier`)
+  so the user can navigate away — a crashed LiveView is not an acceptable
+  rendering of any of these.
+
+  ## `stream/3`, plus a separate count assign
+
+  Streams are not enumerable (`AGENTS.md`), so `:client_count` — set
+  alongside the stream, from the same `Nucleus.M2M.list/1` call, never
+  recomputed separately — drives the empty-state branch. The create
+  affordance (`#new-m2m-client-button`) sits *outside* the
+  `@client_count == 0` conditional, always rendered whenever `@status ==
+  :ok`, so it is present in both the empty and populated states
+  (`M2M-A02`'s explicit requirement) without relying on the `hidden
+  only:block` CSS trick `AGENTS.md` documents — that trick only works when
+  the empty block is the stream comprehension's only sibling, which is not
+  the case here once the create button is added.
+
+  ## Row DOM ids are the client ID directly, not a hash
+
+  Unlike `NucleusWeb.SecretsLive`'s ARN-hash (`docs/adr/0010`), `client_id`
+  is already DOM-safe: `Nucleus.M2M.ClientId`'s allowlist is
+  `[A-Za-z0-9_+]{1,128}`, anchored. `stream_configure(:clients, dom_id: &dom_id/1)`
+  prefixes it (`"m2m-client-" <> client_id`) only to avoid an id starting
+  with a digit; every row also carries `data-client-id={client.client_id}`
+  so M2M-S3/S6 read the authoritative ID from an attribute rather than
+  parsing it back out of the element id, matching the DOM-id contract in
+  issue #35.
+
+  ## No secret column, no mask, no reveal
+
+  `Nucleus.M2M.Client` has no secret field — there is nothing here to mask
+  or reveal, and `M2M-A03` (wiki) states the secret is only ever shown at
+  creation or rotation. A masked placeholder column would imply a reveal
+  that cannot exist.
+
+  ## A `nil` `created_date` is an explicit state, not a blank cell
+
+  `EN-10`/#33's Decision 6: a `Client` whose per-row `DescribeUserPoolClient`
+  failed while listing carries `created_date_error` instead of
+  `created_date`, and is still returned by `Nucleus.M2M.Clients.list_clients/0`
+  — not dropped. The date cell renders `#m2m-client-date-unavailable-{id}`
+  for that row rather than an empty string, so "the date failed to load" is
+  visually distinct from "there was no date to begin with" (there is always
+  a date; only reading it can fail).
+
+  ## Placeholder create handler; the row control is a plain link
+
+  This ticket renders `#new-m2m-client-button`; M2M-S4 (#37) implements it.
+  `handle_event("new_client", ...)` just flashes "not yet implemented" so
+  the button cannot crash the view in the meantime. The row's view control
+  is `<.link navigate={~p"/m2m/clients/\#{client.client_id}"}>` — explicit
+  `client_id` interpolation, not `~p"...\#{client}"`, since `Nucleus.M2M.Client`
+  implements no `Phoenix.Param` — and needs no `handle_event` clause at all,
+  since a `navigate` link has nothing to placeholder.
+
+  `current_scope` and `environments` come from the `:authenticated`
+  `live_session`'s `on_mount` hooks (`NucleusWeb.ScopeHook`,
+  `NucleusWeb.EnvironmentsHook`), same order as `NucleusWeb.SecretsLive` —
+  this module does not assign either itself.
+  """
+
+  use NucleusWeb, :live_view
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M
+  alias Nucleus.M2M.Client
+  alias NucleusWeb.M2MClientsLive.States
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> stream_configure(:clients, dom_id: &dom_id/1)
+      |> stream(:clients, [])
+      |> fetch_clients()
+
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("new_client", _params, socket) do
+    {:noreply, put_flash(socket, :info, "Creating a client is not yet implemented.")}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("retry", _params, socket) do
+    {:noreply, fetch_clients(socket)}
+  end
+
+  defp fetch_clients(socket) do
+    case M2M.list(socket.assigns.current_scope) do
+      {:ok, clients} ->
+        socket
+        |> assign(status: :ok, client_count: length(clients))
+        |> stream(:clients, clients, reset: true)
+
+      {:error, %Error{kind: :not_configured}} ->
+        assign(socket, status: :misconfigured, client_count: 0)
+
+      {:error, %Error{kind: :auth_expired}} ->
+        assign(socket, status: :auth_expired, client_count: 0)
+
+      {:error, %Error{}} ->
+        assign(socket, status: :unavailable, client_count: 0)
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope} environments={@environments}>
+      <States.misconfigured :if={@status == :misconfigured} />
+      <States.unavailable :if={@status == :unavailable} />
+      <States.auth_expired :if={@status == :auth_expired} />
+
+      <div :if={@status == :ok}>
+        <div class="flex items-center justify-between gap-4 pb-4">
+          <h1 class="text-lg font-semibold">M2M Clients</h1>
+          <.button id="new-m2m-client-button" phx-click="new_client">New client</.button>
+        </div>
+
+        <.empty_state
+          :if={@client_count == 0}
+          id="m2m-clients-empty"
+          icon="hero-inbox"
+          message="No M2M clients yet."
+        />
+
+        <div :if={@client_count > 0} id="m2m-clients-table">
+          <table class="table table-zebra">
+            <thead>
+              <tr>
+                <th>Client name</th>
+                <th>Client ID</th>
+                <th>Created</th>
+                <th><span class="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody id="m2m-clients-table-body" phx-update="stream">
+              <tr
+                :for={{dom_id, client} <- @streams.clients}
+                id={dom_id}
+                data-client-id={client.client_id}
+              >
+                <td class="font-medium">{client.client_name}</td>
+                <td class="font-mono text-sm">{client.client_id}</td>
+                <td class="whitespace-nowrap">
+                  <%= if client.created_date do %>
+                    {format_created_date(client.created_date)}
+                  <% else %>
+                    <span
+                      id={date_unavailable_id(client.client_id)}
+                      class="text-base-content/50"
+                    >
+                      unavailable
+                    </span>
+                  <% end %>
+                </td>
+                <td class="text-right">
+                  <.link
+                    id={view_link_id(client.client_id)}
+                    navigate={~p"/m2m/clients/#{client.client_id}"}
+                    class="btn btn-sm"
+                  >
+                    View
+                  </.link>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp dom_id(%Client{client_id: client_id}), do: "m2m-client-" <> client_id
+
+  defp date_unavailable_id(client_id), do: "m2m-client-date-unavailable-" <> client_id
+
+  defp view_link_id(client_id), do: "view-client-" <> client_id
+
+  defp format_created_date(%DateTime{} = datetime) do
+    Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
+  end
+end

--- a/lib/nucleus_web/live/m2m_clients_live/show.ex
+++ b/lib/nucleus_web/live/m2m_clients_live/show.ex
@@ -1,0 +1,37 @@
+defmodule NucleusWeb.M2MClientsLive.Show do
+  @moduledoc """
+  Stub for `/m2m/clients/:client_id` — M2M-S2 (#35) registers this route so
+  `Index`'s per-row view link (`<.link navigate={~p"/m2m/clients/\#{client.client_id}"}>`)
+  has somewhere real to land and the app compiles with both routes in place.
+  M2M-S3 (#36) replaces this module's body wholesale — the gate,
+  `Nucleus.M2M.fetch/2`, `m2m_client_viewed`, token-validity display — without
+  touching the router or `NucleusWeb.M2MClientsLive.Index` (Decision 7).
+
+  `mount/3`, not `handle_params/3`, per Decision 7: `Show` is reached only by
+  a `live_navigate` from `Index` (a fresh remount on every `client_id`, never
+  a `patch` between two client IDs), so there is nothing to re-validate on a
+  patch that never happens — the same reasoning `phx.gen.live`'s own
+  `Show.mount/3` follows (`deps/phoenix/priv/templates/phx.gen.live/show.ex.eex`).
+
+  No gate, no `Nucleus.M2M.fetch/2` call, and no error-state handling belong
+  in this ticket — only the shell, so `client_id` is not even read here yet.
+  """
+
+  use NucleusWeb, :live_view
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope} environments={@environments}>
+      <div id="m2m-client-detail-placeholder">
+        M2M client detail is not implemented yet.
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/nucleus_web/live/m2m_clients_live/states.ex
+++ b/lib/nucleus_web/live/m2m_clients_live/states.ex
@@ -1,0 +1,75 @@
+defmodule NucleusWeb.M2MClientsLive.States do
+  @moduledoc """
+  Shared error-state function components for `NucleusWeb.M2MClientsLive.Index`
+  and (eventually) `.Show` — issue #35's Decision 7 calls these out
+  specifically: two modules can't share markup by accident, so this has to be
+  a real component, not a copy-paste starting point.
+
+  `Nucleus.M2M.list/1` can only ever gate through `Nucleus.M2M.DenyList`
+  (`:not_configured`) or `Nucleus.M2M.Clients.list_clients/0`
+  (`:unavailable`, `:auth_expired`, or — theoretically — one of the
+  remaining `Nucleus.Backend.Error.kinds/0`), so `Index` collapses every kind
+  to one of the three states here, mirroring `NucleusWeb.SecretsLive`'s
+  exhaustive `case` (`docs/adr/0010`) so no kind is left unhandled and no
+  branch crashes the LiveView.
+
+  `Index` uses all three; `Show` (M2M-S3, #36) imports this module and adds
+  its own `#m2m-client-invalid-id`/`#m2m-client-not-found` — not implemented
+  here, since this ticket's `Show` is a stub with no gate to fail.
+  """
+
+  use NucleusWeb, :html
+
+  @doc """
+  `M2M_DENY_SUFFIXES` unset, or otherwise unreadable — an operations
+  problem, not something the user did wrong.
+  """
+  attr :id, :string, default: "m2m-clients-misconfigured"
+
+  def misconfigured(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-shield-exclamation"
+      message="M2M Clients isn't configured yet. This is an operations issue, not something you can fix here."
+    />
+    """
+  end
+
+  @doc """
+  Cognito (or the local backend standing in for it) can't be reached right
+  now — carries a retry affordance, unlike the other two states.
+  """
+  attr :id, :string, default: "m2m-clients-unavailable"
+
+  def unavailable(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-exclamation-triangle"
+      message="Can't reach the M2M client directory right now. Try again shortly."
+    >
+      <:action>
+        <.button phx-click="retry">Retry</.button>
+      </:action>
+    </.empty_state>
+    """
+  end
+
+  @doc """
+  Nucleus's own credentials for the backend expired. Placeholder copy —
+  `SEC-A18`'s slice (`SEC-S7`) owns the real copy and retry semantics; this
+  mirrors whatever that lands rather than inventing a second pattern.
+  """
+  attr :id, :string, default: "m2m-clients-auth-expired"
+
+  def auth_expired(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-lock-closed"
+      message="M2M clients can't be reached right now."
+    />
+    """
+  end
+end

--- a/lib/nucleus_web/router.ex
+++ b/lib/nucleus_web/router.ex
@@ -42,6 +42,16 @@ defmodule NucleusWeb.Router do
     live_session :authenticated,
       on_mount: [{NucleusWeb.ScopeHook, :assign}, {NucleusWeb.EnvironmentsHook, :assign}] do
       live "/environments/:environment/secrets", SecretsLive, :index
+
+      # Two modules, not one switching on `handle_params/3` — M2M-S2
+      # (#35) Decision 7, the `phx.gen.live` module split
+      # (`deps/phoenix/priv/templates/phx.gen.live/{index,show}.ex.eex`):
+      # `Index` and `Show` are reached only by `navigate`, never a `patch`
+      # between each other, so there is nothing for a shared module to
+      # re-validate. `Show` ships as a stub in this ticket — M2M-S3 (#36)
+      # replaces its body without touching this route or `Index`.
+      live "/m2m/clients", M2MClientsLive.Index, :index
+      live "/m2m/clients/:client_id", M2MClientsLive.Show, :show
     end
   end
 

--- a/test/nucleus/m2m_test.exs
+++ b/test/nucleus/m2m_test.exs
@@ -8,6 +8,7 @@ defmodule Nucleus.M2MTest do
 
   alias Nucleus.Backend.Error
   alias Nucleus.M2M
+  alias Nucleus.M2M.Client
   alias Nucleus.M2M.ClientDetail
   alias Nucleus.M2M.DenyList
   alias Nucleus.Scope
@@ -52,20 +53,92 @@ defmodule Nucleus.M2MTest do
 
   defmodule FailingM2MClients do
     @moduledoc """
-    A `Nucleus.M2M.Clients` implementation whose `describe_client/1` always
-    returns a controllable `Nucleus.Backend.Error`, for asserting that
-    `Nucleus.M2M.fetch/2` passes a given error kind through unchanged.
+    A `Nucleus.M2M.Clients` implementation whose `describe_client/1` and
+    `list_clients/0` always return a controllable `Nucleus.Backend.Error`,
+    for asserting that `Nucleus.M2M.fetch/2` and `Nucleus.M2M.list/1` pass a
+    given error kind through unchanged.
+
+    A swapped module, not `LOCAL_FORCE_ERROR`: `Nucleus.Backend.Faults` is
+    node-global (`living-notes.md`) and the `:m2m` boundary's `Clients.Local`
+    checks it first thing on every callback, same as every other local
+    implementation — a swapped module is the only way to control the
+    returned kind precisely, per test, without leaking into any other
+    boundary the same `async: false` suite might touch.
     """
     @behaviour Nucleus.M2M.Clients
 
     @impl Nucleus.M2M.Clients
-    def list_clients, do: raise("should not be called")
+    def list_clients do
+      kind = Application.get_env(:nucleus, __MODULE__, :unavailable)
+      {:error, Error.new(kind, :m2m, "forced for test", %{})}
+    end
 
     @impl Nucleus.M2M.Clients
     def describe_client(_client_id) do
       kind = Application.get_env(:nucleus, __MODULE__, :unavailable)
       {:error, Error.new(kind, :m2m, "forced for test", %{})}
     end
+
+    @impl Nucleus.M2M.Clients
+    def create_client(_client_name, _settings), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def rotate_secret(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def health_check, do: raise("should not be called")
+  end
+
+  defmodule EmptyM2MClients do
+    @moduledoc """
+    A `Nucleus.M2M.Clients` implementation whose `list_clients/0` always
+    succeeds with zero clients — `M2M-A02`'s "an empty tenant" fixture,
+    distinct from an error: `{:ok, []}` must not be confused with a failed
+    list.
+    """
+    @behaviour Nucleus.M2M.Clients
+
+    @impl Nucleus.M2M.Clients
+    def list_clients, do: {:ok, []}
+
+    @impl Nucleus.M2M.Clients
+    def describe_client(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def create_client(_client_name, _settings), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def rotate_secret(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def health_check, do: raise("should not be called")
+  end
+
+  defmodule DegradedRowM2MClients do
+    @moduledoc """
+    A `Nucleus.M2M.Clients` implementation whose `list_clients/0` returns a
+    single in-tenant, non-denied client with `created_date_error` set instead
+    of `created_date` — EN-10 / #33's Decision 6 fixture: a per-row describe
+    failure while listing degrades that one row rather than failing the
+    whole list, and `Nucleus.M2M.list/1` must return it, not drop it.
+    """
+    @behaviour Nucleus.M2M.Clients
+
+    @impl Nucleus.M2M.Clients
+    def list_clients do
+      {:ok,
+       [
+         %Client{
+           client_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+           client_name: "local-control-plane-OPS-9999-degraded",
+           created_date: nil,
+           created_date_error: :unavailable
+         }
+       ]}
+    end
+
+    @impl Nucleus.M2M.Clients
+    def describe_client(_client_id), do: raise("should not be called")
 
     @impl Nucleus.M2M.Clients
     def create_client(_client_name, _settings), do: raise("should not be called")
@@ -205,6 +278,116 @@ defmodule Nucleus.M2MTest do
     test "true for a resolved in-tenant, non-denied client" do
       assert {:ok, detail} = M2M.fetch(@valid_client_id, @scope)
       assert M2M.visible?(detail)
+    end
+  end
+
+  describe "list/1 — M2M-A01 lists the tenant's visible clients" do
+    @tag action: "M2M-A01"
+    test "returns Client structs with client_id, client_name, created_date populated" do
+      assert {:ok, clients} = M2M.list(@scope)
+      assert clients != []
+
+      for client <- clients do
+        assert %Client{} = client
+        assert is_binary(client.client_id)
+        assert is_binary(client.client_name)
+      end
+
+      assert Enum.any?(clients, &(&1.client_id == @valid_client_id))
+      assert Enum.any?(clients, & &1.created_date)
+    end
+
+    @tag action: "M2M-A01"
+    test "the returned structs have no :client_secret key" do
+      assert {:ok, clients} = M2M.list(@scope)
+      assert clients != []
+
+      for client <- clients do
+        refute Map.has_key?(client, :client_secret)
+      end
+    end
+
+    @tag action: "M2M-A01"
+    test "the seeded deny-listed client is absent from the result" do
+      assert {:ok, clients} = M2M.list(@scope)
+      refute Enum.any?(clients, &(&1.client_id == @denied_client_id))
+    end
+
+    @tag action: "M2M-A01"
+    test "the seeded out-of-tenant client is absent from the result" do
+      assert {:ok, clients} = M2M.list(@scope)
+      refute Enum.any?(clients, &(&1.client_id == @out_of_tenant_client_id))
+    end
+
+    @tag action: "M2M-A01"
+    test "a client hidden from list/1 also returns :not_found from fetch/2 — the two paths are pinned together" do
+      assert {:ok, clients} = M2M.list(@scope)
+      listed_ids = MapSet.new(clients, & &1.client_id)
+
+      refute MapSet.member?(listed_ids, @denied_client_id)
+      assert {:error, %Error{kind: :not_found}} = M2M.fetch(@denied_client_id, @scope)
+
+      refute MapSet.member?(listed_ids, @out_of_tenant_client_id)
+      assert {:error, %Error{kind: :not_found}} = M2M.fetch(@out_of_tenant_client_id, @scope)
+    end
+
+    @tag action: "M2M-A01"
+    test "results are sorted case-insensitively, and the order is identical across two calls" do
+      assert {:ok, first} = M2M.list(@scope)
+      assert {:ok, second} = M2M.list(@scope)
+
+      names = Enum.map(first, & &1.client_name)
+      assert names == Enum.sort_by(names, &String.downcase/1)
+      assert Enum.map(second, & &1.client_id) == Enum.map(first, & &1.client_id)
+    end
+
+    @tag action: "M2M-A01"
+    test "a Client with created_date_error set (not created_date) is still returned, not dropped" do
+      use_backend(DegradedRowM2MClients)
+
+      assert {:ok, [client]} = M2M.list(@scope)
+      assert client.created_date == nil
+      assert client.created_date_error == :unavailable
+    end
+  end
+
+  describe "list/1 — M2M-A02 empty state" do
+    @tag action: "M2M-A02"
+    test "an empty m2m seed section returns {:ok, []}, not an error" do
+      use_backend(EmptyM2MClients)
+
+      assert {:ok, []} = M2M.list(@scope)
+    end
+  end
+
+  describe "list/1 — unconfigured deny-list fails closed" do
+    test "returns :not_configured, with zero adapter calls" do
+      unconfigure_deny_list()
+      use_backend(ExplodingM2MClients)
+
+      assert {:error, %Error{kind: :not_configured}} = M2M.list(@scope)
+    end
+  end
+
+  describe "list/1 — no audit event" do
+    test "emits none of the three m2m_* events" do
+      assert {:ok, _clients} = M2M.list(@scope)
+
+      assert_no_audit_event(:m2m_client_viewed)
+      assert_no_audit_event(:m2m_client_created)
+      assert_no_audit_event(:m2m_secret_rotated)
+    end
+  end
+
+  describe "list/1 — error kinds pass through unflattened" do
+    for kind <- Error.kinds() -- [:not_configured] do
+      @tag kind: kind
+      test "#{kind} is returned unflattened", %{kind: kind} do
+        use_backend(FailingM2MClients)
+        Application.put_env(:nucleus, FailingM2MClients, kind)
+
+        assert {:error, %Error{kind: ^kind}} = M2M.list(@scope)
+      end
     end
   end
 end

--- a/test/nucleus_web/live/m2m_clients_live_test.exs
+++ b/test/nucleus_web/live/m2m_clients_live_test.exs
@@ -1,0 +1,283 @@
+defmodule NucleusWeb.M2MClientsLiveTest do
+  # Backend swap (`use_backend/1`) mutates node-global `:nucleus, :backends`
+  # config, matching `Nucleus.M2MTest`'s own constraint — `async: false`.
+  use NucleusWeb.LiveCase, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M.Client
+
+  # Seeded in priv/backends/local_seed.json under TENANT_NAMESPACE = "local"
+  # — the same fixtures `Nucleus.M2MTest` exercises at the context layer.
+  @valid_client_id "4f2a9c1e7b3d8f0a1c2e3f4a5b6c7d8e"
+  @valid_client_name "local-control-plane-OPS-1001-billing-sync"
+  @valid_client_secret "b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a6789"
+  @denied_client_id "5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e"
+  @denied_client_name "local-control-plane-OPS-1042-nucleus"
+  @out_of_tenant_client_id "6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f"
+  @out_of_tenant_client_name "acme-control-plane-OPS-1043-sync"
+
+  @degraded_client_id "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+  defmodule EmptyM2MClients do
+    @moduledoc "M2M-A02's empty-tenant fixture — see `Nucleus.M2MTest`'s twin."
+    @behaviour Nucleus.M2M.Clients
+
+    @impl Nucleus.M2M.Clients
+    def list_clients, do: {:ok, []}
+
+    @impl Nucleus.M2M.Clients
+    def describe_client(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def create_client(_client_name, _settings), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def rotate_secret(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def health_check, do: raise("should not be called")
+  end
+
+  defmodule FailingM2MClients do
+    @moduledoc """
+    A controllable `list_clients/0` failure — a swapped module, not
+    `LOCAL_FORCE_ERROR`, for the same node-global reason `Nucleus.M2MTest`'s
+    twin documents.
+    """
+    @behaviour Nucleus.M2M.Clients
+
+    @impl Nucleus.M2M.Clients
+    def list_clients do
+      kind = Application.get_env(:nucleus, __MODULE__, :unavailable)
+      {:error, Error.new(kind, :m2m, "forced for test", %{})}
+    end
+
+    @impl Nucleus.M2M.Clients
+    def describe_client(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def create_client(_client_name, _settings), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def rotate_secret(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def health_check, do: raise("should not be called")
+  end
+
+  defmodule DegradedRowM2MClients do
+    @moduledoc "EN-10 / #33's Decision 6 fixture — see `Nucleus.M2MTest`'s twin."
+    @behaviour Nucleus.M2M.Clients
+
+    @impl Nucleus.M2M.Clients
+    def list_clients do
+      {:ok,
+       [
+         %Client{
+           client_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+           client_name: "local-control-plane-OPS-9999-degraded",
+           created_date: nil,
+           created_date_error: :unavailable
+         }
+       ]}
+    end
+
+    @impl Nucleus.M2M.Clients
+    def describe_client(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def create_client(_client_name, _settings), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def rotate_secret(_client_id), do: raise("should not be called")
+
+    @impl Nucleus.M2M.Clients
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_backend(module) do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+    Application.put_env(:nucleus, :backends, Keyword.put(original, :m2m, module))
+  end
+
+  defp row_client_ids(view) do
+    view
+    |> render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("#m2m-clients-table-body [data-client-id]")
+    |> LazyHTML.attribute("data-client-id")
+  end
+
+  describe "M2M-A01 — list the tenant's M2M clients" do
+    @tag action: "M2M-A01"
+    test "shows every visible client with its name, ID and creation date", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert has_element?(view, "#m2m-clients-table")
+
+      assert has_element?(
+               view,
+               ~s(#m2m-clients-table-body [data-client-id="#{@valid_client_id}"])
+             )
+
+      assert has_element?(view, "#m2m-clients-table-body", @valid_client_name)
+      assert has_element?(view, "#m2m-clients-table-body", @valid_client_id)
+    end
+
+    @tag action: "M2M-A01"
+    test "a client with created_date_error set renders the date-unavailable state, not a crash",
+         %{conn: conn} do
+      use_backend(DegradedRowM2MClients)
+
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert has_element?(view, "#m2m-client-date-unavailable-#{@degraded_client_id}")
+    end
+
+    @tag action: "M2M-A01"
+    test "the deny-listed client's name and ID appear nowhere in the rendered HTML", %{
+      conn: conn
+    } do
+      {:ok, _view, html} = live(conn, ~p"/m2m/clients")
+
+      refute html =~ @denied_client_name
+      refute html =~ @denied_client_id
+    end
+
+    @tag action: "M2M-A01"
+    test "the out-of-tenant client's name and ID appear nowhere in the rendered HTML", %{
+      conn: conn
+    } do
+      {:ok, _view, html} = live(conn, ~p"/m2m/clients")
+
+      refute html =~ @out_of_tenant_client_name
+      refute html =~ @out_of_tenant_client_id
+    end
+
+    @tag action: "M2M-A01"
+    test "no reveal control, no masked-secret column, and no secret value anywhere in the DOM",
+         %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/m2m/clients")
+
+      refute html =~ @valid_client_secret
+      refute has_element?(view, "th", "Secret")
+      refute has_element?(view, "[phx-click=\"reveal\"]")
+    end
+
+    @tag action: "M2M-A01"
+    test "row order is stable across two mounts", %{conn: conn} do
+      {:ok, view1, _html} = live(conn, ~p"/m2m/clients")
+      {:ok, view2, _html} = live(conn, ~p"/m2m/clients")
+
+      ids1 = row_client_ids(view1)
+      ids2 = row_client_ids(view2)
+
+      assert ids1 != []
+      assert ids1 == ids2
+    end
+  end
+
+  describe "M2M-A02 — empty state" do
+    @tag action: "M2M-A02"
+    test "with an empty seed section, #m2m-clients-empty renders and #m2m-clients-table does not",
+         %{conn: conn} do
+      use_backend(EmptyM2MClients)
+
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert has_element?(view, "#m2m-clients-empty")
+      refute has_element?(view, "#m2m-clients-table")
+    end
+
+    @tag action: "M2M-A02"
+    test "#new-m2m-client-button is present in the empty state", %{conn: conn} do
+      use_backend(EmptyM2MClients)
+
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert has_element?(view, "#new-m2m-client-button")
+    end
+
+    @tag action: "M2M-A02"
+    test "#new-m2m-client-button is also present in the populated state", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert has_element?(view, "#new-m2m-client-button")
+    end
+  end
+
+  describe "error states" do
+    @error_state_ids %{
+      not_configured: "m2m-clients-misconfigured",
+      unavailable: "m2m-clients-unavailable",
+      auth_expired: "m2m-clients-auth-expired"
+    }
+
+    for {kind, expected_id} <- @error_state_ids do
+      @tag kind: kind
+      @tag expected_id: expected_id
+      test "#{kind} renders its own state, mutually exclusive, shell intact, no client UI", %{
+        conn: conn,
+        kind: kind,
+        expected_id: expected_id
+      } do
+        use_backend(FailingM2MClients)
+        Application.put_env(:nucleus, FailingM2MClients, kind)
+
+        {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+        assert has_element?(view, "##{expected_id}")
+
+        for other_id <- Map.values(@error_state_ids) -- [expected_id] do
+          refute has_element?(view, "##{other_id}")
+        end
+
+        refute has_element?(view, "#m2m-clients-table")
+        refute has_element?(view, "#m2m-clients-empty")
+        refute has_element?(view, "#new-m2m-client-button")
+        # The shell survives every error kind (NAV-A07's equivalent for M2M).
+        assert has_element?(view, "#tenant-identifier")
+      end
+    end
+
+    test "live/2 returns {:ok, ...} for every error kind — the LiveView never crashes", %{
+      conn: conn
+    } do
+      for kind <- Error.kinds() do
+        use_backend(FailingM2MClients)
+        Application.put_env(:nucleus, FailingM2MClients, kind)
+
+        assert {:ok, _view, _html} = live(conn, ~p"/m2m/clients")
+      end
+    end
+  end
+
+  describe "placeholder create handler" do
+    test "clicking #new-m2m-client-button does not crash", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      html =
+        view
+        |> element("#new-m2m-client-button")
+        |> render_click()
+
+      assert html =~ "M2M Clients"
+    end
+  end
+
+  describe "navigation to Show" do
+    test "a row's view link navigates to /m2m/clients/:client_id and Show's stub mounts without crashing",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert {:ok, show_view, _html} =
+               view
+               |> element("#view-client-#{@valid_client_id}")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/m2m/clients/#{@valid_client_id}")
+
+      assert has_element?(show_view, "#m2m-client-detail-placeholder")
+    end
+  end
+end

--- a/test/nucleus_web/live/shell_test.exs
+++ b/test/nucleus_web/live/shell_test.exs
@@ -58,6 +58,19 @@ defmodule NucleusWeb.ShellTest do
   end
 
   @tag :unit
+  test "the sidebar M2M Clients item is a real link and navigates to this view", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    assert {:ok, m2m_view, _html} =
+             view
+             |> element("a", "M2M Clients")
+             |> render_click()
+             |> follow_redirect(conn, ~p"/m2m/clients")
+
+    assert has_element?(m2m_view, "#tenant-identifier")
+  end
+
+  @tag :unit
   test "shows the identity control with the dev email, and no sign-out control", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
 


### PR DESCRIPTION
## What

Implements `M2M-A01`/`M2M-A02`: a listing view for the tenant's M2M clients, showing client name, client ID, and creation date, with an empty state that carries a prominent create affordance. This activates the "M2M Clients" sidebar item, which was previously a disabled placeholder pending this ticket.

## How

- `Nucleus.M2M.list/1` fails closed on `DenyList.suffixes/0` before touching the adapter, filters through the same `visible?/1` predicate `fetch/2` already gates single-client reads with (so a client hidden from the list can't remain resolvable by URL — pinned by a dedicated test), and sorts deterministically (`client_name` case-insensitive, raw name as tiebreak). No audit event is emitted, matching the wiki's three-event table.
- `NucleusWeb.M2MClientsLive.Index` renders the list via `stream/3` with a separate `:client_count` assign (streams aren't enumerable), collapses every `Nucleus.Backend.Error` kind into one of three states (`:misconfigured`/`:unavailable`/`:auth_expired`) via the new shared `NucleusWeb.M2MClientsLive.States` component module, and puts the create button (`#new-m2m-client-button`) outside the empty-state conditional so it's present whether the list is empty or populated.
- A row whose per-client describe failed (`created_date_error`, from EN-10's Decision 6) still renders — the date cell shows an explicit "unavailable" state (`#m2m-client-date-unavailable-{id}`) rather than a blank cell or a dropped row.
- `NucleusWeb.M2MClientsLive.Show` is registered and ships as a stub (`#m2m-client-detail-placeholder`, no gate, no `fetch/2` call) so `Index`'s row links have somewhere real to land; M2M-S3 replaces its body without touching the router or `Index`.
- The sidebar's disabled `<span>` for M2M Clients is now a real `<.link navigate={...}>`; `shell_test.exs`'s coverage is updated accordingly rather than left disabled.
- Satisfies `M2M-A01` and `M2M-A02`.

## Record

`docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md` formalizes four decisions: the two-`LiveView`-module route split (`Index`/`Show`, the `phx.gen.live` pattern) already resolved on the issue thread before implementation started; `Nucleus.M2M.list/1` collapsing the deny-list gate into one call, mirroring `Nucleus.Secrets.list/2`'s precedent from ADR-0010; row DOM ids using the plain `client_id` rather than an ARN-style hash, since `ClientId`'s allowlist is already DOM-safe; and the create button living outside the empty-state conditional. `decisions-log.md` gets row #18 pointing at it, and `business-tech-bridge.md`'s M2M-Clients row/prose is updated to reflect `M2M-A01`/`A02` as claimed and covered and that `NucleusWeb.M2MClientsLive.Index`/`.Show` now exist (previously "does not exist yet"). `living-notes.md` was intentionally left untouched — nothing on its Technical Debt, Open Questions, or Active Projects lists moved as a direct result of this ticket, and the durable-record skill's own guidance is to skip that file when nothing on those lists changes.

## Divergence from the plan

None beyond what the issue itself had already decided. The two-module route split (Decision 7) reads like a divergence from a single-module-with-`handle_params/3` design, but that decision was made and recorded on the issue thread before this branch started — this PR follows the plan as amended, it doesn't amend it. Everything else matches the plan text: the sort order, the DOM-id contract, the error-kind collapsing scheme (`:not_configured`→misconfigured, `:auth_expired`→auth_expired, everything else→unavailable), the degrade-not-fail handling of `created_date_error` rows, and the placeholder `new_client` handler are all implemented as specified.

## Verification

`mix precommit` passed after both commits: 694 tests, 25 doctests, 0 failures, no formatting or `deps.unlock` diffs. New coverage: `Nucleus.M2M.list/1` (context tests for filtering, sorting, degrade-not-fail, no-audit, error kinds), `NucleusWeb.M2MClientsLive.Index`/`.Show` (list rendering, deny-list/tenant absence via raw-HTML `refute`, empty state, all three error states, create-button presence in both states, row navigation to the `Show` stub), and an updated `shell_test.exs` case asserting the sidebar link navigates to `/m2m/clients`.

Closes #35
