### PR TITLE
ENV-D1: amend Environments.md's unavailable-vs-not-found edge case

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.11 | Updated: 2026-08-20 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.12 | Updated: 2026-08-20 -->
 
 # Business ↔ Tech Bridge
 
@@ -49,6 +49,12 @@ to cite from test names and bug reports.
 | `Audit-and-Compliance.md` | `AUD-A01`–`A07` | 7 | `Nucleus.Audit` (emit-only; no local store — stateless constraint) | `test/nucleus/audit_test.exs` |
 | `API-Proxy.md` | `PRX-A01`–`A07` | 7 | Backing-API forwarding layer | `test/nucleus_web/proxy_test.exs` |
 | `Platform-Operations.md` | `OPS-A01`–`A13` | 13 | Health/readiness endpoints, config reference | `test/nucleus_web/ops_test.exs` |
+
+`ENV-A05`'s wording changed (ENV-D1) — the error matrix no longer collapses "environment list
+cannot be loaded" into the same "not found" case; it is now a distinct "temporarily unavailable"
+state, matching `SEC-A17` and `Nucleus.Environments.fetch/2`'s `:unavailable` kind. No action ID
+was added or removed, so the `ENV-A01`–`A07` / `7` count above is unchanged — a reader diffing
+against an older commit should read this as a wording fix, not a coverage change.
 
 **Most "Planned" columns are still unimplemented.** `NucleusWeb.Layouts` (app shell, header,
 sidebar) and `test/nucleus_web/live/shell_test.exs` now exist (EN-7) — a deliberate subset only,


### PR DESCRIPTION
## What

The wiki's `Environments.md` error matrix had a stale row claiming a failed environment-list load ("cannot reach the tenant API") is treated "the same as not found." That's been wrong since ADR-0009 shipped: `Nucleus.Environments.fetch/2` returns a distinct `:unavailable` kind for that case, and `NucleusWeb.SecretsLive` already renders two separate DOM states precisely so a reachability failure isn't confused with an unknown environment name. This PR bumps the `docs/requirements` submodule pointer to pick up the wiki's reword and notes the resulting requirement-wording change in the bridge file. No application code changes.

## How

- Wiki `Environments.md` (`nucleus.wiki` commit `e9743e2`, pushed separately) now describes a distinct "temporarily unavailable" state instead of collapsing it into "not found," bringing `ENV-A05`'s wording in line with the already-implemented behaviour.
- `docs/requirements` submodule pointer bumped from `a994520` to `e9743e2` to pull that edit into this repo.
- `business-tech-bridge.md` gets a short note flagging that `ENV-A05`'s wording changed — no action ID was added or removed, so the `ENV-A01`–`A07` / `7` count is unchanged. This is called out explicitly so a reader diffing against an older commit reads it as a wording fix, not a coverage change.
- Requirement IDs touched: `ENV-A05` (wording only). The wiki reword cites `SEC-A17` as precedent for the fail-closed "unavailable" state, matching the kind ADR-0009 already assigns in `Nucleus.Environments.fetch/2`.

## Record

No ADR, decisions-log entry, or living-notes change was written, and that's deliberate: this ticket settled no new architectural decision. `Nucleus.Environments.fetch/2`'s `:unavailable` kind was already decided and shipped in ADR-0009 — this PR only corrects a piece of documentation that had drifted out of sync with it. The one durable-record artifact that did change is `business-tech-bridge.md`, noting the `ENV-A05` wording shift (see above).

## Divergence from the plan

The issue's plan said to cross-reference ADR-0009 from the wiki page "if the wiki's ADR index supports it (check `Architecture-Decisions.md`)." Checking that page showed the wiki's own ADR index only covers ADR-0001–0007 — a separate, frozen numbering track from this repo's `docs/adr/` sequence (0001–0018, including 0009). No wiki page references anything past ADR-0007, and the repo owner confirmed the wiki ADRs are historical reference from project kickoff and are not maintained going forward; only this repo's `docs/adr/` matters now.

Given that, the wiki reword deliberately skips a cross-reference to ADR-0009 (which doesn't exist on the wiki's ADR track and won't be added there) and instead cites `SEC-A17` — a real, maintained wiki requirement that already states the same fail-closed precedent. This is a conscious adaptation of the plan's literal instruction, not an oversight.

## Verification

`mix precommit` passed clean: 694 passed (25 doctests, 669 tests), 14 skipped, 13 excluded, 0 failures. This is a documentation/submodule-pointer change only — no application code was touched, so no new tests were added.

Closes #51
