### PR TITLE
ENV-S1: environment detail view, resolution states, and Manage Secrets

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.12 | Updated: 2026-08-20 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.13 | Updated: 2026-08-20 -->
 
 # Business ↔ Tech Bridge
 
@@ -89,6 +89,16 @@ and the `Nucleus.M2M.DenyList` boundary `list/1` reads. Every other row is unimp
 names are the agreed target so that work lands consistently — treat them as the convention to
 follow, and correct this table if a better structure emerges.
 
+`NucleusWeb.EnvironmentsLive` and `test/nucleus_web/live/environments_live_test.exs` also now
+exist (ENV-S1/#52): `ENV-A02`–`A07` are claimed and covered. `ENV-A01` (sidebar category
+grouping/expand) remains unclaimed — `NAV-S1`'s job. The module mirrors `NucleusWeb.SecretsLive`'s
+`handle_params/3`/kind→DOM-id pattern one boundary narrower (`Nucleus.Environments.fetch/2` only,
+no `Nucleus.Secrets` boundary to also match on), renders the IRI as escaped text with a
+`<.copy_button>` rather than an `href`, and validates `accent_color` against a hex allowlist
+before it ever reaches a `style=` attribute — a non-conforming value falls back to a neutral
+swatch, with the raw string still shown as text. The sidebar's `#environments-list` link
+(`lib/nucleus_web/components/layouts.ex`) now points at this route instead of straight to
+`.../secrets`; `Manage Secrets` on the detail page is what reaches `NucleusWeb.SecretsLive` now.
 
 Two conformance notes worth carrying forward, both recorded in
 `docs/adr/0012-secret-reveal-modal-and-icon-only-copy-affordances.md`:

--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.13 | Updated: 2026-08-20 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.14 | Updated: 2026-08-20 -->
 
 # Business ↔ Tech Bridge
 
@@ -94,9 +94,12 @@ exist (ENV-S1/#52): `ENV-A02`–`A07` are claimed and covered. `ENV-A01` (sideba
 grouping/expand) remains unclaimed — `NAV-S1`'s job. The module mirrors `NucleusWeb.SecretsLive`'s
 `handle_params/3`/kind→DOM-id pattern one boundary narrower (`Nucleus.Environments.fetch/2` only,
 no `Nucleus.Secrets` boundary to also match on), renders the IRI as escaped text with a
-`<.copy_button>` rather than an `href`, and validates `accent_color` against a hex allowlist
-before it ever reaches a `style=` attribute — a non-conforming value falls back to a neutral
-swatch, with the raw string still shown as text. The sidebar's `#environments-list` link
+`<.copy_button>` alongside an `#open-iri` "open in new tab" link — `iri_href/1` only allows the
+link when the IRI's scheme is `http`/`https` with a host, so an unsafe scheme (e.g.
+`javascript:`) never reaches an `href`, only the raw text — and validates `accent_color` against
+a hex allowlist before it ever reaches a `style=` attribute — a non-conforming value falls back
+to a neutral swatch, with the raw string still shown as text. The sidebar's `#environments-list`
+link
 (`lib/nucleus_web/components/layouts.ex`) now points at this route instead of straight to
 `.../secrets`; `Manage Secrets` on the detail page is what reaches `NucleusWeb.SecretsLive` now.
 

--- a/lib/nucleus_web/components/core_components.ex
+++ b/lib/nucleus_web/components/core_components.ex
@@ -426,6 +426,39 @@ defmodule NucleusWeb.CoreComponents do
   end
 
   @doc """
+  Renders a description list — label/value rows, each split into a muted,
+  fixed-width label and its value on the same line, separated by a thin
+  divider. Unlike `list/1`, label and value sit side by side instead of
+  being stacked, which reads less like a table for record attributes.
+
+  ## Examples
+
+      <.description_list>
+        <:item title="Title">{@post.title}</:item>
+        <:item title="Views">{@post.views}</:item>
+      </.description_list>
+  """
+  slot :item, required: true do
+    attr :title, :string, required: true
+  end
+
+  def description_list(assigns) do
+    ~H"""
+    <dl class="divide-y divide-base-300">
+      <div
+        :for={item <- @item}
+        class="flex flex-col gap-1 py-3 sm:flex-row sm:items-baseline sm:gap-4"
+      >
+        <dt class="w-full shrink-0 text-sm font-medium text-base-content/60 sm:w-40">
+          {item.title}
+        </dt>
+        <dd class="flex-1 text-sm">{render_slot(item)}</dd>
+      </div>
+    </dl>
+    """
+  end
+
+  @doc """
   Renders a [Heroicon](https://heroicons.com).
 
   Heroicons come in three styles – outline, solid, and mini.

--- a/lib/nucleus_web/components/layouts.ex
+++ b/lib/nucleus_web/components/layouts.ex
@@ -133,7 +133,7 @@ defmodule NucleusWeb.Layouts do
                   <% else %>
                     <ul id="environments-list" class="menu menu-sm p-0">
                       <li :for={env <- environments}>
-                        <.link navigate={~p"/environments/#{env.short_name}/secrets"}>
+                        <.link navigate={~p"/environments/#{env.short_name}"}>
                           {env.label || env.short_name}
                         </.link>
                       </li>

--- a/lib/nucleus_web/live/environments_live.ex
+++ b/lib/nucleus_web/live/environments_live.ex
@@ -1,0 +1,205 @@
+defmodule NucleusWeb.EnvironmentsLive do
+  @moduledoc """
+  An environment's detail view — `ENV-A02`–`ENV-A07`.
+
+  Single module, no index/show split: there is no `/environments` list route
+  (the sidebar is the index — `Environments.md`'s "Out of scope" section),
+  so there is nothing for a second module to be reached from except this
+  one's own error states.
+
+  ## Validated in `handle_params/3`, not `mount/3`
+
+  Mirrors `NucleusWeb.SecretsLive` and ADR-0009: the environment name comes
+  from the URL, and a `<.link patch={...}>` between two environments does not
+  remount the LiveView. `handle_params/3` runs on every patch; `mount/3` does
+  not, so a check placed there would let a user patch from a validated
+  environment straight into an unvalidated one.
+
+  ## `Nucleus.Environments.fetch/2` directly, no proxy route
+
+  `Environments.md`'s API contract names `GET /api/proxy/environments`, but
+  that line is advisory — `PRX-A01`–`A07` is a separate, unstarted feature,
+  and `Nucleus.Environments.fetch/2` already exists in-process, the same
+  boundary `SecretsLive` calls. Nothing here touches `router.ex`'s `:api`
+  pipeline.
+
+  ## Every outcome gets its own assign and DOM id
+
+  `Environments.fetch/2` only ever tags an error `boundary: :tenant_api`
+  (the one boundary it touches), but this `case` still matches every
+  `Nucleus.Backend.Error.kinds/0` value so the view never crashes if that
+  ever changes:
+
+  | Outcome | `:environment_status` | DOM id |
+  |---|---|---|
+  | `{:ok, env}` | `:ok` | `#environment-detail` |
+  | `kind: :invalid` | `:invalid` | `#environment-invalid` |
+  | `kind: :not_found` | `:not_found` | `#environment-not-found` (`ENV-A05`) |
+  | `kind: :unavailable` | `:unavailable` | `#environment-unavailable` (the `ENV-D1` amendment — distinct from not-found) |
+  | `kind: :auth_expired` | `:auth_expired` | `#environment-auth-expired` (placeholder copy; `SEC-S7`/#15 owns real retry semantics) |
+  | anything else (`:already_exists`, `:not_configured`) | `:unavailable` | `#environment-unavailable` |
+
+  `:not_configured` collapsing to `:unavailable` happens one layer down, in
+  `Nucleus.Environments.fetch/2` itself (`SEC-A17`) — it never reaches this
+  `case` as its own kind. It is listed above only because the catch-all
+  branch must account for every value `kinds/0` could carry.
+
+  Every branch keeps `<Layouts.app>` (and its sidebar) intact, so a crashed
+  or dead-ended LiveView is never how any of these render.
+
+  ## Read-only — `ENV-A07`
+
+  Environment metadata is owned by the tenant's own backing systems, not by
+  Nucleus. There is no form, no button with a write `phx-click`, and no
+  delete affordance anywhere in this module's template — the absence itself
+  is the deliverable.
+
+  ## The IRI is text, never an `href` — and the accent color is validated before use
+
+  `Nucleus.TenantApi.Environment.from_api/1` only validates that `iri` is a
+  string, not that it is a safe URI scheme — rendering it as a link target
+  would let a tenant's own API hand back a `javascript:` scheme. HEEx's
+  default escaping renders it as inert text instead.
+
+  `accent_color` has the same problem in a different attribute: an
+  unvalidated string interpolated into a `style` attribute is the same
+  injection class as an unvalidated `href`. `valid_hex_color?/1` gates it
+  against a hex-color allowlist before it ever reaches a `style=` value; a
+  non-conforming value falls back to a neutral swatch, with the raw string
+  still shown as escaped text so nothing about the environment is hidden,
+  only untrusted as a style input.
+
+  ## Archived environments render fully — `ENV-A06`
+
+  `Environments.fetch/2` resolves archived environments the same as active
+  ones (`Nucleus.Environments`'s own moduledoc) — this module does not filter
+  them a second time. Only `NucleusWeb.EnvironmentsHook` (the sidebar) hides
+  archived environments from navigation; a direct URL always reaches here.
+  """
+
+  use NucleusWeb, :live_view
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Environments
+
+  @hex_color ~r/\A#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\z/
+
+  @impl Phoenix.LiveView
+  def handle_params(%{"environment" => environment}, _uri, socket) do
+    {:noreply, fetch_environment(socket, environment)}
+  end
+
+  defp fetch_environment(socket, environment) do
+    socket = assign(socket, :environment_name, environment)
+
+    case Environments.fetch(environment, socket.assigns.current_scope.token) do
+      {:ok, env} ->
+        assign(socket, environment_status: :ok, environment: env)
+
+      {:error, %Error{kind: :invalid, boundary: :tenant_api}} ->
+        assign(socket, environment_status: :invalid, environment: nil)
+
+      {:error, %Error{kind: :not_found, boundary: :tenant_api}} ->
+        assign(socket, environment_status: :not_found, environment: nil)
+
+      {:error, %Error{kind: :unavailable, boundary: :tenant_api}} ->
+        assign(socket, environment_status: :unavailable, environment: nil)
+
+      {:error, %Error{kind: :auth_expired}} ->
+        assign(socket, environment_status: :auth_expired, environment: nil)
+
+      {:error, %Error{}} ->
+        assign(socket, environment_status: :unavailable, environment: nil)
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope} environments={@environments}>
+      <.empty_state
+        :if={@environment_status == :invalid}
+        id="environment-invalid"
+        icon="hero-shield-exclamation"
+        message="This is not a valid environment name."
+      />
+      <.empty_state
+        :if={@environment_status == :not_found}
+        id="environment-not-found"
+        icon="hero-question-mark-circle"
+        message={"No environment named \"#{@environment_name}\" was found for this tenant."}
+      />
+      <.empty_state
+        :if={@environment_status == :unavailable}
+        id="environment-unavailable"
+        icon="hero-exclamation-triangle"
+        message="Can't verify this environment right now. Try again shortly."
+      />
+      <.empty_state
+        :if={@environment_status == :auth_expired}
+        id="environment-auth-expired"
+        icon="hero-lock-closed"
+        message="This environment can't be reached right now."
+      />
+
+      <div :if={@environment_status == :ok} id="environment-detail">
+        <div class="flex items-center justify-between gap-4 pb-4">
+          <h1 class="text-lg font-semibold">{@environment.label || @environment.short_name}</h1>
+          <.link
+            id="manage-secrets-link"
+            navigate={~p"/environments/#{@environment.short_name}/secrets"}
+            class="btn btn-primary"
+          >
+            Manage Secrets
+          </.link>
+        </div>
+
+        <.list>
+          <:item title="Short name">{@environment.short_name}</:item>
+          <:item title="Label">{@environment.label || @environment.short_name}</:item>
+          <:item :if={@environment.iri} title="IRI">
+            <div class="flex items-center gap-1">
+              <span class="break-all">{@environment.iri}</span>
+              <.copy_button id="copy-iri" value={@environment.iri} label="Copy IRI" />
+            </div>
+          </:item>
+          <:item title="Accent color">
+            <div class="flex items-center gap-2">
+              <span
+                :if={@environment.accent_color}
+                class="inline-block size-4 rounded-full border border-base-300"
+                style={accent_style(@environment.accent_color)}
+              />
+              <span :if={!@environment.accent_color} class="text-base-content/50">None</span>
+              <span :if={@environment.accent_color}>{@environment.accent_color}</span>
+            </div>
+          </:item>
+          <:item title="Categories">
+            {if @environment.categories == [],
+              do: "None",
+              else: Enum.join(@environment.categories, ", ")}
+          </:item>
+          <:item title="Status">
+            <.badge variant={if @environment.archived?, do: "neutral", else: "success"}>
+              {if @environment.archived?, do: "Archived", else: "Active"}
+            </.badge>
+          </:item>
+          <:item :if={@environment.description} title="Description">
+            <p id="environment-description">{@environment.description}</p>
+          </:item>
+        </.list>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  # A validated `style` value, or `nil` when `color` fails the hex allowlist
+  # — the swatch renders neutral and the raw string is still shown as
+  # escaped text alongside it (see the moduledoc, "The IRI is text...").
+  defp accent_style(color) do
+    if valid_hex_color?(color), do: "background-color: #{color};", else: nil
+  end
+
+  defp valid_hex_color?(color) when is_binary(color), do: Regex.match?(@hex_color, color)
+  defp valid_hex_color?(_color), do: false
+end

--- a/lib/nucleus_web/live/environments_live.ex
+++ b/lib/nucleus_web/live/environments_live.ex
@@ -54,12 +54,18 @@ defmodule NucleusWeb.EnvironmentsLive do
   delete affordance anywhere in this module's template — the absence itself
   is the deliverable.
 
-  ## The IRI is text, never an `href` — and the accent color is validated before use
+  ## The IRI and the accent color are both validated before use
 
   `Nucleus.TenantApi.Environment.from_api/1` only validates that `iri` is a
-  string, not that it is a safe URI scheme — rendering it as a link target
-  would let a tenant's own API hand back a `javascript:` scheme. HEEx's
-  default escaping renders it as inert text instead.
+  string, not that it is a safe URI scheme — interpolating it directly into
+  an `href` would let a tenant's own API hand back a `javascript:` scheme.
+  `iri_href/1` gates it against an `http`/`https`-with-host allowlist before
+  it is ever used as a link target; only then does the "open in a new tab"
+  button (`#open-iri`) render at all, and it always pairs
+  `target="_blank"` with `rel="noopener noreferrer"` so the new tab can't
+  reach back into this one. The raw IRI is always shown as HEEx-escaped
+  text next to it regardless of whether it passed validation — the text
+  never depends on the link.
 
   `accent_color` has the same problem in a different attribute: an
   unvalidated string interpolated into a `style` attribute is the same
@@ -83,6 +89,7 @@ defmodule NucleusWeb.EnvironmentsLive do
   alias Nucleus.Environments
 
   @hex_color ~r/\A#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\z/
+  @safe_iri_schemes ~w(http https)
 
   @impl Phoenix.LiveView
   def handle_params(%{"environment" => environment}, _uri, socket) do
@@ -154,13 +161,34 @@ defmodule NucleusWeb.EnvironmentsLive do
           </.link>
         </div>
 
-        <.list>
+        <.description_list>
           <:item title="Short name">{@environment.short_name}</:item>
           <:item title="Label">{@environment.label || @environment.short_name}</:item>
+          <:item title="Status">
+            <.badge variant={if @environment.archived?, do: "neutral", else: "success"}>
+              {if @environment.archived?, do: "Archived", else: "Active"}
+            </.badge>
+          </:item>
           <:item :if={@environment.iri} title="IRI">
             <div class="flex items-center gap-1">
               <span class="break-all">{@environment.iri}</span>
               <.copy_button id="copy-iri" value={@environment.iri} label="Copy IRI" />
+              <span
+                :if={iri_href(@environment.iri)}
+                class="tooltip"
+                data-tip="Open IRI in new tab"
+              >
+                <.link
+                  id="open-iri"
+                  href={iri_href(@environment.iri)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="btn btn-ghost btn-sm btn-square"
+                  aria-label="Open IRI in new tab"
+                >
+                  <.icon name="hero-arrow-top-right-on-square" class="size-4" />
+                </.link>
+              </span>
             </div>
           </:item>
           <:item title="Accent color">
@@ -179,15 +207,10 @@ defmodule NucleusWeb.EnvironmentsLive do
               do: "None",
               else: Enum.join(@environment.categories, ", ")}
           </:item>
-          <:item title="Status">
-            <.badge variant={if @environment.archived?, do: "neutral", else: "success"}>
-              {if @environment.archived?, do: "Archived", else: "Active"}
-            </.badge>
-          </:item>
           <:item :if={@environment.description} title="Description">
             <p id="environment-description">{@environment.description}</p>
           </:item>
-        </.list>
+        </.description_list>
       </div>
     </Layouts.app>
     """
@@ -195,11 +218,30 @@ defmodule NucleusWeb.EnvironmentsLive do
 
   # A validated `style` value, or `nil` when `color` fails the hex allowlist
   # — the swatch renders neutral and the raw string is still shown as
-  # escaped text alongside it (see the moduledoc, "The IRI is text...").
+  # escaped text alongside it (see the moduledoc, "The IRI and the accent
+  # color are both validated before use").
   defp accent_style(color) do
     if valid_hex_color?(color), do: "background-color: #{color};", else: nil
   end
 
   defp valid_hex_color?(color) when is_binary(color), do: Regex.match?(@hex_color, color)
   defp valid_hex_color?(_color), do: false
+
+  # `iri`, or `nil` when it fails the `http`/`https`-with-host allowlist —
+  # the "open in a new tab" button only renders when this returns a value
+  # (see the moduledoc, "The IRI and the accent color are both validated
+  # before use"). The raw string is always shown as escaped text regardless
+  # of this check.
+  defp iri_href(iri) when is_binary(iri) do
+    case URI.parse(iri) do
+      %URI{scheme: scheme, host: host}
+      when scheme in @safe_iri_schemes and is_binary(host) and host != "" ->
+        iri
+
+      _other ->
+        nil
+    end
+  end
+
+  defp iri_href(_iri), do: nil
 end

--- a/lib/nucleus_web/router.ex
+++ b/lib/nucleus_web/router.ex
@@ -41,6 +41,9 @@ defmodule NucleusWeb.Router do
     # environments to, per this ticket's own plan.
     live_session :authenticated,
       on_mount: [{NucleusWeb.ScopeHook, :assign}, {NucleusWeb.EnvironmentsHook, :assign}] do
+      # No conflict with the detail route below — Phoenix disambiguates on
+      # the trailing `/secrets` segment.
+      live "/environments/:environment", EnvironmentsLive, :show
       live "/environments/:environment/secrets", SecretsLive, :index
 
       # Two modules, not one switching on `handle_params/3` — M2M-S2

--- a/test/nucleus_web/live/environments_live_test.exs
+++ b/test/nucleus_web/live/environments_live_test.exs
@@ -1,0 +1,236 @@
+defmodule NucleusWeb.EnvironmentsLiveTest do
+  # `seed_environment/1` and the backend swap below both mutate node-global
+  # state (`Nucleus.Backend.Seed`, `:nucleus, :backends`).
+  use NucleusWeb.LiveCase, async: false
+
+  alias Nucleus.Backend.Error
+
+  defmodule FailingTenantApi do
+    @moduledoc """
+    A `Nucleus.TenantApi` implementation whose `list_environments/1` always
+    fails with a controllable `Nucleus.Backend.Error` — the same swapped-module
+    technique `Nucleus.EnvironmentsTest.ExplodingTenantApi` and
+    `Nucleus.M2MTest.FailingM2MClients` use.
+
+    `LOCAL_FORCE_ERROR` (`Nucleus.Backend.Faults`) is node-global and would
+    also be picked up by `NucleusWeb.EnvironmentsHook`'s own call to the same
+    `:tenant_api` boundary on the very same mount, and by any other
+    `async: false` test in the same run — a swapped module is the only way
+    to control the returned kind precisely, per test.
+    """
+    @behaviour Nucleus.TenantApi
+
+    @impl Nucleus.TenantApi
+    def list_environments(_token) do
+      kind = Application.get_env(:nucleus, __MODULE__, :unavailable)
+      {:error, Error.new(kind, :tenant_api, "forced for test", %{})}
+    end
+
+    @impl Nucleus.TenantApi
+    def health_check, do: raise("should not be called")
+  end
+
+  defp use_failing_tenant_api(kind) do
+    original = Application.get_env(:nucleus, :backends, [])
+    on_exit(fn -> Application.put_env(:nucleus, :backends, original) end)
+
+    Application.put_env(:nucleus, FailingTenantApi, kind)
+
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(original, :tenant_api, FailingTenantApi)
+    )
+  end
+
+  describe "ENV-A02 — view environment details" do
+    @tag action: "ENV-A02"
+    test "prod (multi-category, has a description) shows every field", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "prod")
+
+      assert has_element?(view, "#environment-detail")
+      assert has_element?(view, "#environment-detail", "prod")
+      assert has_element?(view, "#environment-description")
+    end
+
+    @tag action: "ENV-A02"
+    test "the IRI is rendered as text, not a link", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "prod")
+
+      html = view |> element("#environment-detail") |> render()
+      doc = LazyHTML.from_fragment(html)
+
+      refute Enum.empty?(LazyHTML.query(doc, "[id=\"copy-iri\"]"))
+      assert Enum.empty?(LazyHTML.query(doc, "a[href*=\"://\"]"))
+    end
+
+    @tag action: "ENV-A02"
+    test "sandbox (no description) omits the description row entirely", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "sandbox")
+
+      assert has_element?(view, "#environment-detail")
+      refute has_element?(view, "#environment-description")
+    end
+
+    @tag action: "ENV-A02"
+    test "dev (no categories) renders \"None\" without breaking the layout", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "dev")
+
+      assert has_element?(view, "#environment-detail")
+      assert has_element?(view, "#environment-detail", "None")
+    end
+  end
+
+  describe "ENV-A03 — distinguish active from archived environments" do
+    @tag action: "ENV-A03"
+    test "an active environment is badged Active", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "prod")
+
+      assert has_element?(view, "#environment-detail .badge", "Active")
+      refute has_element?(view, "#environment-detail .badge", "Archived")
+    end
+
+    @tag action: "ENV-A03"
+    test "legacy-qa is badged Archived", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "legacy-qa")
+
+      assert has_element?(view, "#environment-detail .badge", "Archived")
+      refute has_element?(view, "#environment-detail .badge", "Active")
+    end
+  end
+
+  describe "ENV-A04 — navigate from an environment to its secrets" do
+    @tag action: "ENV-A04"
+    test "#manage-secrets-link navigates to that environment's secrets view", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "prod")
+
+      assert has_element?(view, "#manage-secrets-link")
+
+      assert {:ok, secrets_view, _html} =
+               view
+               |> element("#manage-secrets-link")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/environments/prod/secrets")
+
+      assert has_element?(secrets_view, "#tenant-identifier")
+    end
+  end
+
+  describe "ENV-A05 — handle an unknown or mistyped environment" do
+    @tag action: "ENV-A05"
+    test "an unknown short name renders not-found, not a crash, not unavailable", %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "nope")
+
+      assert has_element?(view, "#environment-not-found")
+      refute has_element?(view, "#environment-unavailable")
+      refute has_element?(view, "#environment-detail")
+    end
+  end
+
+  describe "ENV-A06 — archived environments are reachable directly" do
+    @tag action: "ENV-A06"
+    test "legacy-qa is reachable by direct URL, renders detail badged Archived, and its manage-secrets link works",
+         %{conn: conn} do
+      assert {:ok, view, _html} = live_environment(conn, "legacy-qa")
+
+      assert has_element?(view, "#environment-detail")
+      assert has_element?(view, "#environment-detail .badge", "Archived")
+
+      assert {:ok, secrets_view, _html} =
+               view
+               |> element("#manage-secrets-link")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/environments/legacy-qa/secrets")
+
+      assert has_element?(secrets_view, "#tenant-identifier")
+    end
+  end
+
+  describe "ENV-A07 — environments view is read-only" do
+    @tag action: "ENV-A07"
+    test "no form, no write phx-click, no delete affordance anywhere in the detail view", %{
+      conn: conn
+    } do
+      assert {:ok, view, _html} = live_environment(conn, "prod")
+
+      html = view |> element("#environment-detail") |> render()
+      doc = LazyHTML.from_fragment(html)
+
+      assert Enum.empty?(LazyHTML.query(doc, "form"))
+      assert Enum.empty?(LazyHTML.query(doc, "[phx-click]"))
+      assert Enum.empty?(LazyHTML.query(doc, "[phx-submit]"))
+      refute html =~ ~r/delete/i
+      refute html =~ ~r/>\s*edit\s*</i
+      refute html =~ ~r/>\s*create\s*</i
+    end
+  end
+
+  describe "an invalid environment name" do
+    test "renders environment-invalid, mirroring SEC-A15's test", %{conn: conn} do
+      assert {:ok, view, _html} = live(conn, "/environments/..%2f..%2fetc")
+
+      assert has_element?(view, "#environment-invalid")
+      refute has_element?(view, "#environment-detail")
+    end
+  end
+
+  describe "the unavailable state is distinct from not-found" do
+    test "a swapped-module tenant_api failure renders environment-unavailable", %{conn: conn} do
+      use_failing_tenant_api(:unavailable)
+
+      assert {:ok, view, _html} = live_environment(conn, "prod")
+
+      assert has_element?(view, "#environment-unavailable")
+      refute has_element?(view, "#environment-not-found")
+      refute has_element?(view, "#environment-detail")
+    end
+  end
+
+  describe "every Nucleus.Backend.Error kind renders a state, never crashes" do
+    test "the shell stays intact and live/2 never returns an error tuple, for every kind", %{
+      conn: conn
+    } do
+      for kind <- Error.kinds() do
+        use_failing_tenant_api(kind)
+
+        assert {:ok, view, _html} = live_environment(conn, "prod"),
+               "expected live/2 to succeed for kind #{inspect(kind)}"
+
+        assert has_element?(view, "#tenant-identifier")
+        refute has_element?(view, "#environment-detail")
+      end
+    end
+  end
+
+  describe "accent color and IRI are never interpolated raw" do
+    test "a malicious iri and accent_color render as escaped text, never as href or unescaped style",
+         %{conn: conn} do
+      seed_environment(%{
+        "shortName" => "malicious-env",
+        "iri" => "javascript:alert(1)",
+        "accentColor" => "red;}</style><script>"
+      })
+
+      assert {:ok, view, _html} = live_environment(conn, "malicious-env")
+
+      assert has_element?(view, "#environment-detail")
+
+      html = view |> element("#environment-detail") |> render()
+      doc = LazyHTML.from_fragment(html)
+
+      # Never an href.
+      hrefs = doc |> LazyHTML.query("a[href]") |> LazyHTML.attribute("href")
+      refute Enum.any?(hrefs, &(&1 =~ "javascript:"))
+
+      # Never interpolated unvalidated into a style attribute.
+      styles = doc |> LazyHTML.query("[style]") |> LazyHTML.attribute("style")
+      refute Enum.any?(styles, &(&1 =~ "red;}"))
+      refute html =~ "</style><script>"
+
+      # Falls back to a neutral swatch, and both raw values still show up as
+      # escaped text.
+      assert LazyHTML.text(doc) =~ "javascript:alert(1)"
+      assert LazyHTML.text(doc) =~ "red;}</style><script>"
+    end
+  end
+end

--- a/test/nucleus_web/live/environments_live_test.exs
+++ b/test/nucleus_web/live/environments_live_test.exs
@@ -54,14 +54,41 @@ defmodule NucleusWeb.EnvironmentsLiveTest do
     end
 
     @tag action: "ENV-A02"
-    test "the IRI is rendered as text, not a link", %{conn: conn} do
+    test "the IRI is shown as text, with a copy button and a validated open-in-new-tab link",
+         %{conn: conn} do
       assert {:ok, view, _html} = live_environment(conn, "prod")
 
       html = view |> element("#environment-detail") |> render()
       doc = LazyHTML.from_fragment(html)
 
       refute Enum.empty?(LazyHTML.query(doc, "[id=\"copy-iri\"]"))
-      assert Enum.empty?(LazyHTML.query(doc, "a[href*=\"://\"]"))
+      assert LazyHTML.text(doc) =~ "https://tenant.example.com/environment/prod"
+
+      open_iri = LazyHTML.query(doc, "[id=\"open-iri\"]")
+      refute Enum.empty?(open_iri)
+
+      assert LazyHTML.attribute(open_iri, "href") == [
+               "https://tenant.example.com/environment/prod"
+             ]
+
+      assert LazyHTML.attribute(open_iri, "target") == ["_blank"]
+      assert LazyHTML.attribute(open_iri, "rel") == ["noopener noreferrer"]
+    end
+
+    @tag action: "ENV-A02"
+    test "an iri with an unsafe scheme renders as text with no open-in-new-tab link", %{
+      conn: conn
+    } do
+      seed_environment(%{"shortName" => "mailto-env", "iri" => "mailto:ops@example.com"})
+
+      assert {:ok, view, _html} = live_environment(conn, "mailto-env")
+
+      html = view |> element("#environment-detail") |> render()
+      doc = LazyHTML.from_fragment(html)
+
+      refute Enum.empty?(LazyHTML.query(doc, "[id=\"copy-iri\"]"))
+      assert Enum.empty?(LazyHTML.query(doc, "[id=\"open-iri\"]"))
+      assert LazyHTML.text(doc) =~ "mailto:ops@example.com"
     end
 
     @tag action: "ENV-A02"
@@ -218,9 +245,10 @@ defmodule NucleusWeb.EnvironmentsLiveTest do
       html = view |> element("#environment-detail") |> render()
       doc = LazyHTML.from_fragment(html)
 
-      # Never an href.
+      # Never an href, and no open-in-new-tab link is rendered at all.
       hrefs = doc |> LazyHTML.query("a[href]") |> LazyHTML.attribute("href")
       refute Enum.any?(hrefs, &(&1 =~ "javascript:"))
+      assert Enum.empty?(LazyHTML.query(doc, "[id=\"open-iri\"]"))
 
       # Never interpolated unvalidated into a style attribute.
       styles = doc |> LazyHTML.query("[style]") |> LazyHTML.attribute("style")

--- a/test/nucleus_web/live/secrets_flow_test.exs
+++ b/test/nucleus_web/live/secrets_flow_test.exs
@@ -6,7 +6,9 @@ defmodule NucleusWeb.SecretsFlowTest do
   through `Nucleus.Environments` (`SEC-S1`), but renders no secrets UI of
   its own yet (`SEC-S2` builds the list). The shell's environment-picker
   navigation is real (EN-7) and worth exercising end to end: load one
-  environment's secrets page, then follow a sidebar link to another.
+  environment's secrets page, follow a sidebar link to another environment's
+  detail view (`ENV-S1` repointed the sidebar there), then on to its secrets
+  via "Manage Secrets" (`ENV-A04`).
 
   Unlike `Phoenix.LiveViewTest`'s `live/2`, `PhoenixTest.visit/2` returns a
   session that also seamlessly follows a *static* page — nothing here
@@ -29,7 +31,7 @@ defmodule NucleusWeb.SecretsFlowTest do
   import PhoenixTest
 
   @tag :unit
-  test "an ops user follows the sidebar from one environment's secrets page to another", %{
+  test "an ops user follows the sidebar to an environment's detail, then to its secrets", %{
     conn: conn
   } do
     conn
@@ -37,6 +39,9 @@ defmodule NucleusWeb.SecretsFlowTest do
     |> assert_has("#tenant-identifier")
     |> assert_has("#environments-list", text: "Staging", timeout: 100)
     |> click_link("Staging")
+    |> assert_path(~p"/environments/staging")
+    |> assert_has("#environment-detail")
+    |> click_link("Manage Secrets")
     |> assert_path(~p"/environments/staging/secrets")
     |> assert_has("#tenant-identifier")
   end

--- a/test/support/live_case.ex
+++ b/test/support/live_case.ex
@@ -54,4 +54,16 @@ defmodule NucleusWeb.LiveCase do
       Phoenix.LiveViewTest.live(unquote(conn), "/environments/#{unquote(environment)}/secrets")
     end
   end
+
+  @doc """
+  Mounts `NucleusWeb.EnvironmentsLive` for `environment`, the
+  `/environments/:environment` detail route the sidebar now links to.
+
+  A macro for the same reason as `live_secrets/2` above.
+  """
+  defmacro live_environment(conn, environment) do
+    quote do
+      Phoenix.LiveViewTest.live(unquote(conn), "/environments/#{unquote(environment)}")
+    end
+  end
 end


### PR DESCRIPTION
## What

This adds the environment detail view — `NucleusWeb.EnvironmentsLive` at `/environments/:environment` — so an environment's metadata (short name, label, IRI, accent color, categories, active/archived status, optional description) can be viewed directly, distinguished from its secrets, and reached without going through the Secrets page first. Previously the sidebar linked straight from an environment name to `/environments/:env/secrets`; it now lands on this detail view, with a "Manage Secrets" link taking the user on to secrets from there. A follow-up commit adds a validated "open in a new tab" link next to the IRI's copy button, and switches the detail layout to a description-list style with label and value on the same line.

## How

- `NucleusWeb.EnvironmentsLive` resolves the environment in `handle_params/3` (not `mount/3`), mirroring `NucleusWeb.SecretsLive`'s pattern so a `<.link patch={...}>` between environments re-validates on every patch, not just on first mount.
- It calls `Nucleus.Environments.fetch/2` directly — no proxy route, no `:api` pipeline change — matching the boundary `SecretsLive` already uses.
- Every `Nucleus.Backend.Error.kinds/0` value maps to a status/DOM-id pair (`#environment-invalid`, `#environment-not-found`, `#environment-unavailable`, `#environment-auth-expired`), with an explicit catch-all so an unrecognized kind still falls through to `:unavailable` instead of crashing the view. `#environment-unavailable` and `#environment-not-found` are kept distinct, per ENV-D1's amendment.
- The IRI renders as escaped text with a `<.copy_button>`, never an `href`; `accent_color` is checked against a hex-color regex before it's allowed into a `style=` attribute, falling back to a neutral swatch with the raw value still shown as text otherwise. Both guard against the tenant's own API handing back an unsafe value.
- The description row and categories row are conditionally rendered/formatted (`None` for an empty category list, row omitted entirely when no description) rather than shown blank.
- The sidebar's `#environments-list` link (`layouts.ex`) now points at this new route instead of directly at `/secrets`; `secrets_flow_test.exs` was updated to walk sidebar → detail → "Manage Secrets" → secrets.
- `live_environment/2` was added to `NucleusWeb.LiveCase` alongside the existing `live_secrets/2`.
- Test coverage (`environments_live_test.exs`) exercises each action tag directly, plus edge cases beyond the explicit acceptance list: an invalid name, the unavailable-vs-not-found distinctness (via a swapped `TenantApi` module rather than the node-global fault injector), every `Backend.Error` kind in turn, and IRI/accent-color injection attempts seeded through the existing `seed_environment/1` helper.
- A new `description_list/1` component in `core_components.ex` replaces `list/1` for this view's layout: label and value sit side by side on one line (divided by a thin border) instead of `list/1`'s stacked bold-title-over-value rows. `list/1` itself is left in place and is now unused elsewhere in the codebase.
- The IRI row gets a `#open-iri` "open in a new tab" link next to the copy button, gated by a new `iri_href/1` helper that only allows `http`/`https` schemes with a host — mirroring the existing `accent_color` hex-allowlist pattern — so an unsafe scheme (e.g. `javascript:`) never becomes an `href`, only escaped text. The link always pairs `target="_blank"` with `rel="noopener noreferrer"`. Status also moved up to sit directly under Label in the row order.

Satisfies **ENV-A02, ENV-A03, ENV-A04, ENV-A05, ENV-A06, ENV-A07**. `ENV-A01` (sidebar category grouping) remains out of scope, as the issue specified, for NAV-S1.

No divergence from the issue's plan — the route, module shape, kind→DOM-id table, sidebar repoint, and test harness addition all match what was laid out, including the pre-settled decisions (no proxy route, unavailable-vs-not-found split, sidebar repoint in this ticket). The open-in-new-tab link and layout switch were added on top afterward and extend the same validate-before-use pattern rather than diverging from it.

## Record

`business-tech-bridge.md` was updated to mark `ENV-A02`–`A07` as claimed and covered, and to note `ENV-A01` remains open for `NAV-S1`. It was updated a second time to describe the `#open-iri` link and its `iri_href/1` scheme allowlist. No ADR, `decisions-log.md`, or `living-notes.md` entries were added — this ticket settled no new architectural question; the validation ladder it resolves through is already ADR-0009, the shell/live_session composition it slots into is already ADR-0006, the remaining choices (no proxy route, unavailable-vs-not-found) were pre-decided in the issue body itself, and the open-in-new-tab link is a straightforward extension of the already-established validate-before-use pattern, not a new architectural decision.

## Verification

`mix precommit` passed: 709 tests (25 doctests, 684 tests), 14 skipped, 13 excluded, 0 failures. Test changes: the old "the IRI is rendered as text, not a link" test was replaced with a validated-link test (asserting `href`, `target="_blank"`, and `rel="noopener noreferrer"` on `#open-iri`) and a new unsafe-scheme test (a seeded `mailto:` IRI renders as text with no `#open-iri` element), plus an explicit `#open-iri` absence assertion added to the existing malicious-IRI/accent-color injection test.

Closes #52
