### PR TITLE
Copy-button tooltip anchors left of the modal edge; credentials panel leads with the key pair

### DIFF
--- a/lib/nucleus_web/components/core_components.ex
+++ b/lib/nucleus_web/components/core_components.ex
@@ -749,6 +749,14 @@ defmodule NucleusWeb.CoreComponents do
   the button carries `phx-update="ignore"`, and putting hover state on an
   ignored element is exactly the kind of thing that stops surviving a patch.
 
+  `tooltip_position` defaults to `"top"` — daisyUI's own default, and the
+  right choice in every existing call site, all of which sit comfortably
+  inside their container. It exists as an attr, not a hardcoded class,
+  because a button sitting near a container's right edge (a narrow modal,
+  say) will have `"top"`'s horizontally-centered tooltip clip against that
+  edge; `"left"` anchors the tooltip's content away from the edge instead of
+  over it, with no change to the button itself.
+
   ## `show_label` — text only, full size, no icon
 
   `show_label` is for somewhere with room for the words and a sibling
@@ -766,16 +774,21 @@ defmodule NucleusWeb.CoreComponents do
 
       <.copy_button id="copy-arn" value={@secret.arn} label="Copy ARN" />
       <.copy_button id="copy-value" value={@secret.value} label="Copy value" show_label />
+      <.copy_button id="copy-secret" value={@secret} label="Copy secret" tooltip_position="left" />
   """
   attr :id, :string, required: true
   attr :value, :string, required: true
   attr :label, :string, default: "Copy"
   attr :show_label, :boolean, default: false
+  attr :tooltip_position, :string, default: "top", values: ~w(top bottom left right)
   attr :class, :any, default: nil
 
   def copy_button(assigns) do
     ~H"""
-    <span class={[!@show_label && "tooltip"]} data-tip={!@show_label && @label}>
+    <span
+      class={[!@show_label && "tooltip", !@show_label && tooltip_position_class(@tooltip_position)]}
+      data-tip={!@show_label && @label}
+    >
       <button
         type="button"
         id={@id}
@@ -868,6 +881,24 @@ defmodule NucleusWeb.CoreComponents do
     </script>
     """
   end
+
+  # Tailwind v4's content scanner reads this file as plain text — it cannot
+  # evaluate `"tooltip-#{position}"` at build time, so an interpolated class
+  # name never gets its CSS generated even though the DOM ends up with the
+  # right string. Each branch below spells its class out literally so the
+  # scanner has something to find.
+  #
+  # `attr ... values: ~w(top bottom left right)` only warns at compile time
+  # against a literal misuse in a template — it does not validate a value
+  # computed at runtime (an assign, an interpolated string). The catch-all
+  # below keeps a bad or future `tooltip_position` from raising
+  # `FunctionClauseError` at render time; it falls back to daisyUI's own
+  # default position rather than rendering no tooltip at all.
+  defp tooltip_position_class("top"), do: "tooltip-top"
+  defp tooltip_position_class("bottom"), do: "tooltip-bottom"
+  defp tooltip_position_class("left"), do: "tooltip-left"
+  defp tooltip_position_class("right"), do: "tooltip-right"
+  defp tooltip_position_class(_other), do: "tooltip-top"
 
   @doc """
   Translates an error message using gettext.

--- a/lib/nucleus_web/live/m2m_clients_live/credentials_panel.ex
+++ b/lib/nucleus_web/live/m2m_clients_live/credentials_panel.ex
@@ -40,6 +40,30 @@ defmodule NucleusWeb.M2MClientsLive.CredentialsPanel do
   is display-only, so neither value can be resubmitted to the server by an
   errant form ancestor or a copy-paste into the wrong field.
 
+  ## Warning sits below the key pair, not above it
+
+  The two values render first, the warning directly beneath them, and the
+  dismiss button last — the operator's eyes land on the ID/secret pair,
+  read the warning immediately below without a jump back up the panel, then
+  reach the button right after. Leading with the warning (as an earlier
+  revision did) forced a look-down-then-back-up round trip for no benefit;
+  the modal's own title and this component's dismiss-only design already
+  signal "this is the one chance," so the warning does not need to be seen
+  first to do its job.
+
+  ## Copy-button tooltips point left, not the default top
+
+  Each value's row ends in a `copy_button/1`, whose default tooltip is a
+  `.tooltip-top` pseudo-element centered horizontally over the icon-only
+  button. Centered-over-the-button clips against `.modal-box`'s right edge
+  regardless of how wide the box is made — the tooltip is anchored to the
+  button's center either way, and the button itself sits close to that
+  edge by design (the value it copies fills the rest of the row). Both
+  calls below pass `tooltip_position="left"` instead, which anchors the
+  tooltip's content to the left of the button — away from the edge — so
+  nothing needs to clip and the box keeps `.modal-box`'s ordinary default
+  width.
+
   ## DOM ids default to issue #38's contract, overridable for reuse
 
   The seven ids below are the ones #38's plan tabulates for the creation
@@ -89,18 +113,6 @@ defmodule NucleusWeb.M2MClientsLive.CredentialsPanel do
           Client created
         </h2>
 
-        <div
-          id={@warning_dom_id}
-          role="alert"
-          class="alert alert-warning mb-4 items-start"
-        >
-          <.icon name="hero-exclamation-triangle" class="size-5 shrink-0 mt-0.5" />
-          <span>
-            This secret will not be shown again. Copy both values now — if it's
-            lost, the only recovery is rotating the secret.
-          </span>
-        </div>
-
         <div class="space-y-4">
           <div>
             <div class="text-sm font-medium mb-1">Client ID</div>
@@ -111,7 +123,12 @@ defmodule NucleusWeb.M2MClientsLive.CredentialsPanel do
               >
                 {@client_id}
               </div>
-              <.copy_button id={@copy_client_id_dom_id} value={@client_id} label="Copy client ID" />
+              <.copy_button
+                id={@copy_client_id_dom_id}
+                value={@client_id}
+                label="Copy client ID"
+                tooltip_position="left"
+              />
             </div>
           </div>
 
@@ -128,14 +145,27 @@ defmodule NucleusWeb.M2MClientsLive.CredentialsPanel do
                 id={@copy_client_secret_dom_id}
                 value={@client_secret}
                 label="Copy secret"
+                tooltip_position="left"
               />
             </div>
           </div>
         </div>
 
+        <div
+          id={@warning_dom_id}
+          role="alert"
+          class="alert alert-warning mt-4 mb-4 items-start"
+        >
+          <.icon name="hero-exclamation-triangle" class="size-5 shrink-0 mt-0.5" />
+          <span>
+            Copy the secret now. It will not be shown again. If it's lost,
+            the only recovery is rotating the secret.
+          </span>
+        </div>
+
         <div class="modal-action">
           <.button id={@dismiss_dom_id} type="button" variant="primary" phx-click={@on_dismiss}>
-            I've copied both values — dismiss
+            Done
           </.button>
         </div>
       </.focus_wrap>


### PR DESCRIPTION
## What

Small polish follow-up to the M2M client creation credentials panel (#64, closed #38). The icon-only copy buttons' default top-centered tooltip clips against the modal's right edge when the button sits close to it; and the warning banner reading above the ID/secret pair forced a look-down-then-back-up glance that added nothing. Both are fixed here.

## How

- `<.copy_button>` in `core_components.ex` gains a `tooltip_position` attr (`"top"` default — daisyUI's own default and correct at every other call site — or `"bottom"`/`"left"`/`"right"`). Because Tailwind v4's content scanner reads the file as plain text, an interpolated `"tooltip-#{position}"` string would never get its class generated, so each position is spelled out literally in a small private function, with an unmatched value falling back to `"top"` rather than raising at render time.
- `CredentialsPanel` passes `tooltip_position="left"` to both the client-ID and client-secret copy buttons — anchoring the tooltip content away from `.modal-box`'s right edge instead of centering it over the button.
- The warning banner moves from above the ID/secret values to directly below them, so the eye lands on the values first, reads the warning right underneath, then reaches the dismiss button — no round trip. Warning copy is tightened ("Copy the secret now. It will not be shown again...") and the dismiss button label shortens from "I've copied both values — dismiss" to "Done".
- This is UI polish, not an architectural decision — no new ADR or `decisions-log.md` entry.

## Verification

- `mix precommit` passed: 807 passed (32 doctests, 775 tests), 26 skipped, 13 excluded, 0 failures.
- No new tests added; existing `CredentialsPanel` coverage exercises the reordered markup and both copy buttons unchanged in behaviour, only in tooltip anchor and DOM order.