### PR TITLE
M2M-S3: Client detail, token validity display, and no update or delete

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.12 | Updated: 2026-08-20 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.13 | Updated: 2026-08-20 -->
 
 # Business ↔ Tech Bridge
 
@@ -78,8 +78,18 @@ claimed and covered (M2M-S1/#34), and `M2M-A01`/`A02` join them (M2M-S2/#35):
 `Nucleus.M2M.list/1`, streamed with `phx-update="stream"` and a separate `:client_count` assign,
 renders a `created_date_error` row as an explicit "unavailable" date rather than dropping it, and
 shows a create affordance outside the empty-state conditional so it stays visible in both states.
-`NucleusWeb.M2MClientsLive.Show` ships as a stub in this same ticket — route registered, shell
-only, no gate — so M2M-S3 replaces its body without touching the router or `Index`.
+`M2M-A03`/`A15`/`A16` join the claimed set too (M2M-S3/#36):
+`NucleusWeb.M2MClientsLive.Show` replaces its M2M-S2 stub — `mount/3` (not `handle_params/3`,
+since every navigation to a different `client_id` is a fresh remount, never a patch) resolves via
+`Nucleus.M2M.fetch/2` on the disconnected render and `Nucleus.M2M.view/2` (`fetch/2` plus the
+`m2m_client_viewed` audit emission) only once `connected?(socket)`, so the audit fires exactly
+once per open with no disconnected-render flicker (`docs/adr/0019-m2m-client-detail-mount-audit-guard-and-token-validity.md`).
+Renders client ID, name, scope, `Nucleus.M2M.TokenValidity.humanize/1`'s display of
+`token_validity_seconds` (hours, else minutes, else seconds, singular at exactly one), and
+creation date, plus an explicit secret-unavailable note; renders no rename/edit/delete control at
+all (`M2M-A15`), and collapses every `Nucleus.Backend.Error` kind either to `States`' three shared
+states or its own `#m2m-client-invalid-id`/`#m2m-client-not-found`, identically for a deny-listed
+and a genuinely nonexistent ID.
 `Nucleus.M2M.fetch/2` (`test/nucleus/m2m_test.exs`) is the context-layer gate every per-client M2M
 action mounts through, the same relationship `Nucleus.Environments.fetch/2` has to
 `NucleusWeb.SecretsLive`; `Nucleus.M2M.list/1` reuses its `visible?/1` predicate rather than a

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.19 | Updated: 2026-08-20 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.20 | Updated: 2026-08-20 -->
 
 # Decisions Log
 
@@ -43,6 +43,7 @@ job and the row should point rather than paraphrase.
 | 16 | M2M client adapter — derived OAuth scope (no new config var), operator-chosen token validity (5–60 min, stored in seconds), bounded fan-out with degrade-not-fail listing; `M2M-A09` removed mid-implementation — Cognito does not enforce client-name uniqueness | 2026-08-19 | Decided | `docs/adr/0016-m2m-client-adapter.md` |
 | 17 | M2M naming, deny-list, and resolution gate — `M2M_DENY_SUFFIXES` defaults to the prototype's Terraform value (fail-closed, `none` sentinel), `ClientId` uses AWS's own `[\w+]+` pattern not a tighter one, tenancy is the full `{tenant}-control-plane-` prefix (pool shared across tenants), deny-list enforced at creation too — new wiki action `M2M-A18` | 2026-08-19 | Decided | `docs/adr/0017-m2m-naming-deny-list-and-resolution-gate.md` |
 | 18 | M2M clients listing — two `Phoenix.LiveView` modules (`Index`/`Show`, the `phx.gen.live` split) not one switching on `handle_params/3`; `Nucleus.M2M.list/1` collapses the deny-list gate to one call, reusing `visible?/1`; row DOM ids are the plain `client_id` (already allowlist-safe, unlike Secrets' ARN hash); create button sits outside the empty-state conditional | 2026-08-20 | Decided | `docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md` |
+| 19 | M2M client detail — `Show.mount/3` calls `fetch/2` (no audit) disconnected and `view/2` (audit) only once `connected?(socket)`, so `m2m_client_viewed` fires exactly once per open with no render flicker; `TokenValidity.humanize/1` corrected to the actual three-tier, seconds-based `M2M-A16` rule over the issue's stale hours-only draft; `Format.created_date/1` extracted so `Index`/`Show` share one formatter | 2026-08-20 | Decided | `docs/adr/0019-m2m-client-detail-mount-audit-guard-and-token-validity.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -64,7 +65,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0018` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0019` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/docs/adr/0019-m2m-client-detail-mount-audit-guard-and-token-validity.md
+++ b/docs/adr/0019-m2m-client-detail-mount-audit-guard-and-token-validity.md
@@ -1,0 +1,163 @@
+# ADR-0019: M2M Client Detail — Mount-Time Audit Guard and the Seconds-Based Token Validity Correction
+
+## Status
+
+Accepted — 2026-08-20
+
+Decided on [M2M-S3](https://github.com/dave-bell/nucleus/issues/36). Builds on
+`0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md` (the first
+real `Audit.emit/2` call site, and the `audit_user/1`/`$callers`-fallback
+conventions this ticket's own call site reuses unchanged) and
+`0018-m2m-clients-listing-module-split-and-dom-ids.md` (the two-module split
+and `Show.mount/3` shape this ticket fills in).
+
+## Context
+
+`M2M-A03` requires a `m2m_client_viewed` audit record per client-detail
+open; `M2M-A16` requires the displayed token validity to pluralise
+correctly. Two things the issue's plan left unresolved (or got wrong) before
+implementation:
+
+1. **The plan's `m2m_client_viewed` guard left the disconnected render
+   unaddressed.** The issue thread settled that the audit emission must be
+   guarded by `connected?(socket)` — `mount/3` runs once for the disconnected
+   (static) render and once more for the connected render, and every other
+   `Audit.emit/2` call site in this codebase is event-driven (`handle_event`),
+   not mount-driven, so this is the first time that distinction matters. What
+   the thread did not settle: if the audit call is skipped on the
+   disconnected pass, is the client's data skipped too, or resolved by some
+   other path?
+2. **The plan's `TokenValidity.humanize/1` was two-tier and hours-only,**
+   `humanize(hours :: integer() | nil)`, `1` → `"1 hour"`, everything else
+   pluralised. `docs/requirements/M2M-Clients.md`'s actual `M2M-A16` text is
+   three-tier — hours, else minutes, else seconds, each singular at exactly
+   `1` — and `Nucleus.M2M.ClientDetail` (already shipped by EN-10 / #33)
+   carries `token_validity_seconds`, not `token_validity_hours`. The plan
+   predates the struct it was describing.
+
+## Decision
+
+### `connected?(socket)` selects the function, not just whether to call it
+
+`Show.mount/3` calls `Nucleus.M2M.fetch/2` (no audit) on the disconnected
+pass and `Nucleus.M2M.view/2` (`fetch/2` + `Audit.emit(:m2m_client_viewed,
+...)`) only once `connected?(socket)` is true:
+
+```elixir
+result =
+  if connected?(socket) do
+    M2M.view(client_id, scope)
+  else
+    M2M.fetch(client_id, scope)
+  end
+```
+
+This keeps both Phoenix lifecycle passes rendering the same, correct client
+detail — no blank-then-populate flicker — while the one-time audit side
+effect fires exactly once per human page open. The alternative (skip
+resolution entirely on the disconnected pass, render nothing until
+connected) was rejected: it would make the static HTML a placeholder shell
+on every load, a regression from `Index`'s existing behaviour of resolving
+data on both passes unconditionally. The cost is one extra
+`Nucleus.M2M.Clients.describe_client/1` call per page open (the disconnected
+pass's own `fetch/2`) — a single-client `DescribeUserPoolClient`, not the
+fan-out `Index`'s own ADR (`0018`) already accepts paying twice per list
+load.
+
+This is the second real call site for `Audit.emit/2` from application code
+(after `Nucleus.Secrets.reveal/3`, `0011`) and the first triggered by
+`mount/3` rather than `handle_event/3`. `Scope.audit_user/1` and the test
+sink's `$callers` fallback (`0011`) apply unchanged — `Phoenix.LiveViewTest`
+sets `$callers` on a mounted view's process regardless of which callback
+emits, so no new test infrastructure was needed to assert on it.
+
+### `TokenValidity.humanize/1` takes seconds, three tiers, largest exact unit wins
+
+```elixir
+@spec humanize(seconds :: pos_integer() | nil) :: String.t()
+```
+
+Whole hours read in hours, else whole minutes read in minutes, else seconds
+— singular at exactly `1` in every tier, `nil` reads `"not set"`. This
+matches `docs/requirements/M2M-Clients.md`'s `M2M-A16` text and
+`ClientDetail.token_validity_seconds`'s actual shape, not the issue body's
+draft. `Nucleus.M2M.Clients.Cognito.token_validity_seconds/1` (EN-10 / #33,
+already shipped) normalises Cognito's `AccessTokenValidity` +
+`TokenValidityUnits` — seconds, minutes, hours, or days — to seconds before
+this function ever sees it; the seeded local fixture at `450` seconds (not
+a whole number of minutes) is the case that proves the two compose, rather
+than a hypothetical.
+
+### A small shared formatter, not two private copies
+
+`NucleusWeb.M2MClientsLive.Format.created_date/1` is called by both
+`Index` and `Show` for the one field both render the same way
+(`Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")`), with a `nil` clause
+`Show` needs and `Index` does not (`Index` takes its own
+`created_date_error`-driven DOM branch for a per-row describe failure;
+`ClientDetail` has no equivalent per-field error kind, so `Show`'s `nil` is
+a client this feature didn't create arriving with no reliable value).
+Matches Decision 7's own reasoning (`0018`) for why `States` is a real
+module and not a copy-paste starting point — applied here to a formatter,
+not markup.
+
+## Consequences
+
+### Positive
+
+- No flicker between the disconnected and connected render, and exactly one
+  audit record per human open, pinned by a test that opens the same client
+  twice and asserts two independent records (`test/nucleus_web/live/m2m_clients_live_test.exs`).
+- The `connected?(socket)`-gated dual-path is the pattern any future
+  mount-triggered audit call site in this codebase should reach for first,
+  rather than re-deriving it — the same role `0011`'s `audit_user/1`/
+  `$callers` conventions already play for event-driven call sites.
+- `TokenValidity.humanize/1` and the Cognito adapter's unit normalisation
+  are proven to compose by a real seeded fixture, not asserted independently
+  of each other.
+
+### Negative
+
+- One extra `describe_client/1` call per page open (disconnected pass) that
+  a design skipping disconnected-pass resolution would not pay. Accepted as
+  consistent with `Index`'s existing double-fetch-per-load behaviour, and
+  small next to a single-client describe.
+- `Format.created_date/1` is a two-call-site module for a three-line
+  function — a low bar for extraction, justified here only because this
+  codebase has an explicit, precedent-setting rule (Decision 7, `0018`)
+  against letting two LiveView modules maintain the same rendering logic
+  independently.
+
+## Alternatives considered
+
+**Skip client resolution entirely on the disconnected pass, populate only
+once connected.** Rejected — regresses to a blank shell on every static
+load, unlike `Index`'s existing behaviour, for a saving (one adapter call)
+too small to justify the flicker.
+
+**Call `Audit.emit/2` directly from `Show`, bypassing `view/2`.** Rejected
+— `Nucleus.M2M.view/2` exists specifically so the fetch-plus-audit pairing
+lives in one tested context function, matching `Nucleus.Secrets.reveal/3`'s
+shape; duplicating the emission in the LiveView would leave two places that
+must agree on the event name and detail keys.
+
+**Keep `TokenValidity.humanize/1` as the plan drafted it (hours-only,
+`nil | integer` hours).** Rejected — does not match either the requirement
+text (`M2M-A16` is three-tier) or the struct it must read
+(`token_validity_seconds`); shipping it as drafted would have been visibly
+wrong against the wiki on the first non-hour fixture.
+
+## References
+
+- M2M-S3 (issue #36) — the deciding issue
+- `docs/adr/0011-secret-reveal-stream-reinsertion-and-audit-test-fallback.md`
+  — the audit-emission and test-sink conventions this ticket's call site
+  reuses
+- `docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md` — the
+  module split and `Show.mount/3` shape this ticket fills in, and Decision
+  7's "not a copy-paste starting point" reasoning this ADR extends to
+  `Format`
+- `docs/requirements/M2M-Clients.md` — `M2M-A03`, `M2M-A15`, `M2M-A16`'s
+  actual (three-tier) text
+- `lib/nucleus/m2m/clients/cognito.ex:256-271` — EN-10's Cognito unit
+  normalisation this ticket's formatter composes with

--- a/lib/nucleus/m2m.ex
+++ b/lib/nucleus/m2m.ex
@@ -56,14 +56,17 @@ defmodule Nucleus.M2M do
   not-yet-created client has no `Client.t()`/`ClientDetail.t()` for
   `visible?/1` to take.
 
-  ## No audit event
+  ## `fetch/2` and `list/1` emit no audit event; `view/2` does
 
-  The wiki's audit table has three M2M events and none of them is a lookup
-  or a rejection. `m2m_client_viewed` belongs to M2M-S3, on the detail view,
-  not here — this function is also called by the rotation path, and
-  emitting here would log a spurious "viewed" on every rotation.
+  `fetch/2` is also called by the rotation path (M2M-S6), so emitting
+  `m2m_client_viewed` there would log a spurious "viewed" on every rotation
+  nobody performed as a view. `m2m_client_viewed` instead lives on `view/2`,
+  the resolve-plus-audit wrapper `NucleusWeb.M2MClientsLive.Show` calls —
+  see `view/2`'s own doc. `list/1` emits nothing either: the wiki's audit
+  table has three M2M events and listing is not one of them.
   """
 
+  alias Nucleus.Audit
   alias Nucleus.Backend.Error
   alias Nucleus.M2M.Client
   alias Nucleus.M2M.ClientDetail
@@ -93,6 +96,53 @@ defmodule Nucleus.M2M do
       else
         not_found(client_id)
       end
+    end
+  end
+
+  @doc """
+  `fetch/2` plus the `m2m_client_viewed` audit emission (`M2M-A03`) — a
+  distinct function, deliberately not folded into `fetch/2` itself.
+
+  M2M-S6's rotation path also resolves the client through `fetch/2`;
+  emitting the audit event there would record a spurious "viewed" on every
+  rotation nobody performed as a view. Keeping `fetch/2` audit-free is
+  M2M-S1 / #34's own guarantee, re-asserted by that ticket's test — this
+  function must not weaken it.
+
+  Emits **once per call, on success only**. A failed lookup — `:invalid`,
+  `:not_found`, `:unavailable`, or any other kind `fetch/2` passes through —
+  is not a view that happened and produces no audit record. Callers control
+  "once per open, not per render" themselves: `NucleusWeb.M2MClientsLive.Show`
+  calls this from `mount/3`, guarded by `connected?(socket)`, so one human
+  open of the page produces exactly one call, not one per disconnected and
+  connected render.
+
+  `details` carries exactly `client_name` — the only key
+  `Nucleus.Audit.Event`'s catalogue allowlists for this event
+  (`lib/nucleus/audit/event.ex:110-115`); passing anything else is rejected
+  by `Audit.emit/2` by design, not an obstacle to work around. `user` comes
+  from `Nucleus.Scope.audit_user/1`, not a raw `scope.user.email` read —
+  matching `Nucleus.Secrets.reveal/3` and ADR-0011's reasoning: a Cognito
+  access token can carry no `email` claim, and `audit_user/1` already falls
+  back to `username`, then `"anonymous"`, so a signed-in view is never
+  misattributed just because `email` happened to be `nil` or blank.
+  """
+  @spec view(client_id :: term(), scope :: Scope.t()) ::
+          {:ok, ClientDetail.t()} | {:error, Error.t()}
+  def view(client_id, %Scope{} = scope) do
+    case fetch(client_id, scope) do
+      {:ok, detail} = ok ->
+        :ok =
+          Audit.emit(:m2m_client_viewed,
+            user: Scope.audit_user(scope),
+            tenant: scope.tenant,
+            details: %{client_name: detail.client_name}
+          )
+
+        ok
+
+      error ->
+        error
     end
   end
 

--- a/lib/nucleus/m2m/token_validity.ex
+++ b/lib/nucleus/m2m/token_validity.ex
@@ -1,0 +1,74 @@
+defmodule Nucleus.M2M.TokenValidity do
+  @moduledoc """
+  Humanises `Nucleus.M2M.ClientDetail.token_validity_seconds` for display
+  (`M2M-A16`).
+
+  A pure function, its own module, unit-tested — the singular case ("1
+  hour", not "1 hours") is exactly the kind of detail that gets refactored
+  into a single interpolated plural by someone tidying a template later.
+  Deliberately not `ngettext`/`Gettext`: this app has no active
+  translations, and `M2M-A16` describes English pluralisation of one field,
+  not localisation.
+
+  ## Largest exact unit wins
+
+  `docs/requirements/M2M-Clients.md`'s `M2M-A16`: a whole number of hours
+  reads in hours, else a whole number of minutes reads in minutes, else it
+  reads in seconds. This is a three-tier rule, not the two-tier
+  hours-only rule an earlier draft of this ticket's plan described —
+  `token_validity_seconds` (not `token_validity_hours`) is the field this
+  reads, per `Nucleus.M2M.ClientDetail` and EN-10 / #33.
+
+  Cognito's own `AccessTokenValidity` + `TokenValidityUnits` can express a
+  value in seconds, minutes, hours, or days; `Nucleus.M2M.Clients.Cognito`
+  normalises all of that to seconds before this ever sees it
+  (`lib/nucleus/m2m/clients/cognito.ex:256-271`). A value that arrived in a
+  non-hours unit (say, a Terraform-managed client set to `450` seconds) is
+  exactly the case that proves this function and that normalisation compose:
+  `450` is not a whole number of minutes (`450 / 60 = 7.5`), so it falls
+  through to the seconds tier and reads `"450 seconds"`, not `"0 hours"` or
+  a crash.
+  """
+
+  @doc """
+  Humanises `seconds` into its largest exact unit, singular at exactly `1`.
+
+  `nil` yields a neutral "not set" rather than `"nil hours"` or a crash — a
+  client this feature didn't create can, in principle, arrive with no
+  reliable value to show.
+
+      iex> Nucleus.M2M.TokenValidity.humanize(3600)
+      "1 hour"
+
+      iex> Nucleus.M2M.TokenValidity.humanize(7200)
+      "2 hours"
+
+      iex> Nucleus.M2M.TokenValidity.humanize(60)
+      "1 minute"
+
+      iex> Nucleus.M2M.TokenValidity.humanize(900)
+      "15 minutes"
+
+      iex> Nucleus.M2M.TokenValidity.humanize(1)
+      "1 second"
+
+      iex> Nucleus.M2M.TokenValidity.humanize(450)
+      "450 seconds"
+
+      iex> Nucleus.M2M.TokenValidity.humanize(nil)
+      "not set"
+  """
+  @spec humanize(seconds :: pos_integer() | nil) :: String.t()
+  def humanize(nil), do: "not set"
+
+  def humanize(seconds) when is_integer(seconds) and seconds > 0 do
+    cond do
+      rem(seconds, 3600) == 0 -> pluralize(div(seconds, 3600), "hour")
+      rem(seconds, 60) == 0 -> pluralize(div(seconds, 60), "minute")
+      true -> pluralize(seconds, "second")
+    end
+  end
+
+  defp pluralize(1, unit), do: "1 #{unit}"
+  defp pluralize(n, unit), do: "#{n} #{unit}s"
+end

--- a/lib/nucleus_web/live/m2m_clients_live/format.ex
+++ b/lib/nucleus_web/live/m2m_clients_live/format.ex
@@ -1,0 +1,35 @@
+defmodule NucleusWeb.M2MClientsLive.Format do
+  @moduledoc """
+  Shared, pure display formatting for `NucleusWeb.M2MClientsLive.Index` and
+  `.Show` — both need `created_date` rendered the same way, and per issue
+  #35's Decision 7 ("two modules can't share markup by accident"), a
+  formatter both call is a real shared module, not two independently
+  maintained private helpers that can silently drift apart.
+  """
+
+  @doc """
+  Formats a client's `created_date` for display.
+
+  `Index` never calls the `nil` clause today — a `Nucleus.M2M.Client` row
+  whose per-client describe failed while listing carries
+  `created_date_error` instead, and `Index` takes its own dedicated
+  `#m2m-client-date-unavailable-{id}` branch for that case rather than
+  rendering this function's `nil` output. `Show`'s
+  `Nucleus.M2M.ClientDetail.created_date` has no equivalent per-field error
+  kind, so a client this feature didn't create (no `AccessTokenValidity` set,
+  say) can still arrive with `created_date: nil`; this clause is `Show`'s
+  only defence against rendering `"nil"` or crashing on that case.
+
+      iex> NucleusWeb.M2MClientsLive.Format.created_date(~U[2026-05-01 09:00:00Z])
+      "2026-05-01 09:00 UTC"
+
+      iex> NucleusWeb.M2MClientsLive.Format.created_date(nil)
+      "unavailable"
+  """
+  @spec created_date(DateTime.t() | nil) :: String.t()
+  def created_date(%DateTime{} = datetime) do
+    Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
+  end
+
+  def created_date(nil), do: "unavailable"
+end

--- a/lib/nucleus_web/live/m2m_clients_live/index.ex
+++ b/lib/nucleus_web/live/m2m_clients_live/index.ex
@@ -104,6 +104,7 @@ defmodule NucleusWeb.M2MClientsLive.Index do
   alias Nucleus.Backend.Error
   alias Nucleus.M2M
   alias Nucleus.M2M.Client
+  alias NucleusWeb.M2MClientsLive.Format
   alias NucleusWeb.M2MClientsLive.States
 
   @impl Phoenix.LiveView
@@ -186,7 +187,7 @@ defmodule NucleusWeb.M2MClientsLive.Index do
                 <td class="font-mono text-sm">{client.client_id}</td>
                 <td class="whitespace-nowrap">
                   <%= if client.created_date do %>
-                    {format_created_date(client.created_date)}
+                    {Format.created_date(client.created_date)}
                   <% else %>
                     <span
                       id={date_unavailable_id(client.client_id)}
@@ -219,8 +220,4 @@ defmodule NucleusWeb.M2MClientsLive.Index do
   defp date_unavailable_id(client_id), do: "m2m-client-date-unavailable-" <> client_id
 
   defp view_link_id(client_id), do: "view-client-" <> client_id
-
-  defp format_created_date(%DateTime{} = datetime) do
-    Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
-  end
 end

--- a/lib/nucleus_web/live/m2m_clients_live/show.ex
+++ b/lib/nucleus_web/live/m2m_clients_live/show.ex
@@ -1,35 +1,187 @@
 defmodule NucleusWeb.M2MClientsLive.Show do
   @moduledoc """
-  Stub for `/m2m/clients/:client_id` — M2M-S2 (#35) registers this route so
-  `Index`'s per-row view link (`<.link navigate={~p"/m2m/clients/\#{client.client_id}"}>`)
-  has somewhere real to land and the app compiles with both routes in place.
-  M2M-S3 (#36) replaces this module's body wholesale — the gate,
-  `Nucleus.M2M.fetch/2`, `m2m_client_viewed`, token-validity display — without
+  A client's detail view (`M2M-A03`), token validity display (`M2M-A16`),
+  and the deliberate absence of any rename/reconfigure/delete affordance
+  (`M2M-A15`) — M2M-S3, issue #36. Replaces M2M-S2 / #35's stub body without
   touching the router or `NucleusWeb.M2MClientsLive.Index` (Decision 7).
 
-  `mount/3`, not `handle_params/3`, per Decision 7: `Show` is reached only by
-  a `live_navigate` from `Index` (a fresh remount on every `client_id`, never
-  a `patch` between two client IDs), so there is nothing to re-validate on a
-  patch that never happens — the same reasoning `phx.gen.live`'s own
-  `Show.mount/3` follows (`deps/phoenix/priv/templates/phx.gen.live/show.ex.eex`).
+  ## `mount/3`, not `handle_params/3` — Decision 7, `docs/adr/0018`
 
-  No gate, no `Nucleus.M2M.fetch/2` call, and no error-state handling belong
-  in this ticket — only the shell, so `client_id` is not even read here yet.
+  This route is reached only by a `navigate` from `Index` (`/m2m/clients` ->
+  `/m2m/clients/:client_id`), never by a `patch` between two client IDs — a
+  fresh remount happens on every navigation, so there is nothing to
+  re-validate on a patch that never occurs. `Nucleus.M2M.fetch/2` (via
+  `view/2`, see below) is called from `mount/3` directly, matching
+  `phx.gen.live`'s own `Show.mount/3` shape and `Index`'s identical
+  reasoning for having no `handle_params/3` of its own.
+
+  ## `m2m_client_viewed` fires exactly once per open, not per render
+
+  `mount/3` runs once for the disconnected (static) render and once more
+  after the client connects over the LiveView socket — both with the same
+  `client_id`. Resolving via plain `Nucleus.M2M.fetch/2` (no audit) on the
+  disconnected pass keeps the static HTML correct; resolving via
+  `Nucleus.M2M.view/2` (`fetch/2` + `Audit.emit(:m2m_client_viewed, ...)`)
+  only once `connected?(socket)` is true means the one-time audit side
+  effect fires exactly once per human page open, never twice for the same
+  open and never on a failed lookup — `view/2` only emits on success.
+
+  ## Every `Nucleus.Backend.Error.kinds/0` value gets its own state
+
+  | Outcome | `:status` | DOM id |
+  |---|---|---|
+  | `{:ok, detail}` | `:ok` | `#m2m-client-detail` |
+  | `kind: :invalid` (`M2M-A13`) | `:invalid` | `#m2m-client-invalid-id` |
+  | `kind: :not_found` (`M2M-A14`) | `:not_found` | `#m2m-client-not-found` |
+  | `kind: :not_configured` | `:misconfigured` | `#m2m-clients-misconfigured` |
+  | `kind: :unavailable` (and `:already_exists`, which `fetch/2` has no
+    reason to return) | `:unavailable` | `#m2m-clients-unavailable` |
+  | `kind: :auth_expired` | `:auth_expired` | `#m2m-clients-auth-expired` |
+
+  The three collapsed error states reuse
+  `NucleusWeb.M2MClientsLive.States` — the same real component `Index`
+  uses, not a copy-paste starting point (Decision 7) — and add this
+  module's own `:invalid`/`:not_found` markup, since those two kinds are
+  specific to resolving a single client by ID and have no equivalent in
+  `Index`'s list-level `case`.
+
+  Every branch keeps the shell intact (`<Layouts.app>`, `#tenant-identifier`)
+  so the operator can navigate away; a crashed LiveView is not an acceptable
+  rendering of any of them. **No client detail renders in any error
+  state** — no ID, no name, no scope, no validity, no created date, and no
+  rotation control.
+
+  ## `M2M-A15` — no rename, reconfigure, or delete affordance
+
+  The only mutating affordance this feature offers at all is secret
+  rotation (`M2M-A11`), and that control belongs to M2M-S6 (#39), not this
+  ticket — `#m2m-client-detail` renders nothing in its place today, on
+  purpose, so a negative test for "no rename/edit/delete control" stays
+  unambiguous rather than needing to also distinguish a disabled
+  placeholder from a real one.
+
+  ## The client ID is never echoed via `raw/1`
+
+  HEEx escapes interpolated content by default; `{@detail.client_id}` and
+  every other field render through ordinary interpolation, never `raw/1` —
+  there is no reason to defeat HEEx's own escaping here.
+
+  `current_scope` and `environments` come from the `:authenticated`
+  `live_session`'s `on_mount` hooks, same as `Index` and
+  `NucleusWeb.SecretsLive` — this module does not assign either itself.
   """
 
   use NucleusWeb, :live_view
 
+  alias Nucleus.Backend.Error
+  alias Nucleus.M2M
+  alias Nucleus.M2M.ClientDetail
+  alias Nucleus.M2M.TokenValidity
+  alias NucleusWeb.M2MClientsLive.Format
+  alias NucleusWeb.M2MClientsLive.States
+
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
-    {:ok, socket}
+  def mount(%{"client_id" => client_id}, _session, socket) do
+    scope = socket.assigns.current_scope
+
+    result =
+      if connected?(socket) do
+        M2M.view(client_id, scope)
+      else
+        M2M.fetch(client_id, scope)
+      end
+
+    {:ok, assign_result(socket, result)}
+  end
+
+  defp assign_result(socket, {:ok, %ClientDetail{} = detail}) do
+    assign(socket, status: :ok, detail: detail)
+  end
+
+  defp assign_result(socket, {:error, %Error{kind: :invalid}}) do
+    assign(socket, status: :invalid, detail: nil)
+  end
+
+  defp assign_result(socket, {:error, %Error{kind: :not_found}}) do
+    assign(socket, status: :not_found, detail: nil)
+  end
+
+  defp assign_result(socket, {:error, %Error{kind: :not_configured}}) do
+    assign(socket, status: :misconfigured, detail: nil)
+  end
+
+  defp assign_result(socket, {:error, %Error{kind: :auth_expired}}) do
+    assign(socket, status: :auth_expired, detail: nil)
+  end
+
+  defp assign_result(socket, {:error, %Error{}}) do
+    assign(socket, status: :unavailable, detail: nil)
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash} current_scope={@current_scope} environments={@environments}>
-      <div id="m2m-client-detail-placeholder">
-        M2M client detail is not implemented yet.
+      <States.misconfigured :if={@status == :misconfigured} />
+      <States.unavailable :if={@status == :unavailable} />
+      <States.auth_expired :if={@status == :auth_expired} />
+
+      <.empty_state
+        :if={@status == :invalid}
+        id="m2m-client-invalid-id"
+        icon="hero-exclamation-triangle"
+        message="That's not a valid M2M client ID."
+      />
+
+      <.empty_state
+        :if={@status == :not_found}
+        id="m2m-client-not-found"
+        icon="hero-magnifying-glass"
+        message="No such M2M client."
+      />
+
+      <div :if={@status == :ok} id="m2m-client-detail">
+        <div class="flex items-center justify-between gap-4 pb-4">
+          <h1 class="text-lg font-semibold">{@detail.client_name}</h1>
+          <.link navigate={~p"/m2m/clients"} class="btn btn-sm btn-ghost">
+            Back to clients
+          </.link>
+        </div>
+
+        <dl class="grid grid-cols-1 gap-4">
+          <div>
+            <dt class="text-sm text-base-content/60">Client ID</dt>
+            <dd id="m2m-client-id" class="font-mono text-sm">{@detail.client_id}</dd>
+          </div>
+
+          <div>
+            <dt class="text-sm text-base-content/60">Client name</dt>
+            <dd id="m2m-client-name">{@detail.client_name}</dd>
+          </div>
+
+          <div>
+            <dt class="text-sm text-base-content/60">OAuth scope</dt>
+            <dd id="m2m-client-scope" class="font-mono text-sm">{@detail.scope}</dd>
+          </div>
+
+          <div>
+            <dt class="text-sm text-base-content/60">Access token validity</dt>
+            <dd id="m2m-client-token-validity">
+              {TokenValidity.humanize(@detail.token_validity_seconds)}
+            </dd>
+          </div>
+
+          <div>
+            <dt class="text-sm text-base-content/60">Created</dt>
+            <dd id="m2m-client-created">{Format.created_date(@detail.created_date)}</dd>
+          </div>
+        </dl>
+
+        <p id="m2m-client-secret-note" class="mt-6 text-sm text-base-content/70">
+          The client secret is shown only once, at creation or rotation, and cannot be
+          retrieved again afterward. If it's been lost, rotating the secret is the only
+          recovery.
+        </p>
       </div>
     </Layouts.app>
     """

--- a/test/nucleus/m2m/token_validity_test.exs
+++ b/test/nucleus/m2m/token_validity_test.exs
@@ -1,0 +1,82 @@
+defmodule Nucleus.M2M.TokenValidityTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.M2M.TokenValidity
+
+  doctest TokenValidity
+
+  describe "humanize/1 — hours" do
+    @tag action: "M2M-A16"
+    @tag :unit
+    test "exactly one hour reads singular" do
+      assert TokenValidity.humanize(3600) == "1 hour"
+    end
+
+    @tag action: "M2M-A16"
+    test "a whole number of hours other than one pluralises" do
+      assert TokenValidity.humanize(7200) == "2 hours"
+      assert TokenValidity.humanize(24 * 3600) == "24 hours"
+    end
+  end
+
+  describe "humanize/1 — minutes (whole minutes, not whole hours)" do
+    @tag action: "M2M-A16"
+    @tag :unit
+    test "exactly one minute reads singular" do
+      assert TokenValidity.humanize(60) == "1 minute"
+    end
+
+    @tag action: "M2M-A16"
+    test "a whole number of minutes other than one pluralises" do
+      assert TokenValidity.humanize(900) == "15 minutes"
+      assert TokenValidity.humanize(1800) == "30 minutes"
+    end
+  end
+
+  describe "humanize/1 — seconds (neither whole hours nor whole minutes)" do
+    @tag action: "M2M-A16"
+    @tag :unit
+    test "exactly one second reads singular" do
+      assert TokenValidity.humanize(1) == "1 second"
+    end
+
+    @tag action: "M2M-A16"
+    test "a value that is not a whole number of minutes pluralises in seconds" do
+      assert TokenValidity.humanize(450) == "450 seconds"
+    end
+  end
+
+  describe "humanize/1 — nil" do
+    @tag action: "M2M-A16"
+    @tag :unit
+    test "yields a neutral string, not \"nil hours\" or a crash" do
+      assert TokenValidity.humanize(nil) == "not set"
+    end
+  end
+
+  describe "humanize/1 — the exact singular/plural boundary" do
+    @tag action: "M2M-A16"
+    test "1 and 2 produce different suffixes at every tier" do
+      assert TokenValidity.humanize(3600) == "1 hour"
+      assert TokenValidity.humanize(2 * 3600) == "2 hours"
+
+      assert TokenValidity.humanize(60) == "1 minute"
+      assert TokenValidity.humanize(120) == "2 minutes"
+
+      assert TokenValidity.humanize(1) == "1 second"
+      assert TokenValidity.humanize(2) == "2 seconds"
+    end
+  end
+
+  describe "humanize/1 — largest exact unit wins" do
+    @tag action: "M2M-A16"
+    test "a value that is a whole number of both hours and minutes reads in hours" do
+      assert TokenValidity.humanize(3600) == "1 hour"
+    end
+
+    @tag action: "M2M-A16"
+    test "a value that is a whole number of minutes but not hours reads in minutes" do
+      assert TokenValidity.humanize(900) == "15 minutes"
+    end
+  end
+end

--- a/test/nucleus/m2m_test.exs
+++ b/test/nucleus/m2m_test.exs
@@ -17,6 +17,7 @@ defmodule Nucleus.M2MTest do
 
   # Seeded in priv/backends/local_seed.json under TENANT_NAMESPACE = "local".
   @valid_client_id "4f2a9c1e7b3d8f0a1c2e3f4a5b6c7d8e"
+  @valid_client_secret "b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a6789"
   @denied_client_id "5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e"
   @out_of_tenant_client_id "6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f"
   @nonexistent_client_id String.duplicate("f", 32)
@@ -388,6 +389,70 @@ defmodule Nucleus.M2MTest do
 
         assert {:error, %Error{kind: ^kind}} = M2M.list(@scope)
       end
+    end
+  end
+
+  describe "view/2 — M2M-A03 resolves and audits a client view" do
+    @tag action: "M2M-A03"
+    test "returns a ClientDetail with client_id, client_name, scope, token_validity_seconds, and created_date populated" do
+      assert {:ok, %ClientDetail{} = detail} = M2M.view(@valid_client_id, @scope)
+
+      assert detail.client_id == @valid_client_id
+      assert is_binary(detail.client_name)
+      assert is_binary(detail.scope)
+      assert is_integer(detail.token_validity_seconds)
+      assert %DateTime{} = detail.created_date
+    end
+
+    @tag action: "M2M-A03"
+    test "the resolved struct has no :client_secret key" do
+      assert {:ok, detail} = M2M.view(@valid_client_id, @scope)
+      refute Map.has_key?(detail, :client_secret)
+    end
+
+    @tag action: "M2M-A03"
+    test "emits exactly one m2m_client_viewed, with client_name in details and the tenant set" do
+      assert {:ok, detail} = M2M.view(@valid_client_id, @scope)
+
+      assert_audit_event(:m2m_client_viewed,
+        tenant: "local",
+        details: %{client_name: detail.client_name}
+      )
+
+      assert audit_events() |> Enum.filter(&(&1.event == :m2m_client_viewed)) |> length() == 1
+    end
+
+    @tag action: "M2M-A03"
+    test "a view that did not happen is not recorded: :invalid emits no audit event" do
+      assert {:error, %Error{kind: :invalid}} = M2M.view("../etc", @scope)
+      assert_no_audit_event(:m2m_client_viewed)
+    end
+
+    @tag action: "M2M-A03"
+    test "a view that did not happen is not recorded: :not_found (deny-listed) emits no audit event" do
+      assert {:error, %Error{kind: :not_found}} = M2M.view(@denied_client_id, @scope)
+      assert_no_audit_event(:m2m_client_viewed)
+    end
+
+    @tag action: "M2M-A03"
+    test "a view that did not happen is not recorded: :unavailable emits no audit event" do
+      use_backend(FailingM2MClients)
+      Application.put_env(:nucleus, FailingM2MClients, :unavailable)
+
+      assert {:error, %Error{kind: :unavailable}} = M2M.view(@valid_client_id, @scope)
+      assert_no_audit_event(:m2m_client_viewed)
+    end
+
+    @tag action: "M2M-A03"
+    test "fetch/2 still emits nothing — M2M-S1 / #34's guarantee, re-asserted so this ticket cannot break it" do
+      assert {:ok, _detail} = M2M.fetch(@valid_client_id, @scope)
+      assert_no_audit_event(:m2m_client_viewed)
+    end
+
+    @tag action: "M2M-A03"
+    test "the seeded client's secret never appears in the audit trail" do
+      assert {:ok, _detail} = M2M.view(@valid_client_id, @scope)
+      refute_audit_contains(@valid_client_secret)
     end
   end
 end

--- a/test/nucleus_web/live/m2m_clients_live_test.exs
+++ b/test/nucleus_web/live/m2m_clients_live_test.exs
@@ -40,9 +40,10 @@ defmodule NucleusWeb.M2MClientsLiveTest do
 
   defmodule FailingM2MClients do
     @moduledoc """
-    A controllable `list_clients/0` failure — a swapped module, not
-    `LOCAL_FORCE_ERROR`, for the same node-global reason `Nucleus.M2MTest`'s
-    twin documents.
+    A controllable `list_clients/0`/`describe_client/1` failure — a swapped
+    module, not `LOCAL_FORCE_ERROR`, for the same node-global reason
+    `Nucleus.M2MTest`'s twin documents. `describe_client/1` is `Show`'s call
+    path (M2M-S3); `list_clients/0` remains `Index`'s.
     """
     @behaviour Nucleus.M2M.Clients
 
@@ -53,7 +54,10 @@ defmodule NucleusWeb.M2MClientsLiveTest do
     end
 
     @impl Nucleus.M2M.Clients
-    def describe_client(_client_id), do: raise("should not be called")
+    def describe_client(_client_id) do
+      kind = Application.get_env(:nucleus, __MODULE__, :unavailable)
+      {:error, Error.new(kind, :m2m, "forced for test", %{})}
+    end
 
     @impl Nucleus.M2M.Clients
     def create_client(_client_name, _settings), do: raise("should not be called")
@@ -267,7 +271,7 @@ defmodule NucleusWeb.M2MClientsLiveTest do
   end
 
   describe "navigation to Show" do
-    test "a row's view link navigates to /m2m/clients/:client_id and Show's stub mounts without crashing",
+    test "a row's view link navigates to /m2m/clients/:client_id and Show renders the client's detail",
          %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/m2m/clients")
 
@@ -277,7 +281,225 @@ defmodule NucleusWeb.M2MClientsLiveTest do
                |> render_click()
                |> follow_redirect(conn, ~p"/m2m/clients/#{@valid_client_id}")
 
-      assert has_element?(show_view, "#m2m-client-detail-placeholder")
+      assert has_element?(show_view, "#m2m-client-detail")
+      assert has_element?(show_view, "#m2m-client-id", @valid_client_id)
+    end
+  end
+
+  describe "M2M-A03 — view a client's details" do
+    @tag action: "M2M-A03"
+    test "shows ID, name, scope, validity and creation date, and never the secret", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+
+      assert has_element?(view, "#m2m-client-detail")
+      assert has_element?(view, "#m2m-client-secret-note")
+      refute html =~ @valid_client_secret
+    end
+
+    @tag action: "M2M-A03"
+    test "all five fields render with their DOM ids", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+
+      assert has_element?(view, "#m2m-client-id", @valid_client_id)
+      assert has_element?(view, "#m2m-client-name", @valid_client_name)
+      assert has_element?(view, "#m2m-client-scope")
+      assert has_element?(view, "#m2m-client-token-validity")
+      assert has_element?(view, "#m2m-client-created")
+    end
+
+    @tag action: "M2M-A03"
+    test "#m2m-client-secret-note is present and each seeded client's secret appears nowhere in its own rendered HTML",
+         %{conn: conn} do
+      # Every seeded, in-tenant, non-denied client — not just @valid_client_id —
+      # per the acceptance criterion "for every seeded client", not just one.
+      visible_fixtures = [
+        {@valid_client_id, @valid_client_secret},
+        {"7a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d",
+         "c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b"},
+        {"9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a",
+         "d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c"},
+        {"1c2d3e4f5a67890b1c2d3e4f5a67890b",
+         "e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d"},
+        {"2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b",
+         "f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e4f5a67890b1c2d3e"}
+      ]
+
+      for {client_id, secret} <- visible_fixtures do
+        {:ok, view, html} = live(conn, ~p"/m2m/clients/#{client_id}")
+
+        assert has_element?(view, "#m2m-client-detail")
+        assert has_element?(view, "#m2m-client-secret-note")
+        refute html =~ secret
+      end
+    end
+
+    @tag action: "M2M-A03"
+    test "one m2m_client_viewed per open; a subsequent unrelated event on the same view emits no second one",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+
+      assert_audit_event(:m2m_client_viewed, details: %{client_name: @valid_client_name})
+
+      # `Show` defines no `handle_event/3` or `handle_info/2` of its own (only
+      # secret rotation, M2M-S6, will add one) — there is no genuine
+      # "unrelated event" to dispatch at this LiveView yet. `render/1` is the
+      # closest available proxy: forcing a re-render without a fresh mount
+      # must not re-invoke `view/2`, since the audit call lives in `mount/3`,
+      # not `render/1`.
+      render(view)
+
+      count_viewed = fn -> audit_events() |> Enum.count(&(&1.event == :m2m_client_viewed)) end
+      assert count_viewed.() == 1
+
+      # The stronger, concretely testable half of "once per open": a second,
+      # independent open of the *same* client — a reload, or a second tab —
+      # is its own event, not folded into or blocked by the first. Proves
+      # `view/2` neither under- nor over-counts across separate mounts.
+      {:ok, _second_view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+      assert count_viewed.() == 2
+    end
+  end
+
+  describe "M2M-A13 — invalid client ID" do
+    @tag action: "M2M-A13"
+    test "a malformed ID in the URL renders #m2m-client-invalid-id, no #m2m-client-detail", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/not a valid id")
+
+      assert has_element?(view, "#m2m-client-invalid-id")
+      refute has_element?(view, "#m2m-client-detail")
+    end
+  end
+
+  describe "M2M-A14 — not found, identical for deny-listed and nonexistent" do
+    @tag action: "M2M-A14"
+    test "the seeded deny-listed client's ID renders #m2m-client-not-found, identical to a genuinely nonexistent ID",
+         %{conn: conn} do
+      {:ok, denied_view, _html} = live(conn, ~p"/m2m/clients/#{@denied_client_id}")
+      {:ok, nonexistent_view, _html} = live(conn, ~p"/m2m/clients/#{String.duplicate("f", 32)}")
+
+      assert has_element?(denied_view, "#m2m-client-not-found")
+      refute has_element?(denied_view, "#m2m-client-detail")
+
+      assert has_element?(nonexistent_view, "#m2m-client-not-found")
+      refute has_element?(nonexistent_view, "#m2m-client-detail")
+    end
+
+    @tag action: "M2M-A14"
+    test "the out-of-tenant client's ID also renders #m2m-client-not-found", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{@out_of_tenant_client_id}")
+
+      assert has_element?(view, "#m2m-client-not-found")
+      refute has_element?(view, "#m2m-client-detail")
+    end
+  end
+
+  describe "M2M-A15 — no update or delete affordance" do
+    @tag action: "M2M-A15"
+    test "no rename, edit, reconfigure or delete control exists in #m2m-client-detail", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+
+      refute has_element?(view, "#m2m-client-detail form")
+      refute has_element?(view, "#m2m-client-detail [phx-click=\"delete\"]")
+      refute has_element?(view, "#m2m-client-detail [phx-click=\"edit\"]")
+      refute has_element?(view, "#m2m-client-detail [phx-click=\"rename\"]")
+
+      detail_html =
+        view
+        |> element("#m2m-client-detail")
+        |> render()
+
+      refute detail_html =~ "Delete"
+      refute detail_html =~ "Remove"
+      refute detail_html =~ "Rename"
+      refute detail_html =~ "Edit"
+    end
+  end
+
+  describe "M2M-A16 — token validity display" do
+    @tag action: "M2M-A16"
+    test "the fixture with exactly one hour renders \"1 hour\"", %{conn: conn} do
+      one_hour_client_id = "9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a"
+
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{one_hour_client_id}")
+
+      assert has_element?(view, "#m2m-client-token-validity", "1 hour")
+    end
+
+    @tag action: "M2M-A16"
+    test "the fixture with a different value pluralises", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+
+      assert has_element?(view, "#m2m-client-token-validity", "15 minutes")
+    end
+
+    @tag action: "M2M-A16"
+    test "the fixture whose underlying unit is not hours (nor whole minutes) still renders correctly",
+         %{conn: conn} do
+      seconds_tier_client_id = "1c2d3e4f5a67890b1c2d3e4f5a67890b"
+
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{seconds_tier_client_id}")
+
+      assert has_element?(view, "#m2m-client-token-validity", "450 seconds")
+    end
+  end
+
+  describe "Show — error states" do
+    @error_state_ids %{
+      not_configured: "m2m-clients-misconfigured",
+      unavailable: "m2m-clients-unavailable",
+      auth_expired: "m2m-clients-auth-expired"
+    }
+
+    for {kind, expected_id} <- @error_state_ids do
+      @tag kind: kind
+      @tag expected_id: expected_id
+      test "#{kind} renders its own state, shell intact, no detail fields, no crash", %{
+        conn: conn,
+        kind: kind,
+        expected_id: expected_id
+      } do
+        use_backend(FailingM2MClients)
+        Application.put_env(:nucleus, FailingM2MClients, kind)
+
+        assert {:ok, view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+
+        assert has_element?(view, "##{expected_id}")
+        refute has_element?(view, "#m2m-client-detail")
+        refute has_element?(view, "#m2m-client-invalid-id")
+        refute has_element?(view, "#m2m-client-not-found")
+        assert has_element?(view, "#tenant-identifier")
+      end
+    end
+
+    test "live/2 returns {:ok, ...} for every Nucleus.Backend.Error kind — never crashes", %{
+      conn: conn
+    } do
+      for kind <- Error.kinds() do
+        use_backend(FailingM2MClients)
+        Application.put_env(:nucleus, FailingM2MClients, kind)
+
+        assert {:ok, _view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+      end
+    end
+  end
+
+  describe "Show — mount/3 re-validates on every navigation, not just the first" do
+    test "patching from the list to a client, then to a second client, re-validates each time",
+         %{conn: conn} do
+      second_client_id = "7a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+
+      {:ok, first_view, _html} = live(conn, ~p"/m2m/clients/#{@valid_client_id}")
+      assert has_element?(first_view, "#m2m-client-id", @valid_client_id)
+
+      {:ok, second_view, _html} = live(conn, ~p"/m2m/clients/#{second_client_id}")
+      assert has_element?(second_view, "#m2m-client-id", second_client_id)
+
+      {:ok, denied_view, _html} = live(conn, ~p"/m2m/clients/#{@denied_client_id}")
+      assert has_element?(denied_view, "#m2m-client-not-found")
     end
   end
 end


### PR DESCRIPTION
## What

Fills in `NucleusWeb.M2MClientsLive.Show`'s M2M-S2 stub with the real M2M client detail screen: ID, name, OAuth scope, humanized token validity, and creation date, plus an explicit note that the secret is only ever available at creation or rotation. The screen offers no rename, edit, or delete affordance — rotation (M2M-S6) is the only mutating control this feature will ever add here — and every `Nucleus.Backend.Error` kind, including the deny-listed-vs-nonexistent distinction, renders its own state with the shell intact and no client data leaked.

## How

- `Nucleus.M2M.view/2` (new) wraps the existing `fetch/2` with a success-only `Audit.emit(:m2m_client_viewed, ...)`, keeping `fetch/2` itself audit-free — re-asserted by a new test so M2M-S1/#34's guarantee can't regress under the rotation path that also calls `fetch/2`.
- `Show.mount/3` calls `fetch/2` (no audit) on the disconnected render and `view/2` (audit) only once `connected?(socket)`, so both Phoenix lifecycle passes render identical data but the audit fires exactly once per human open — proven by a test that opens the same client twice and asserts two independent audit records.
- `Nucleus.M2M.TokenValidity.humanize/1` (new) formats `ClientDetail.token_validity_seconds` in the largest exact unit — hours, else minutes, else seconds, singular at exactly one — unit-tested at each tier boundary and against a fixture whose underlying Cognito unit isn't hours, to prove it composes with EN-10/#33's normalisation.
- `Show` reuses `NucleusWeb.M2MClientsLive.States` for the three shared error states and adds its own `#m2m-client-invalid-id`/`#m2m-client-not-found` markup, rendering the deny-listed and genuinely-nonexistent cases identically so neither leaks client existence.
- `NucleusWeb.M2MClientsLive.Format.created_date/1` (new) is extracted so `Index` and `Show` share one date formatter instead of two independently-maintained copies; `Index`'s own copy was removed and it now calls the shared module — a small, behavior-preserving refactor of already-shipped M2M-S2 code.
- Satisfies **M2M-A03** (view a client's details, secret never shown), **M2M-A15** (no update or delete, proven by a negative test asserting the absence of rename/edit/delete controls and their labels), and **M2M-A16** (correct singular/plural token validity display).

## Record

`docs/adr/0019-m2m-client-detail-mount-audit-guard-and-token-validity.md` documents two things surfaced during implementation rather than settled by the issue: the `connected?(socket)` dual-path pattern that keeps the disconnected and connected render consistent while still auditing exactly once, and the correction of `TokenValidity.humanize/1` to the actual three-tier, seconds-based rule. `decisions-log.md` gains row 19 pointing at the ADR; `business-tech-bridge.md`'s M2M section marks `M2M-A03`/`A15`/`A16` claimed and covered and describes `Show`'s real implementation in place of the stub note it previously carried. `living-notes.md` was deliberately not touched — this ticket didn't move anything on its Open Questions or Active Projects lists.

## Divergence from the plan

The issue's plan predates its own dependency tickets (M2M-S1/#34, M2M-S2/#35) and was corrected in three places by the issue's own comment thread before implementation started — none of these are unilateral decisions made in this PR:

- **Resolution happens in `Show.mount/3`, not `handle_params/3`.** The plan assumed a single LiveView module patching between client IDs. M2M-S2/#35's Decision 7 settled on two separate route modules (`Index`/`Show`) reached only by `navigate`, so there is nothing to patch between — every `client_id` change is a fresh remount. `docs/adr/0018` records the module split this follows.
- **Token validity is `TokenValidity.humanize(token_validity_seconds)`, three-tier**, not the plan's stale `humanize(token_validity_hours)`, two-tier, hours-only draft. EN-10/#33's Decision 4 (comment on this issue) settled that access token validity is operator-chosen at creation in minutes, so `ClientDetail` carries `token_validity_seconds`, and `M2M-A16`'s actual wiki text is largest-exact-unit (hours, else minutes, else seconds).
- **The audit emission is guarded by `connected?(socket)`**, per the same M2M-S2/#35 comment thread, since `mount/3` runs on both the disconnected and connected render and an unguarded `view/2` call would double-count one human open.
- **File layout is two modules** (`lib/nucleus_web/live/m2m_clients_live/index.ex` and `show.ex`), not the single `m2m_clients_live.ex` the plan's route example referenced — again per Decision 7.

## Verification

`mix precommit` (compile `--warnings-as-errors`, `deps.unlock --unused`, `format`, `test`) passed clean: 735 tests (32 doctests, 703 tests), 14 skipped, 13 excluded, 0 failures. `mix nucleus.trace --feature M2M` shows M2M-A01, A02, A03, A13, A14, A15, A16 covered — 7 of 17 M2M actions; A04–A12 and A17–A18 belong to later M2M-S4/S5/S6 tickets and are out of scope here.

Closes #36
