### PR TITLE
EN-11: Nomad jobs boundary — Nucleus.NomadJobs behaviour, Req impl with detail fan-out, seeded local impl

### DIFF
--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.22 | Updated: 2026-08-25 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.23 | Updated: 2026-08-25 -->
 
 # Decisions Log
 
@@ -46,6 +46,7 @@ job and the row should point rather than paraphrase.
 | 19 | M2M client detail — `Show.mount/3` calls `fetch/2` (no audit) disconnected and `view/2` (audit) only once `connected?(socket)`, so `m2m_client_viewed` fires exactly once per open with no render flicker; `TokenValidity.humanize/1` corrected to the actual three-tier, seconds-based `M2M-A16` rule over the issue's stale hours-only draft; `Format.created_date/1` extracted so `Index`/`Show` share one formatter | 2026-08-20 | Decided | `docs/adr/0019-m2m-client-detail-mount-audit-guard-and-token-validity.md` |
 | 20 | M2M client creation — `create/4` (not the plan's stale `create/3`) threads `token_validity_minutes` through to `Clients.create_client/2`'s own structural range guard; `DenyList.suffixes/0` checked before `denied?/1` (a fail-open ordering bug caught in review, now pinned by a test); the one-time credentials panel is deliberately not `<.modal>` (no backdrop/Escape dismissal); re-lists on success and clears `:credentials` on reopen, reusing ADR-0014's patterns | 2026-08-24 | Decided | `docs/adr/0020-m2m-client-creation-and-credentials-panel.md` |
 | 21 | M2M secret rotation — `rotate/2` mirrors `create/4`'s shape (resolves through `fetch/2`, audits on success only); `CredentialsPanel` gains a `title` attribute rather than forking for rotation's wording; a failed rotation's `:unavailable` kind stays local (`#rotate-secret-error`, "reload and check") rather than collapsing to the shared page-replacing `States.unavailable/1`, since Cognito's rotate sequence can partially apply; retry means re-confirming, not a second control that skips `M2M-A12` | 2026-08-25 | Decided | `docs/adr/0021-m2m-secret-rotation-and-unavailable-copy.md` |
+| 22 | Nomad jobs adapter — `Job.Version` from the detail response not `Meta.version`; periodic run count dropped entirely; image from the `Lifecycle == nil` task not `Tasks[0]`; `ParentID` filtering covers dispatch children too; cron reads `Periodic.Specs \|\| Periodic.Spec`; one `detail_error` field covers all three detail-sourced fields; `:nomad_jobs` kept distinct from wiki `ADR-0007`'s single `NOMAD_BACKEND`; async load with a ~15s overall budget plus a 10s per-request timeout | 2026-08-25 | Decided | `docs/adr/0022-nomad-jobs-adapter.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -67,7 +68,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0021` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0022` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/config/config.exs
+++ b/config/config.exs
@@ -22,16 +22,18 @@ config :nucleus, NucleusWeb.Endpoint,
 # independently — see lib/nucleus/backend.ex and
 # docs/adr/0002-backend-adapter-boundaries.md.
 #
-# These are the `real` implementations, delivered by EN-3, EN-4, and EN-10.
-# dev and test override all three to the `.Local` implementations so a fresh
-# clone needs no credentials; runtime.exs allows a per-boundary override via
-# SECRETS_BACKEND, TENANT_API_BACKEND, and M2M_BACKEND.
+# These are the `real` implementations, delivered by EN-3, EN-4, EN-10, and
+# EN-11. dev and test override all four to the `.Local` implementations so a
+# fresh clone needs no credentials; runtime.exs allows a per-boundary
+# override via SECRETS_BACKEND, TENANT_API_BACKEND, M2M_BACKEND, and
+# NOMAD_JOBS_BACKEND.
 #
 # There is deliberately no `auth` boundary. Authentication is never swappable.
 config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Aws,
   tenant_api: Nucleus.TenantApi.Http,
-  m2m: Nucleus.M2M.Clients.Cognito
+  m2m: Nucleus.M2M.Clients.Cognito,
+  nomad_jobs: Nucleus.NomadJobs.Http
 
 # The tenant's backing API — the authority on environments. `base_url` has no
 # default on purpose: there is no sensible host to fall back to, and a boundary
@@ -74,6 +76,19 @@ config :nucleus, Nucleus.M2M.Clients.Cognito,
   role_arn: nil,
   region: nil,
   external_id: nil
+
+# The tenant's Nomad cluster — see lib/nucleus/nomad/transport.ex. Both
+# NOMAD_ADDR and NOMAD_TOKEN are documented as Required in
+# docs/requirements/Platform-Operations.md, but there is no boot-time check
+# here, matching Nucleus.TenantApi.Http's base_url reasoning: a missing value
+# surfaces as `:not_configured` on the call, never a crash and never a
+# request to a default host. NOMAD_TOKEN absent means every request omits
+# the X-Nomad-Token header entirely, never an empty one.
+config :nucleus, Nucleus.Nomad.Transport,
+  base_url: nil,
+  token: nil,
+  connect_timeout_ms: 5_000,
+  receive_timeout_ms: 10_000
 
 # Identity/scope seam (EN-6) — auth is deliberately deferred; see
 # lib/nucleus/scope.ex and docs/adr/0005-deferred-authentication.md.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -47,12 +47,13 @@ config :nucleus, dev_routes: true
 
 # Run every boundary against its local implementation, so a fresh clone starts
 # with no AWS role and no tenant API reachable. Override per boundary with
-# SECRETS_BACKEND=real / TENANT_API_BACKEND=real / M2M_BACKEND=real (see
-# config/runtime.exs).
+# SECRETS_BACKEND=real / TENANT_API_BACKEND=real / M2M_BACKEND=real /
+# NOMAD_JOBS_BACKEND=real (see config/runtime.exs).
 config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Local,
   tenant_api: Nucleus.TenantApi.Local,
-  m2m: Nucleus.M2M.Clients.Local
+  m2m: Nucleus.M2M.Clients.Local,
+  nomad_jobs: Nucleus.NomadJobs.Local
 
 # Deploy-time cluster/deployment segments of the Parameter Store path (see
 # lib/nucleus/secrets/path.ex). Hardcoded here rather than sourced from an env

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -145,6 +145,30 @@ if user_pool_id = System.get_env("COGNITO_USER_POOL_ID") do
   config :nucleus, Nucleus.M2M.Clients.Cognito, user_pool_id: user_pool_id
 end
 
+# Nomad job reads for the :nomad_jobs boundary's real implementation — read
+# only when that implementation is actually selected, same reasoning as the
+# :secrets and :m2m blocks above. Both NOMAD_ADDR and NOMAD_TOKEN are
+# documented as Required in docs/requirements/Platform-Operations.md, so a
+# real implementation with either missing raises at boot rather than
+# reaching :not_configured on the first call — a developer running fully
+# local, the dev/test default, must not have to invent either to boot the
+# app, which is exactly why this block is gated on the real implementation
+# being selected.
+if Application.get_env(:nucleus, :backends, [])[:nomad_jobs] ==
+     Nucleus.Backend.impl_for_mode!(:nomad_jobs, :real) do
+  nomad_addr =
+    System.get_env("NOMAD_ADDR") ||
+      raise "environment variable NOMAD_ADDR is missing (required when the :nomad_jobs boundary runs its real implementation)"
+
+  nomad_token =
+    System.get_env("NOMAD_TOKEN") ||
+      raise "environment variable NOMAD_TOKEN is missing (required when the :nomad_jobs boundary runs its real implementation)"
+
+  config :nucleus, Nucleus.Nomad.Transport,
+    base_url: nomad_addr,
+    token: nomad_token
+end
+
 # Audit sink overrides. AUDIT_FORMAT is "json" or "text" (see
 # Nucleus.Audit.Format); anything else raises at boot rather than silently
 # falling back — a typo here should not silently change what a compliance

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,8 @@ config :nucleus, Nucleus.Mailer, adapter: Swoosh.Adapters.Test
 config :nucleus, :backends,
   secrets: Nucleus.Secrets.Store.Local,
   tenant_api: Nucleus.TenantApi.Local,
-  m2m: Nucleus.M2M.Clients.Local
+  m2m: Nucleus.M2M.Clients.Local,
+  nomad_jobs: Nucleus.NomadJobs.Local
 
 # Deploy-time cluster/deployment segments of the Parameter Store path — see
 # config/dev.exs and lib/nucleus/secrets/path.ex.

--- a/docs/adr/0022-nomad-jobs-adapter.md
+++ b/docs/adr/0022-nomad-jobs-adapter.md
@@ -1,0 +1,271 @@
+# ADR-0022: Nomad Jobs Adapter
+
+## Status
+
+Accepted — 2026-08-25
+
+Decided on [EN-11](https://github.com/dave-bell/nucleus/issues/57). Builds on
+`0002-backend-adapter-boundaries.md` (behaviour/real-local shape),
+`0003-shared-local-backend-seed.md` (`Nucleus.Backend.Seed`), and the
+list-then-detail fan-out precedent `0016-m2m-client-adapter.md` set for
+EN-10/#33's Cognito boundary.
+
+## Context
+
+`:nomad_jobs` is the boundary the `Applications` view (`docs/requirements/Applications.md`)
+sits on — the EN-3/EN-10 adapter pattern applied to Nomad's HTTP API. Unlike
+those two boundaries, this ticket's issue thread resolved **eight decisions
+before implementation began**, three of which diverged from the plan the
+issue body originally proposed. This ADR is the implementation-time record
+of all eight, plus two design choices implementation itself required that
+the decision thread did not need to settle. Full rationale for each
+Decision lives in its own issue comment, linked below; this ADR does not
+restate it.
+
+## Decision
+
+### 1. `Job.Version` from the detail response, not `Meta.version`
+
+Nomad's scheduler revision integer — read from `GET /v1/job/:id`, never
+`?meta=true` on the list call. Diverges from the plan, which recommended
+`Meta.version`. The prototype's own precedent (`nomad.py:139`, reading
+`job.get("Version", 0)` from the **list** response, which has no `Version`
+field) is a bug, not a design to inherit — it returned `0` for every job,
+so no expectation is anchored to that reading. `Job.Version` answers "which
+submission of this jobspec is live," a real operational signal
+`Meta.version` cannot restate from CI's own image-tag value.
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417134643))
+
+### 2. The periodic run count is dropped entirely
+
+`periodic_run_count` does not exist on `Job.t()`. `JobSummary.Children` is
+never read. `job_gc_threshold` (default 4h) permanently deletes terminal
+periodic children, so a point-in-time `Children` sum is not a lifetime
+total with a caveat — it is a number that looks like one, isn't, and never
+grows for an hourly job. This deletes a binding `Then` clause from
+`APP-A04`, tracked separately as APP-D2, not folded into APP-D1 (#60).
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417135175))
+
+### 3. Image from the task where `Lifecycle == nil`, never `Tasks[0]`
+
+Preferring `Leader == true` if several qualify, otherwise the first in
+order. No driver gate, no `Kind` filter, no new `Nucleus.Backend.Error`
+kind — a job with no qualifying task is `image: nil` with no error, the
+same ordinary absence as a job with no image configured. `Tasks[0]` is
+wrong on this platform: every job has at least a primary task plus an
+injected Consul Connect sidecar (appended, so it never leads), and commonly
+an authored prestart task (conventionally written first). The prototype's
+`nomad.py:159-166` demonstrates the exact bug `Lifecycle == nil` avoids. The
+per-tenant Connect ingress gateway (no `Lifecycle` on its one task, image a
+`${meta.connect.gateway_image}` template variable) is correctly selected by
+this rule and yields the requirement's existing "template-variable image
+reference, shown as-is" row — that row was simply never attributed to this
+subject before.
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417135625))
+
+### 4. `ParentID` filtering applies to every child, not periodic children only
+
+Parameterized/dispatch children are excluded from the list the same way
+periodic children are — one predicate, no job-type branching, and cheaper
+than the alternative (reading `ParameterizedJob` to restrict the filter
+would need it anyway to find the dispatches).
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417136001))
+
+### 5. Cron spec: `Periodic.Specs` if non-empty, else `Periodic.Spec`
+
+Not in the plan, which read only `Periodic.Spec`. Nomad 1.6.2 deprecated
+HCL `cron` in favour of `crons` (`Periodic.Specs`, a list); the two fields
+are mutually exclusive by validation (`nomad/structs/structs.go:5917-5920`
+rejects a job with both set or with neither), with no canonicalisation
+migrating one to the other, so reading both is unambiguous. No multi-cron
+display rule is needed — no multi-cron jobspec is in use.
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417136382))
+
+### 6. One `detail_error` field, not three per-field `*_error` fields
+
+```elixir
+defstruct [:name, :status, :version, :namespace, :image, :cron, :periodic?, :detail_error]
+```
+
+`version`, `image`, and `cron` all come from the *same* per-job detail call
+(Decisions 1, 3, 5) — a consequence of Decision 1 that did not hold when the
+plan was written, since `Meta.version` would have come from the list call
+and survived a detail-fetch failure on its own. Three parallel `*_error`
+fields would carry the identical kind from the identical failure. Non-nil
+`detail_error` means all three are unknown; nil means they are
+authoritative, including `image: nil` meaning a genuine absence.
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417136747))
+
+### 7. `:nomad_jobs` / `NOMAD_JOBS_BACKEND`, diverging from wiki `ADR-0007`
+
+The wiki's `ADR-0007` (reference-only, `docs/adr/0002:9-15`) names a single
+`NOMAD_BACKEND`. Kept separate deliberately: job reads (this boundary) and
+Nomad *Variables* (a future `:nomad_vars` boundary for Data Export,
+read+write) are different capabilities with different access levels.
+Collapsing them into one switch would put a write callback on the same
+boundary as `APP-A08`'s read-only guarantee — exactly the coupling
+`docs/adr/0002-backend-adapter-boundaries.md` exists to prevent. The shared
+`Nucleus.Nomad.Transport` is what the two boundaries actually have in
+common, which is why it is built as its own module now.
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417137215))
+
+### 8. Async load, bounded at two levels
+
+`APP-S1` (#58) loads asynchronously rather than in a synchronous `mount`.
+`Nucleus.NomadJobs.list/1` enforces a ~15s overall budget across the
+fan-out (`Task.async/1` plus `Task.yield/2` + `Task.shutdown/2`), returning
+`{:error, %Error{kind: :unavailable}}` if exceeded; `Nucleus.Nomad.Transport`
+bounds each individual request at 10s (`receive_timeout`). `max_concurrency:
+10` is retained from EN-10/#33's precedent rather than raised to shorten the
+pathological case — that would triple instantaneous load on Nomad to
+optimise a path that only occurs when Nomad is already unhealthy.
+`timeout: :infinity` stays on `Task.async_stream/3` itself: the per-request
+timeout is what should terminate one stalled task, not the stream's own
+timer.
+([Decision](https://github.com/dave-bell/nucleus/issues/57#issuecomment-5417137671))
+
+### Implementation-time addition: one shared translation, not two
+
+Not raised on the issue thread. `Nucleus.NomadJobs.Job.from_api/3`,
+`.degraded/3`, and `.child?/1` are the only functions that read Nomad's
+JSON shapes, and both `Nucleus.NomadJobs.Http` (a real list stub plus a
+real detail response) and `Nucleus.NomadJobs.Local` (one seeded record
+carrying the same two shapes under `"stub"`/`"detail"` keys) call them —
+mirroring the precedent `Nucleus.TenantApi.Environment.from_api_list/1`
+already set between `Http` and `.Local` one boundary over. This is what
+lets a seed fixture (the leading-prestart-task-plus-injected-sidecar
+fixture, the ingress-gateway fixture) prove Decisions 3 and 5's extraction
+logic directly, rather than merely asserting that `Local` returns whatever
+its own fixture already says.
+
+### Implementation-time addition: the ~15s budget is configurable, not a literal
+
+`Nucleus.NomadJobs.list/1` reads its budget from `config :nucleus,
+Nucleus.NomadJobs, budget_ms: ...`, defaulting to 15,000. A hard-coded
+module attribute would force the stalled-fan-out test Decision 8 itself
+calls for to actually block for 15 real seconds; the config seam lets that
+test arm a 50ms budget against a deliberately-stalling fake implementation
+instead.
+
+### Implementation-time correction: the fan-out runs unlinked from its caller
+
+Caught in review, not on the issue thread. The first pass wrapped
+`impl().list_jobs/1` in a bare `Task.async/1`. `Task.async/1` **links** the
+spawned process to its caller, so an unhandled exception anywhere in the
+fan-out — not just a classified `Nucleus.Backend.Error`, which
+`Nucleus.NomadJobs.Http`'s own per-row `rescue` already degrades, but a
+crash in `fetch_list/1`'s own parsing or a pattern-match failure on an
+unexpected list-stub shape — would propagate the linked exit to whatever
+process called `list/1` and kill it too, before `Task.yield/2` ever ran.
+The `{:exit, reason}` branch existed in the `case` but was unreachable: the
+caller died with the task before it could be evaluated. `Nucleus.Application`
+now starts a `Task.Supervisor` (`Nucleus.TaskSupervisor`), and `list/1` uses
+`Task.Supervisor.async_nolink/2` against it — the pattern the `Task` docs
+name specifically for "the caller won't fail" when the task does. A test
+(`test/nucleus/nomad_jobs_test.exs`, "a crash inside the fan-out") spawns
+the caller in its own monitored process and asserts it exits `:normal` with
+a classified error in hand, rather than going down with the task; reverting
+to `Task.async/1` reproduces the failure and makes that test fail.
+
+## Consequences
+
+### Positive
+
+- Both bugs the prototype's `nomad.py` carried (`Version` read from the
+  wrong response; image read from the wrong task) are now impossible to
+  reintroduce silently — each has its own test asserting the *wrong*
+  reading would fail it, not merely that the right one passes.
+- `Nucleus.Nomad.Transport` needs no change to support a future
+  `:nomad_vars` boundary — it takes no assumption specific to jobs beyond
+  its own `boundary` option, which every caller already supplies.
+- The shared `Job.from_api/3`/`.degraded/3` translation means `Local`'s
+  fixtures are not a second, independently-maintained model of Nomad's
+  response shape — a Decision-3/5 regression in `Http` would also break the
+  matching `Local` fixture test, not just its own.
+- `APP-A07`'s error state is reachable within a bounded time under every
+  failure mode this boundary can produce: a failed list call, a stalled
+  fan-out, and (one layer up, in `Nucleus.NomadJobs.list/1`) an exceeded
+  overall budget.
+
+### Negative
+
+- **`APP-D1` (#60) and `APP-D2` are now required before `APP-S2` (#59) can
+  land correctly** — Decisions 1–3 each correct or remove a matrix row in
+  `Applications.md` that predates this ticket. Neither is in this ticket's
+  scope; both are called out explicitly in the Decision comments and in
+  `APP-S1`/`APP-S2`'s own tickets.
+- **A dispatch parent with zero dispatches now carries no activity
+  indicator at all** (Decision 2's run count removal, compounded by
+  Decision 4 folding dispatch parents into the same no-schedule rendering
+  periodic parents get). Accepted as a trade in Decision 2's own comment;
+  revisit with a boolean "has run" if this gap needs closing later.
+- **`detail_error` couples three fields' fate together.** A future Nomad
+  API change that makes only one of `Version`/image/cron detail-only would
+  need this struct revisited — accepted because that is the actual shape of
+  today's single detail call, not a hedge against a hypothetical split.
+
+## Alternatives considered
+
+**`Meta.version` via `GET /v1/jobs?meta=true`.** Rejected — see Decision 1.
+Also would have implied a Nomad ≥ 1.4.x floor the accepted design does not
+need.
+
+**A windowed "N runs in the last `job_gc_threshold`" presentation instead of
+dropping the run count outright.** Rejected — see Decision 2. Nucleus
+cannot discover the window: `job_gc_threshold` is only exposed via
+`/v1/agent/self`, which needs `agent:read`, a capability `ADR-0006` (wiki)
+does not grant.
+
+**A docker-driver gate, or a `Kind`-based exclusion, for image selection.**
+Both rejected — see Decision 3. Every task in a Nucleus-managed job is a
+container, so the driver discriminates nothing; excluding non-empty `Kind`
+would skip a genuine connect-native primary task.
+
+**`Job.VersionTag`** (Nomad 1.9+ named job versions). Considered and
+rejected in Decision 1's own comment — the only candidate for which "not
+available" would be genuinely meaningful, but nothing in the platform tags
+job versions today. Revisit only if release naming is requested.
+
+**`GET /v1/jobs/statuses`**, to avoid the fan-out entirely. Rejected —
+undocumented, absent from the API sidebar, requires `read-job` rather than
+`list-jobs`, has an open pagination bug
+([hashicorp/nomad#28178](https://github.com/hashicorp/nomad/issues/28178)),
+and returns neither the image, `Meta`, nor the cron spec, so it would not
+remove the fan-out even if adopted.
+
+**One `:nomad` boundary instead of `:nomad_jobs` + a future `:nomad_vars`.**
+Rejected — see Decision 7.
+
+**Raising `max_concurrency` above 10 to shorten the pathological fan-out
+case.** Rejected — see Decision 8. Optimises a path that only occurs when
+Nomad is already unhealthy, at the cost of tripling instantaneous load on
+it, and diverges from EN-10's precedent for no benefit in the normal case.
+
+## References
+
+- EN-11 — [issue #57](https://github.com/dave-bell/nucleus/issues/57), the
+  deciding issue, including the full implementation plan and all eight
+  resolved decisions
+- `docs/adr/0002-backend-adapter-boundaries.md` — the behaviour/real-local
+  shape and neutral error kinds this implementation fills in
+- `docs/adr/0003-shared-local-backend-seed.md` — `Nucleus.Backend.Seed`,
+  read (never written) by `Nucleus.NomadJobs.Local`
+- `docs/adr/0016-m2m-client-adapter.md` — the list-then-detail fan-out
+  precedent (`Task.async_stream/3`, degrade-not-fail per row) this
+  implementation follows exactly
+- `docs/requirements/ADR-0006-Nomad-API-Authentication.md` (wiki,
+  reference-only) — the static ACL token this adapter's `X-Nomad-Token`
+  header implements, and the `list-jobs`/`read-job` capability grant this
+  ticket's two-call-per-job design assumes
+- `docs/requirements/ADR-0004-Explicit-Image-Versioning.md` (wiki,
+  reference-only) — background for why "version" and "container image" are
+  two distinct `Job` fields
+- `docs/requirements/Applications.md` — `APP-A01`–`A08`; this ticket claims
+  no `@tag action:` against any of them (APP-S1/#58, APP-S2/#59 claim all
+  eight)
+- APP-S1 (#58), APP-S2 (#59), APP-D1 (#60), APP-D2 — blocked by this
+  ticket; APP-D1/APP-D2 must amend `Applications.md` before APP-S2 can
+  label its columns correctly
+- Prototype
+  [`plugins/nomad.py`](https://github.com/SemaphoreSolutions/labbit-nucleus/blob/c462b1c397172b465d2936a2a31ff6dea29516ac/backend/src/control_plane/plugins/nomad.py) —
+  source of the two transcribed bugs Decisions 1 and 3 correct

--- a/lib/nucleus/application.ex
+++ b/lib/nucleus/application.ex
@@ -18,6 +18,11 @@ defmodule Nucleus.Application do
       # ship in the release but are never selected in production, so gating this
       # would only add a "seed owner missing" branch for readers to handle.
       Nucleus.Backend.Seed,
+      # Runs Nucleus.NomadJobs.list/1's detail fan-out unlinked from its caller
+      # (Task.Supervisor.async_nolink/2) — a crash inside the fan-out must
+      # degrade to {:error, %Error{kind: :unavailable}} within list/1's own
+      # budget, never take the calling LiveView process down with it.
+      {Task.Supervisor, name: Nucleus.TaskSupervisor},
       # Start a worker by calling: Nucleus.Worker.start_link(arg)
       # {Nucleus.Worker, arg},
       # Start to serve requests, typically the last entry

--- a/lib/nucleus/backend.ex
+++ b/lib/nucleus/backend.ex
@@ -15,24 +15,25 @@ defmodule Nucleus.Backend do
   | `:secrets` | AWS SSM Parameter Store, in the tenant's account | `Nucleus.Secrets.Store.Aws` | `Nucleus.Secrets.Store.Local` |
   | `:tenant_api` | Tenant backing API (authoritative environment list) | `Nucleus.TenantApi.Http` | `Nucleus.TenantApi.Local` |
   | `:m2m` | Cognito App Clients, in this tenant's user pool | `Nucleus.M2M.Clients.Cognito` | `Nucleus.M2M.Clients.Local` |
+  | `:nomad_jobs` | Nomad job list + detail, read-only | `Nucleus.NomadJobs.Http` | `Nucleus.NomadJobs.Local` |
 
   The behaviours and both implementations are delivered by EN-3 (`:tenant_api`),
-  EN-4 (`:secrets`), and EN-10 (`:m2m`). This module is the shared scaffolding
-  they plug into, so the module names above are registered here before the
-  modules exist.
+  EN-4 (`:secrets`), EN-10 (`:m2m`), and EN-11 (`:nomad_jobs`). This module is
+  the shared scaffolding they plug into, so the module names above are
+  registered here before the modules exist.
 
   Authentication is deliberately absent. There is no `:auth` boundary and no
   `AUTH_BACKEND` — auth is the actual security boundary and is never swappable.
 
   ## Selection
 
-      config :nucleus, :backends, secrets: Nucleus.Secrets.Store.Aws, tenant_api: Nucleus.TenantApi.Http, m2m: Nucleus.M2M.Clients.Cognito
+      config :nucleus, :backends, secrets: Nucleus.Secrets.Store.Aws, tenant_api: Nucleus.TenantApi.Http, m2m: Nucleus.M2M.Clients.Cognito, nomad_jobs: Nucleus.NomadJobs.Http
 
-  `config/dev.exs` and `config/test.exs` override all three to the local
+  `config/dev.exs` and `config/test.exs` override all four to the local
   implementations, so a fresh clone runs and its tests pass with no
   credentials at all. `config/runtime.exs` allows a per-boundary override
-  through `SECRETS_BACKEND`, `TENANT_API_BACKEND`, and `M2M_BACKEND`, each
-  `"real"` (the default) or `"local"`.
+  through `SECRETS_BACKEND`, `TENANT_API_BACKEND`, `M2M_BACKEND`, and
+  `NOMAD_JOBS_BACKEND`, each `"real"` (the default) or `"local"`.
 
   Selection is per boundary rather than one global switch because the pain it
   solves is per boundary: Parameter Store access needs a Terraform-provisioned
@@ -58,19 +59,20 @@ defmodule Nucleus.Backend do
   @impls %{
     secrets: %{real: Nucleus.Secrets.Store.Aws, local: Nucleus.Secrets.Store.Local},
     tenant_api: %{real: Nucleus.TenantApi.Http, local: Nucleus.TenantApi.Local},
-    m2m: %{real: Nucleus.M2M.Clients.Cognito, local: Nucleus.M2M.Clients.Local}
+    m2m: %{real: Nucleus.M2M.Clients.Cognito, local: Nucleus.M2M.Clients.Local},
+    nomad_jobs: %{real: Nucleus.NomadJobs.Http, local: Nucleus.NomadJobs.Local}
   }
 
   @boundaries Enum.sort(Map.keys(@impls))
 
-  @type boundary :: :secrets | :tenant_api | :m2m
+  @type boundary :: :secrets | :tenant_api | :m2m | :nomad_jobs
   @type mode :: :real | :local
 
   @doc """
   Every known boundary.
 
       iex> Nucleus.Backend.boundaries()
-      [:m2m, :secrets, :tenant_api]
+      [:m2m, :nomad_jobs, :secrets, :tenant_api]
   """
   @spec boundaries() :: [boundary()]
   def boundaries, do: @boundaries

--- a/lib/nucleus/nomad/transport.ex
+++ b/lib/nucleus/nomad/transport.ex
@@ -1,0 +1,219 @@
+defmodule Nucleus.Nomad.Transport do
+  @moduledoc """
+  Shared `Req`-based transport for every Nomad HTTP API boundary.
+
+  Deliberately its own module, not folded into `Nucleus.NomadJobs.Http` — Data
+  Export (`docs/requirements/Data-Export-Configuration.md`) needs Nomad
+  *Variables* under a different boundary (`:nomad_vars`, read+write) and will
+  reuse this transport unchanged. Building it once now avoids the
+  retro-extraction EN-9 had to perform for the shared AWS identity seam. See
+  `docs/adr/0022-nomad-jobs-adapter.md`.
+
+  ## The destination is deployment configuration, never a caller's choice
+
+  The base URL comes from `NOMAD_ADDR`, validated the same way
+  `Nucleus.TenantApi.Http`'s `url/0` guards against SSRF (`PRX-A07`): a
+  missing, blank, or unparseable base URL is `{:error, %Error{kind:
+  :not_configured}}` **with no request attempted**, never a crash and never a
+  request to some default host. `path` is supplied by the calling boundary
+  (`/v1/jobs`, `/v1/job/:id`, ...), never by an end user.
+
+  ## Auth is a static deployment token, not a passthrough
+
+  `X-Nomad-Token` is set from `NOMAD_TOKEN` per
+  `docs/requirements/ADR-0006-Nomad-API-Authentication.md`'s static-ACL-token
+  decision. The header is omitted entirely when the token is unset or blank —
+  never sent as an empty string.
+
+  ## Failure is prompt and total
+
+  `retry: false` — a retry ladder turns a clean fail-closed rejection into a
+  hung caller, the same reasoning `Nucleus.TenantApi.Http` states for the
+  tenant API. `redirect: false` — a redirect risks carrying the token to
+  whatever host it names; it maps to `:unavailable` like any other unexpected
+  status. `receive_timeout` bounds **one** request (10s by default, Decision 8
+  — `docs/adr/0022-nomad-jobs-adapter.md`); the overall fan-out budget belongs
+  to the caller (`Nucleus.NomadJobs.list/1`), not this transport.
+
+  ## Never log the token, never log the body
+
+  Only the status, a per-call request identifier, and — on transport failure —
+  the error's reason. Matches `Nucleus.TenantApi.Http`'s logging discipline
+  exactly.
+
+  ## Assumed response shape
+
+  A top-level JSON object or array, per Nomad's own HTTP API. This is
+  asserted rather than guessed at: an undecodable or absent body on a `200` is
+  `:unavailable`, not a best-effort parse. Shape-specific validation (is this
+  actually a list of jobs?) is the calling boundary's job, not this
+  transport's — `request/3` hands back whatever `Jason.decode/1` produces.
+  """
+
+  require Logger
+
+  alias Nucleus.Backend.Error
+
+  @default_connect_timeout_ms 5_000
+  @default_receive_timeout_ms 10_000
+
+  @doc """
+  Performs one Nomad HTTP API request.
+
+  ## Options
+
+    * `:boundary` (required) — the calling boundary (`:nomad_jobs` today, a
+      future `:nomad_vars`), attributed on every `Nucleus.Backend.Error` this
+      call can return.
+    * `:query` — a keyword list of query parameters, URL-encoded by `Req`.
+
+  Status mapping is an explicit `case`, never a default-to-success: `200`
+  decodes the body; `401`/`403` map to `:auth_expired`; every other status,
+  and any transport-level failure, maps to `:unavailable`.
+  """
+  @spec request(method :: atom(), path :: String.t(), opts :: keyword()) ::
+          {:ok, map() | list()} | {:error, Error.t()}
+  def request(method, path, opts \\ [])
+      when is_atom(method) and is_binary(path) and is_list(opts) do
+    boundary = Keyword.fetch!(opts, :boundary)
+    query = Keyword.get(opts, :query, [])
+    request_id = request_id()
+
+    with {:ok, url} <- url(path, boundary) do
+      perform(method, url, path, query, boundary, request_id)
+    end
+  end
+
+  defp perform(method, url, path, query, boundary, request_id) do
+    request =
+      Req.new(
+        [
+          method: method,
+          url: url,
+          params: query,
+          headers: headers(),
+          retry: false,
+          redirect: false,
+          decode_body: false,
+          receive_timeout: timeout(:receive_timeout_ms, @default_receive_timeout_ms),
+          connect_options: [timeout: timeout(:connect_timeout_ms, @default_connect_timeout_ms)]
+        ] ++ Keyword.take(config(), [:plug])
+      )
+
+    case Req.request(request) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        log(:info, method, path, "200", request_id)
+        decode(body, boundary, request_id)
+
+      {:ok, %Req.Response{status: status}} when status in [401, 403] ->
+        log(:warning, method, path, status, request_id)
+
+        {:error,
+         error(boundary, :auth_expired, "nomad rejected our credentials", %{
+           status: status,
+           request_id: request_id
+         })}
+
+      {:ok, %Req.Response{status: status}} ->
+        log(:warning, method, path, status, request_id)
+
+        {:error,
+         error(boundary, :unavailable, "nomad answered #{status}", %{
+           status: status,
+           request_id: request_id
+         })}
+
+      {:error, exception} ->
+        Logger.warning(
+          "nomad #{method} #{path} failed: #{transport_reason(exception)} " <>
+            "request_id=#{request_id}"
+        )
+
+        {:error,
+         error(boundary, :unavailable, "nomad is unreachable", %{
+           reason: transport_reason(exception),
+           request_id: request_id
+         })}
+    end
+  end
+
+  defp decode(body, boundary, request_id) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} ->
+        {:ok, decoded}
+
+      {:error, _reason} ->
+        # The decoder's message quotes the offending input, so it is
+        # deliberately not carried into `details` — that would put the
+        # response body in a log, the same rule Nucleus.TenantApi.Http states.
+        {:error,
+         error(boundary, :unavailable, "nomad returned a body that is not JSON", %{
+           request_id: request_id
+         })}
+    end
+  end
+
+  defp decode(_body, boundary, request_id) do
+    {:error, error(boundary, :unavailable, "nomad returned no body", %{request_id: request_id})}
+  end
+
+  defp url(path, boundary) do
+    case config()[:base_url] do
+      value when is_binary(value) -> validate_base_url(String.trim(value), path, boundary)
+      _absent -> {:error, not_configured(boundary)}
+    end
+  end
+
+  defp validate_base_url(base_url, path, boundary) do
+    case URI.new(base_url) do
+      {:ok, %URI{scheme: scheme, host: host}}
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        {:ok, String.trim_trailing(base_url, "/") <> path}
+
+      _invalid ->
+        {:error, not_configured(boundary)}
+    end
+  end
+
+  defp not_configured(boundary) do
+    error(
+      boundary,
+      :not_configured,
+      "NOMAD_ADDR is missing or is not an http(s) URL",
+      %{variable: "NOMAD_ADDR"}
+    )
+  end
+
+  defp headers do
+    case config()[:token] do
+      token when is_binary(token) and token != "" ->
+        [{"accept", "application/json"}, {"x-nomad-token", token}]
+
+      _blank_or_nil ->
+        [{"accept", "application/json"}]
+    end
+  end
+
+  defp timeout(key, default) do
+    case config()[key] do
+      ms when is_integer(ms) and ms > 0 -> ms
+      _absent_or_invalid -> default
+    end
+  end
+
+  defp log(level, method, path, status, request_id) do
+    Logger.log(level, "nomad #{method} #{path} -> #{status} request_id=#{request_id}")
+  end
+
+  defp transport_reason(%{reason: reason}), do: inspect(reason)
+  defp transport_reason(%module{}), do: inspect(module)
+  defp transport_reason(other), do: inspect(other)
+
+  defp request_id, do: 8 |> :crypto.strong_rand_bytes() |> Base.encode16(case: :lower)
+
+  defp config, do: Application.get_env(:nucleus, __MODULE__, [])
+
+  defp error(boundary, kind, message, details) do
+    Error.new(kind, boundary, message, details)
+  end
+end

--- a/lib/nucleus/nomad_jobs.ex
+++ b/lib/nucleus/nomad_jobs.ex
@@ -1,0 +1,175 @@
+defmodule Nucleus.NomadJobs do
+  @moduledoc """
+  The boundary to Nomad job data for the tenant's `Applications` view
+  (`docs/requirements/Applications.md`) — read-only visibility into what is
+  actually deployed, never a way to change it.
+
+  Two implementations, selected per boundary by `NOMAD_JOBS_BACKEND` — see
+  `Nucleus.Backend`:
+
+  | Mode | Module | |
+  |---|---|---|
+  | `real` | `Nucleus.NomadJobs.Http` | `Nucleus.Nomad.Transport` against the tenant's Nomad cluster |
+  | `local` | `Nucleus.NomadJobs.Local` | `priv/backends/local_seed.json` |
+
+  Named `:nomad_jobs`, not `:nomad` — deliberately diverging from wiki
+  `ADR-0007`, which names a single `NOMAD_BACKEND`. Job **reads** (this
+  boundary) and Nomad *Variables* (a future `:nomad_vars` boundary for Data
+  Export configuration, read+write) are different capabilities with
+  different access levels; collapsing them into one switch would put a write
+  callback on the same boundary as `APP-A08`'s read-only guarantee. See
+  `docs/adr/0022-nomad-jobs-adapter.md`, Decision 7.
+
+  ## Call through this module, not an implementation
+
+  `list/1` and `health_check/0` resolve the implementation on every call,
+  through `Nucleus.Backend.impl_for/1`. Nothing outside this module should
+  name `Http` or `Local`.
+
+  ## No create, update, or delete callback of any kind
+
+  This boundary is read-only **by construction**, in the terms
+  `Nucleus.Secrets.Store` and `Nucleus.M2M.Clients` use for their own
+  omissions (rotation aside, in M2M's case). `APP-A08` depends on this being
+  true one layer below the UI, not merely enforced by a LiveView template
+  choosing not to render a button.
+
+  ## Emits no audit event
+
+  `Applications.md`'s audit table is empty by design: "Viewing deployed
+  application status is not a sensitive read." Matches the omission
+  `Nucleus.M2M.list/1` documents for client listing.
+
+  ## `list/1` takes a `Scope`, but tenancy does not come from it
+
+  Matches `Nucleus.M2M.list/1`'s signature — `scope` is accepted for
+  call-site symmetry with every other context function, not read here for
+  tenancy. Nomad, like Cognito, has no per-request environment or tenant
+  switch: one cluster per deployment, no runtime tenant switching
+  (`docs/requirements/Platform-Operations.md`). The namespace comes from
+  `Nucleus.Scope.tenant_namespace/0` (deployment config) — the same source
+  `Nucleus.M2M.Clients.Cognito` reads for its own tenant-scoped OAuth scope.
+  See `Nucleus.M2M`'s moduledoc, "Note the asymmetry with Secrets", for the
+  fuller reasoning this borrows.
+
+  ## The intended call site is a `Task`, not the LiveView process
+
+  `APP-S1` (#58) mounts immediately with a loading state and runs this call
+  off the LiveView process (Decision 8). `list/1` is safe to call from
+  anywhere — no process-dictionary state, no `self()` assumption — but this
+  is the only intended call site, which is why the budget below exists: it
+  guarantees the eventual `Task` result resolves into something rather than
+  hanging.
+
+  ## The ~15s overall budget
+
+  The detail fan-out (`Nucleus.NomadJobs.Http`) runs
+  `Task.async_stream(max_concurrency: 10, timeout: :infinity)` against every
+  parent job — the per-request `receive_timeout` (10s,
+  `Nucleus.Nomad.Transport`) is what terminates one stalled call, not the
+  stream's own timer. But nothing bounds *all the waves* that concurrency
+  produces against a namespace with many jobs, so `list/1` wraps the whole
+  call in its own budget and returns `{:error, %Error{kind: :unavailable}}`
+  if it is exceeded — `APP-A07`'s error state is always reachable within a
+  bounded time, never an indefinite spinner. See
+  `docs/adr/0022-nomad-jobs-adapter.md`, Decision 8.
+
+  The budget defaults to 15s and is configurable via `config :nucleus,
+  Nucleus.NomadJobs, budget_ms: ...` — a fixed module attribute would force a
+  stalled-detail test to actually wait 15 real seconds to exercise this
+  branch.
+  ## A crash inside the fan-out must not take the caller down with it
+
+  `list/1` runs the implementation through `Task.Supervisor.async_nolink/2`
+  (`Nucleus.TaskSupervisor`, `lib/nucleus/application.ex`), never
+  `Task.async/1`. `Task.async/1` **links** the spawned process to the
+  caller — an unhandled exception anywhere in the fan-out (not just a
+  classified `Nucleus.Backend.Error`, which `Nucleus.NomadJobs.Http`'s own
+  per-row `rescue` already degrades) would propagate the exit signal to
+  whatever process called `list/1` and kill it too, before the `Task.yield/2`
+  logic below ever ran. `async_nolink/2` is what makes the `{:exit, reason}`
+  branch reachable at all, and what keeps the ~15s budget's guarantee — "an
+  error tuple, never a crash" — true for the caller as well as for `list/1`
+  itself.
+  """
+
+  alias Nucleus.Backend
+  alias Nucleus.Backend.Error
+  alias Nucleus.NomadJobs.Job
+  alias Nucleus.Scope
+
+  @boundary :nomad_jobs
+  @budget_ms 15_000
+  @task_supervisor Nucleus.TaskSupervisor
+
+  @doc """
+  Every parent job in `namespace`'s Nomad namespace (`APP-A01`).
+
+  Child jobs — periodic and parameterized/dispatch alike — must already be
+  excluded by the implementation before returning; see
+  `Nucleus.NomadJobs.Job.child?/1`.
+
+  A per-job detail-fetch failure degrades that one row (`Job.detail_error`
+  set, `version`/`image`/`cron` all `nil`) rather than failing the whole
+  list — only a failure of the list call itself does that.
+  """
+  @callback list_jobs(namespace :: String.t()) :: {:ok, [Job.t()]} | {:error, Error.t()}
+
+  @doc """
+  Whether this boundary can reach the system behind it.
+  """
+  @callback health_check() :: :ok | {:error, Error.t()}
+
+  @doc """
+  The boundary name, for `Nucleus.Backend` and error construction.
+  """
+  @spec boundary() :: atom()
+  def boundary, do: @boundary
+
+  @doc """
+  Every deployed application, through the configured implementation, bounded
+  to a ~15s overall budget.
+
+  See the module doc for why `scope` is accepted but not read for tenancy,
+  why the budget lives here rather than in the transport or the
+  implementation, and why the fan-out runs unlinked from the caller.
+  """
+  @spec list(Scope.t()) :: {:ok, [Job.t()]} | {:error, Error.t()}
+  def list(%Scope{} = _scope) do
+    namespace = Scope.tenant_namespace()
+    budget_ms = budget_ms()
+    task = Task.Supervisor.async_nolink(@task_supervisor, fn -> impl().list_jobs(namespace) end)
+
+    case Task.yield(task, budget_ms) || Task.shutdown(task, :brutal_kill) do
+      {:ok, result} ->
+        result
+
+      {:exit, reason} ->
+        {:error,
+         Error.new(:unavailable, @boundary, "the nomad jobs fan-out crashed", %{
+           reason: inspect(reason)
+         })}
+
+      nil ->
+        {:error,
+         Error.new(
+           :unavailable,
+           @boundary,
+           "nomad did not answer within the overall budget",
+           %{budget_ms: budget_ms}
+         )}
+    end
+  end
+
+  @doc """
+  Checks the configured implementation can reach Nomad.
+  """
+  @spec health_check() :: :ok | {:error, Error.t()}
+  def health_check, do: impl().health_check()
+
+  defp budget_ms do
+    Application.get_env(:nucleus, __MODULE__, []) |> Keyword.get(:budget_ms, @budget_ms)
+  end
+
+  defp impl, do: Backend.impl_for(@boundary)
+end

--- a/lib/nucleus/nomad_jobs/http.ex
+++ b/lib/nucleus/nomad_jobs/http.ex
@@ -1,0 +1,135 @@
+defmodule Nucleus.NomadJobs.Http do
+  @moduledoc """
+  Nomad jobs over HTTP, using `Nucleus.Nomad.Transport`.
+
+  ## Two calls per parent job — unavoidable, not a design choice to litigate
+
+  `GET /v1/jobs?namespace=<namespace>` returns a `JobListStub` per job: no
+  container image, no `Job.Version`, and `Periodic` as a boolean rather than
+  the cron object. `ADR-0006`'s (wiki) accepted decision already grants both
+  `list-jobs` and `read-job` in the deployment namespace and anticipates this
+  fan-out directly. `Task.async_stream/3` with `max_concurrency: 10,
+  timeout: :infinity` — the same construction EN-10/#33's
+  `Nucleus.M2M.Clients.Cognito.list_clients/0` uses for its own
+  list-then-describe fan-out. `timeout: :infinity` is correct on the stream
+  itself: the per-request `receive_timeout` (`Nucleus.Nomad.Transport`)
+  terminates a stalled call, and the overall budget belongs to
+  `Nucleus.NomadJobs.list/1`, not this module or the stream.
+
+  ## Children are filtered before the fan-out, not after
+
+  `ParentID` is present in the **list** stub, so `Nucleus.NomadJobs.Job.child?/1`
+  runs against the raw stub before any detail call — periodic and
+  parameterized/dispatch children alike (Decision 4) never cost a
+  `GET /v1/job/:id`.
+
+  ## A per-job detail failure degrades that one row
+
+  `Nucleus.NomadJobs.Job.degraded/3`, not a failure of the whole list. A
+  `rescue` around each fan-out task additionally catches an unexpected
+  response shape (a future Nomad API change) exactly like a classified
+  `Nucleus.Backend.Error` does, mirroring
+  `Nucleus.M2M.Clients.Cognito.describe_for_list/3`'s own `rescue` — logging
+  only the exception's module, never its message, since a `MatchError`
+  carries the full unexpected term.
+
+  See `docs/adr/0022-nomad-jobs-adapter.md` for the full decision record.
+  """
+
+  @behaviour Nucleus.NomadJobs
+
+  require Logger
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Nomad.Transport
+  alias Nucleus.NomadJobs
+  alias Nucleus.NomadJobs.Job
+
+  @max_concurrency 10
+
+  @impl NomadJobs
+  def list_jobs(namespace) when is_binary(namespace) do
+    with {:ok, stubs} <- fetch_list(namespace) do
+      jobs =
+        stubs
+        |> Enum.reject(&Job.child?/1)
+        |> fan_out(namespace)
+
+      {:ok, jobs}
+    end
+  end
+
+  @impl NomadJobs
+  def health_check do
+    # Reachability, not permission — the same reasoning
+    # Nucleus.TenantApi.Http.health_check/0 states. An auth failure still
+    # means Nomad answered; only an unreachable or errored Nomad is unhealthy.
+    case fetch_list(Nucleus.Scope.tenant_namespace()) do
+      {:ok, _stubs} -> :ok
+      {:error, %Error{kind: :auth_expired}} -> :ok
+      {:error, %Error{} = error} -> {:error, error}
+    end
+  end
+
+  defp fetch_list(namespace) do
+    case Transport.request(:get, "/v1/jobs",
+           query: [namespace: namespace],
+           boundary: NomadJobs.boundary()
+         ) do
+      {:ok, stubs} when is_list(stubs) ->
+        {:ok, stubs}
+
+      {:ok, _other} ->
+        {:error, error(:unavailable, "nomad returned an unexpected shape for /v1/jobs")}
+
+      {:error, %Error{} = error} ->
+        {:error, error}
+    end
+  end
+
+  defp fan_out(stubs, namespace) do
+    stubs
+    |> Task.async_stream(&build_job(&1, namespace),
+      max_concurrency: @max_concurrency,
+      timeout: :infinity
+    )
+    |> Enum.map(fn {:ok, job} -> job end)
+  end
+
+  defp build_job(%{"ID" => id} = stub, namespace) do
+    case fetch_detail(id, namespace) do
+      {:ok, detail} -> Job.from_api(stub, detail, namespace)
+      {:error, %Error{kind: kind}} -> Job.degraded(stub, namespace, kind)
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "nomad_jobs detail fan-out unexpected failure job_id=#{id} " <>
+          "exception=#{inspect(error.__struct__)}"
+      )
+
+      Job.degraded(stub, namespace, :unavailable)
+  end
+
+  defp fetch_detail(job_id, namespace) do
+    path = "/v1/job/" <> URI.encode(job_id)
+
+    case Transport.request(:get, path,
+           query: [namespace: namespace],
+           boundary: NomadJobs.boundary()
+         ) do
+      {:ok, %{} = detail} ->
+        {:ok, detail}
+
+      {:ok, _other} ->
+        {:error, error(:unavailable, "nomad returned an unexpected shape for /v1/job")}
+
+      {:error, %Error{} = error} ->
+        {:error, error}
+    end
+  end
+
+  defp error(kind, message, details \\ %{}) do
+    Error.new(kind, NomadJobs.boundary(), message, details)
+  end
+end

--- a/lib/nucleus/nomad_jobs/job.ex
+++ b/lib/nucleus/nomad_jobs/job.ex
@@ -1,0 +1,152 @@
+defmodule Nucleus.NomadJobs.Job do
+  @moduledoc """
+  One deployed application (`APP-A01`), and the shared translation from
+  Nomad's own JSON shapes into that struct.
+
+  `from_api/3` and `child?/1` are called by both `Nucleus.NomadJobs.Http` (a
+  real list stub plus a real per-job detail response) and
+  `Nucleus.NomadJobs.Local` (one seeded record modelling the same two
+  shapes) — the same "translation is shared, not duplicated" precedent
+  `Nucleus.TenantApi.Environment.from_api_list/1` sets between
+  `Nucleus.TenantApi.Http` and `.Local`. A seed fixture therefore exercises
+  the exact same extraction logic a real Nomad response would.
+
+  ## Fields
+
+    * `name`, `status`, `namespace`, `periodic?` — from the list stub.
+      `status` is one of Nomad's three documented values (`"pending"`,
+      `"running"`, `"dead"`), cast defensively: an unknown value passes
+      through as-is rather than crashing.
+    * `version` — `Job.Version`, Nomad's scheduler revision integer. A
+      revision counter, not a release identifier: it says the jobspec was
+      resubmitted, never what changed (`APP-S2`/#59 labels this column "Job
+      revision" accordingly). **Not** `Meta.version` — see `version_from/1`.
+    * `image` — the container image reference of the task where `Lifecycle
+      == nil`. **Not** `Tasks[0]` — see `image_from/1`. `nil` when no task
+      qualifies, which is a genuine absence, not a fetch failure.
+    * `cron` — the cron spec, or `nil` when `periodic?` is `false`. Never a
+      blank string (`APP-A05`).
+    * `detail_error` — a `Nucleus.Backend.Error.kind()` or `nil`. Non-nil
+      means `version`, `image`, **and** `cron` are all unknown for this row,
+      since all three come from the one per-job detail call. Nil means they
+      are authoritative.
+
+  See `docs/adr/0022-nomad-jobs-adapter.md` for the decisions behind each of
+  these (Decisions 1, 2, 3, 5, 6).
+  """
+
+  alias Nucleus.Backend.Error
+
+  @enforce_keys [:name, :status, :namespace, :periodic?]
+  defstruct [:name, :status, :version, :namespace, :image, :cron, :periodic?, :detail_error]
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          status: String.t(),
+          version: non_neg_integer() | nil,
+          namespace: String.t(),
+          image: String.t() | nil,
+          cron: String.t() | nil,
+          periodic?: boolean(),
+          detail_error: Error.kind() | nil
+        }
+
+  @doc """
+  Whether `stub` (a Nomad `JobListStub`-shaped map) names a child job that
+  must not surface as its own row (`APP-A01`).
+
+  Applies to periodic **and** parameterized/dispatch children alike
+  (Decision 4) — any non-blank `ParentID` excludes it, with no knowledge of
+  job type needed.
+  """
+  @spec child?(map()) :: boolean()
+  def child?(%{"ParentID" => parent_id}) when is_binary(parent_id), do: parent_id != ""
+  def child?(_stub), do: false
+
+  @doc """
+  Builds a fully-resolved job from a list stub and its per-job detail
+  response.
+  """
+  @spec from_api(stub :: map(), detail :: map(), namespace :: String.t()) :: t()
+  def from_api(stub, detail, namespace) do
+    %__MODULE__{
+      name: stub["Name"],
+      status: stub["Status"],
+      namespace: namespace,
+      periodic?: periodic?(stub),
+      version: version_from(detail),
+      image: image_from(detail),
+      cron: cron_from(detail),
+      detail_error: nil
+    }
+  end
+
+  @doc """
+  Builds a degraded job: the list stub's fields are authoritative, but the
+  per-job detail call failed, so `version`, `image`, and `cron` are all
+  unknown (Decision 6).
+  """
+  @spec degraded(stub :: map(), namespace :: String.t(), kind :: Error.kind()) :: t()
+  def degraded(stub, namespace, kind) do
+    %__MODULE__{
+      name: stub["Name"],
+      status: stub["Status"],
+      namespace: namespace,
+      periodic?: periodic?(stub),
+      version: nil,
+      image: nil,
+      cron: nil,
+      detail_error: kind
+    }
+  end
+
+  defp periodic?(%{"Periodic" => true}), do: true
+  defp periodic?(_stub), do: false
+
+  # `Job.Version` — Nomad's scheduler revision integer (Decision 1). The list
+  # stub carries no `Version` field at all (the prototype's `nomad.py:139`
+  # bug read `job.get("Version", 0)` from it and got 0 every time), so this
+  # only ever reads the detail response.
+  defp version_from(%{"Version" => version}) when is_integer(version), do: version
+  defp version_from(_detail), do: nil
+
+  # The task where `Lifecycle == nil` — never `Tasks[0]` (Decision 3).
+  # Authored prestart tasks commonly come first in the HCL, and an injected
+  # Consul Connect sidecar is appended, so position alone selects the wrong
+  # task for a job authored that way (the prototype's `nomad.py:159-166` bug).
+  # Prefers `Leader == true` if several tasks qualify, otherwise the first in
+  # encounter order. No driver gate and no `Kind` filter: every task here is
+  # a container, and a connect-native primary task keeps a non-nil `Kind` but
+  # still has `Lifecycle == nil`, so it is correctly kept.
+  defp image_from(%{"TaskGroups" => groups}) when is_list(groups) do
+    groups
+    |> Enum.flat_map(&Map.get(&1, "Tasks", []))
+    |> Enum.filter(&(&1["Lifecycle"] == nil))
+    |> pick_task()
+    |> case do
+      nil -> nil
+      task -> get_in(task, ["Config", "image"])
+    end
+  end
+
+  defp image_from(_detail), do: nil
+
+  defp pick_task([]), do: nil
+  defp pick_task([first | _] = tasks), do: Enum.find(tasks, first, &(&1["Leader"] == true))
+
+  # `Periodic.Specs` if non-empty, else `Periodic.Spec` (Decision 5) — the
+  # two are mutually exclusive in every jobspec Nomad accepts (validation
+  # rejects a job with both set, or with neither), so reading both covers the
+  # legacy `cron` block and the modern `crons` block with no multi-cron
+  # display rule needed. `Enum.join/2` only matters if a multi-cron jobspec
+  # ever appears; none does today.
+  defp cron_from(%{"Periodic" => %{"Specs" => specs}}) when is_list(specs) and specs != [] do
+    Enum.join(specs, ", ")
+  end
+
+  defp cron_from(%{"Periodic" => %{"Spec" => spec}}) when is_binary(spec) and spec != "" do
+    spec
+  end
+
+  defp cron_from(_detail), do: nil
+end

--- a/lib/nucleus/nomad_jobs/local.ex
+++ b/lib/nucleus/nomad_jobs/local.ex
@@ -1,0 +1,101 @@
+defmodule Nucleus.NomadJobs.Local do
+  @moduledoc """
+  Nomad jobs served from `priv/backends/local_seed.json`.
+
+  A real implementation of `Nucleus.NomadJobs`, not a test double — the same
+  module serves `mix phx.server` in development and the test suite. A fresh
+  clone needs no Nomad ACL token to exercise the `Applications` view at all.
+
+  ## State lives in `Nucleus.Backend.Seed`, not a second `Agent`
+
+  Reads go through `Seed.read/1`, keyed on this boundary's `"nomad_jobs"`
+  section — the same reasoning `Nucleus.TenantApi.Local` and
+  `Nucleus.M2M.Clients.Local` document for their own sections. This boundary
+  has no mutation of any kind (see `Nucleus.NomadJobs`'s moduledoc), so
+  `Seed.update/2` is never called here.
+
+  ## The seed section's shape mirrors two real Nomad API calls, not one struct
+
+  A list of `%{"stub" => ..., "detail" => ...}` entries — `"stub"` shaped
+  like one element of `GET /v1/jobs`'s response, `"detail"` shaped like
+  `GET /v1/job/:id`'s. `Nucleus.NomadJobs.Job.from_api/3` and `.child?/1` are
+  the exact functions `Nucleus.NomadJobs.Http` calls against a real
+  response, so a fixture here exercises the same translation logic a real
+  Nomad job would — the same "seed mirrors the real shape" precedent
+  `Nucleus.TenantApi.Local` sets by seeding `Environment.from_api_list/1`'s
+  own input shape.
+
+  ## The fixtures are deliberate
+
+  | Entry | Exercises |
+  |---|---|
+  | `acme-api` | primary task selection: an authored prestart task first, an injected-shaped `connect-proxy-*` sidecar, image read from neither (Decision 3) |
+  | `acme-ingress` | `Lifecycle == nil` selecting the one task on a Connect ingress gateway job, yielding its unresolved `${meta.connect.gateway_image}` reference |
+  | `acme-nightly-report` + two children | a periodic parent; children carry a non-blank `ParentID` and never surface as their own rows (`APP-A01`) |
+  | `acme-hourly-sync` | the modern `crons` block (`Periodic.Specs`), Decision 5's other branch |
+  | `acme-batch-import` + two children | a parameterized/dispatch parent; `ParentID` filtering applies to dispatch children too (Decision 4), not periodic children only |
+  | `acme-adhoc-export` | a parameterized parent with zero dispatches — renders as no-schedule, not periodic-shaped |
+  | `acme-legacy-raw-exec` | no task has `Lifecycle == nil` — `image: nil` with `detail_error: nil`, a genuine absence, not a fetch failure |
+  | `acme-worker-pending`, `acme-api`/`acme-nightly-report` (running), `acme-worker-dead` | one job per `status` value |
+
+  ## Faults come first
+
+  Every callback calls `Nucleus.Backend.Faults.maybe_fault/1` before doing
+  anything else, so `LOCAL_FORCE_ERROR=unavailable` makes `APP-A07`'s error
+  state testable without a real Nomad outage. This boundary has no per-row
+  fault injection — that is `Nucleus.NomadJobs.Http`'s own contract test,
+  against a stubbed transport, not a concern of the local implementation.
+  """
+
+  @behaviour Nucleus.NomadJobs
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Faults
+  alias Nucleus.Backend.Seed
+  alias Nucleus.NomadJobs
+  alias Nucleus.NomadJobs.Job
+
+  @impl NomadJobs
+  def list_jobs(namespace) do
+    with :ok <- Faults.maybe_fault(NomadJobs.boundary()),
+         {:ok, entries} <- entries() do
+      jobs =
+        entries
+        |> Enum.reject(&Job.child?(Map.get(&1, "stub", %{})))
+        |> Enum.map(&Job.from_api(&1["stub"], &1["detail"], namespace))
+
+      {:ok, jobs}
+    end
+  end
+
+  @impl NomadJobs
+  def health_check do
+    with :ok <- Faults.maybe_fault(NomadJobs.boundary()),
+         {:ok, _entries} <- entries() do
+      :ok
+    end
+  end
+
+  defp entries do
+    case Seed.read(NomadJobs.boundary()) do
+      list when is_list(list) ->
+        {:ok, list}
+
+      nil ->
+        {:error,
+         error(:not_configured, ~s(the backend seed has no "nomad_jobs" section), %{
+           seed_path: Seed.default_path()
+         })}
+
+      other ->
+        {:error,
+         error(:not_configured, ~s(the seed's "nomad_jobs" section is not a list), %{
+           section: inspect(other)
+         })}
+    end
+  end
+
+  defp error(kind, message, details) do
+    Error.new(kind, NomadJobs.boundary(), message, details)
+  end
+end

--- a/priv/backends/local_seed.json
+++ b/priv/backends/local_seed.json
@@ -179,5 +179,344 @@
         }
       ]
     }
-  }
+  },
+  "nomad_jobs": [
+    {
+      "stub": {
+        "ID": "acme-api",
+        "ParentID": null,
+        "Name": "acme-api",
+        "Status": "running",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 7,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "migrate",
+                "Lifecycle": { "Hook": "prestart", "Sidecar": false },
+                "Leader": false,
+                "Config": { "image": "registry.example.com/acme/migrate:sha-aaa1111" }
+              },
+              {
+                "Name": "api",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/api:v1.4.0" }
+              },
+              {
+                "Name": "connect-proxy-acme-api",
+                "Lifecycle": { "Hook": "prestart", "Sidecar": true },
+                "Leader": false,
+                "Config": { "image": "envoyproxy/envoy:v1.29.0" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-ingress",
+        "ParentID": null,
+        "Name": "acme-ingress",
+        "Status": "running",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 3,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "connect-ingress-acme-ingress",
+                "Lifecycle": null,
+                "Leader": false,
+                "Config": { "image": "${meta.connect.gateway_image}" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-nightly-report",
+        "ParentID": null,
+        "Name": "acme-nightly-report",
+        "Status": "running",
+        "Periodic": true
+      },
+      "detail": {
+        "Version": 2,
+        "Periodic": { "Spec": "0 3 * * *", "Specs": [], "SpecType": "cron" },
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "report",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/report:sha-bbb2222" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-nightly-report/periodic-1755000000",
+        "ParentID": "acme-nightly-report",
+        "Name": "acme-nightly-report/periodic-1755000000",
+        "Status": "dead",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 2,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "report",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/report:sha-bbb2222" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-nightly-report/periodic-1755086400",
+        "ParentID": "acme-nightly-report",
+        "Name": "acme-nightly-report/periodic-1755086400",
+        "Status": "dead",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 2,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "report",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/report:sha-bbb2222" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-hourly-sync",
+        "ParentID": null,
+        "Name": "acme-hourly-sync",
+        "Status": "running",
+        "Periodic": true
+      },
+      "detail": {
+        "Version": 5,
+        "Periodic": { "Spec": "", "Specs": ["0 * * * *"], "SpecType": "cron" },
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "sync",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/sync:v3.2.1" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-batch-import",
+        "ParentID": null,
+        "Name": "acme-batch-import",
+        "Status": "running",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 1,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "import",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/batch-import:v2.0.0" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-batch-import/dispatch-1755000111",
+        "ParentID": "acme-batch-import",
+        "Name": "acme-batch-import/dispatch-1755000111",
+        "Status": "dead",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 1,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "import",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/batch-import:v2.0.0" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-batch-import/dispatch-1755000222",
+        "ParentID": "acme-batch-import",
+        "Name": "acme-batch-import/dispatch-1755000222",
+        "Status": "dead",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 1,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "import",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/batch-import:v2.0.0" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-adhoc-export",
+        "ParentID": null,
+        "Name": "acme-adhoc-export",
+        "Status": "running",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 1,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "export",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/adhoc-export:v1.0.0" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-legacy-raw-exec",
+        "ParentID": null,
+        "Name": "acme-legacy-raw-exec",
+        "Status": "running",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 1,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "connect-proxy-acme-legacy-raw-exec",
+                "Lifecycle": { "Hook": "prestart", "Sidecar": true },
+                "Leader": false,
+                "Config": { "image": "envoyproxy/envoy:v1.29.0" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-worker-pending",
+        "ParentID": null,
+        "Name": "acme-worker-pending",
+        "Status": "pending",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 1,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "worker",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/worker:v0.9.0" }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stub": {
+        "ID": "acme-worker-dead",
+        "ParentID": null,
+        "Name": "acme-worker-dead",
+        "Status": "dead",
+        "Periodic": false
+      },
+      "detail": {
+        "Version": 1,
+        "Periodic": null,
+        "TaskGroups": [
+          {
+            "Tasks": [
+              {
+                "Name": "worker",
+                "Lifecycle": null,
+                "Leader": true,
+                "Config": { "image": "registry.example.com/acme/worker:v0.8.0" }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/test/nucleus/backend_test.exs
+++ b/test/nucleus/backend_test.exs
@@ -29,8 +29,8 @@ defmodule Nucleus.BackendTest do
 
   describe "boundaries/0" do
     @tag :unit
-    test "covers secrets, tenant_api, and m2m, and no auth boundary" do
-      assert Backend.boundaries() == [:m2m, :secrets, :tenant_api]
+    test "covers secrets, tenant_api, m2m, and nomad_jobs, and no auth boundary" do
+      assert Backend.boundaries() == [:m2m, :nomad_jobs, :secrets, :tenant_api]
       refute :auth in Backend.boundaries()
     end
   end
@@ -53,7 +53,7 @@ defmodule Nucleus.BackendTest do
       error = assert_raise ArgumentError, fn -> Backend.impl_for(unknown) end
 
       assert error.message =~ "unknown backend boundary: :nomad"
-      assert error.message =~ "Known boundaries: [:m2m, :secrets, :tenant_api]"
+      assert error.message =~ "Known boundaries: [:m2m, :nomad_jobs, :secrets, :tenant_api]"
     end
 
     @tag :unit
@@ -111,6 +111,7 @@ defmodule Nucleus.BackendTest do
       assert Backend.env_var(:secrets) == "SECRETS_BACKEND"
       assert Backend.env_var(:tenant_api) == "TENANT_API_BACKEND"
       assert Backend.env_var(:m2m) == "M2M_BACKEND"
+      assert Backend.env_var(:nomad_jobs) == "NOMAD_JOBS_BACKEND"
     end
   end
 
@@ -130,6 +131,7 @@ defmodule Nucleus.BackendTest do
       assert log =~ "secrets -> Nucleus.Secrets.Store.Local (SECRETS_BACKEND=local)"
       assert log =~ "tenant_api -> Nucleus.TenantApi.Local (TENANT_API_BACKEND=local)"
       assert log =~ "m2m -> Nucleus.M2M.Clients.Local (M2M_BACKEND=local)"
+      assert log =~ "nomad_jobs -> Nucleus.NomadJobs.Local (NOMAD_JOBS_BACKEND=local)"
     end
 
     @tag :unit

--- a/test/nucleus/nomad/transport_test.exs
+++ b/test/nucleus/nomad/transport_test.exs
@@ -1,0 +1,246 @@
+defmodule Nucleus.Nomad.TransportTest do
+  # Configuration is application-global, so these cannot run concurrently.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  # Several cases deliberately provoke a transport failure, which logs a
+  # warning. Captured so the suite's output stays readable.
+  @moduletag :capture_log
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Nomad.Transport
+
+  @stub __MODULE__
+  @boundary :nomad_jobs
+
+  setup do
+    original = Application.get_env(:nucleus, Transport)
+    on_exit(fn -> Application.put_env(:nucleus, Transport, original) end)
+    :ok
+  end
+
+  defp configure(overrides \\ []) do
+    Application.put_env(
+      :nucleus,
+      Transport,
+      Keyword.merge(
+        [base_url: "https://nomad.example.com", plug: {Req.Test, @stub}],
+        overrides
+      )
+    )
+  end
+
+  defp stub(fun), do: Req.Test.stub(@stub, fun)
+
+  defp respond(status, body, content_type \\ "application/json") do
+    stub(fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type(content_type)
+      |> Plug.Conn.resp(status, body)
+    end)
+  end
+
+  defp respond_json(status, data), do: respond(status, Jason.encode!(data))
+
+  defp request(path, opts \\ []) do
+    Transport.request(:get, path, Keyword.merge([boundary: @boundary], opts))
+  end
+
+  defp capture_info(fun) do
+    original = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: original) end)
+
+    capture_log(fun)
+  end
+
+  describe "the request" do
+    test "hits the given path on the configured base URL, with query params" do
+      configure()
+
+      stub(fn conn ->
+        assert conn.request_path == "/v1/jobs"
+        assert conn.query_string == "namespace=local"
+        assert conn.host == "nomad.example.com"
+        assert conn.method == "GET"
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = request("/v1/jobs", query: [namespace: "local"])
+    end
+
+    test "preserves a path prefix on the base URL and tolerates a trailing slash" do
+      configure(base_url: "https://nomad.example.com/api/")
+
+      stub(fn conn ->
+        assert conn.request_path == "/api/v1/jobs"
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = request("/v1/jobs")
+    end
+
+    test "sends no X-Nomad-Token header when unset" do
+      configure()
+
+      stub(fn conn ->
+        assert Plug.Conn.get_req_header(conn, "x-nomad-token") == []
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = request("/v1/jobs")
+    end
+
+    test "sends X-Nomad-Token when configured" do
+      configure(token: "tok_abc123")
+
+      stub(fn conn ->
+        assert Plug.Conn.get_req_header(conn, "x-nomad-token") == ["tok_abc123"]
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = request("/v1/jobs")
+    end
+
+    test "sends no X-Nomad-Token header for a blank token, rather than an empty one" do
+      configure(token: "")
+
+      stub(fn conn ->
+        assert Plug.Conn.get_req_header(conn, "x-nomad-token") == []
+        Req.Test.json(conn, [])
+      end)
+
+      assert {:ok, []} = request("/v1/jobs")
+    end
+  end
+
+  describe "decoding" do
+    test "a JSON array decodes to a list" do
+      configure()
+      respond_json(200, [%{"ID" => "api"}])
+
+      assert {:ok, [%{"ID" => "api"}]} = request("/v1/jobs")
+    end
+
+    test "a JSON object decodes to a map" do
+      configure()
+      respond_json(200, %{"ID" => "api"})
+
+      assert {:ok, %{"ID" => "api"}} = request("/v1/job/api")
+    end
+
+    test "an undecodable body maps to :unavailable" do
+      configure()
+      respond(200, "{not json")
+
+      assert {:error, %Error{kind: :unavailable, boundary: :nomad_jobs, message: message}} =
+               request("/v1/jobs")
+
+      assert message =~ "not JSON"
+    end
+  end
+
+  describe "status mapping" do
+    for status <- [400, 404, 429, 500, 502, 503, 418] do
+      test "#{status} maps to :unavailable" do
+        configure()
+        respond(unquote(status), "{}")
+
+        assert {:error, %Error{kind: :unavailable, boundary: :nomad_jobs, details: details}} =
+                 request("/v1/jobs")
+
+        assert details.status == unquote(status)
+      end
+    end
+
+    for status <- [401, 403] do
+      test "#{status} maps to :auth_expired" do
+        configure()
+        respond(unquote(status), "{}")
+
+        assert {:error, %Error{kind: :auth_expired, details: %{status: unquote(status)}}} =
+                 request("/v1/jobs")
+      end
+    end
+
+    test "a transport error maps to :unavailable" do
+      configure()
+      stub(fn conn -> Req.Test.transport_error(conn, :econnrefused) end)
+
+      assert {:error, %Error{kind: :unavailable, details: details}} = request("/v1/jobs")
+      assert details.reason =~ "econnrefused"
+    end
+
+    test "a redirect is not followed" do
+      configure()
+
+      stub(fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://attacker.example.com/v1/jobs")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      assert {:error, %Error{kind: :unavailable, details: %{status: 302}}} = request("/v1/jobs")
+    end
+  end
+
+  describe "an unusable base URL" do
+    for {label, base_url} <- [
+          {"unset", nil},
+          {"blank", "   "},
+          {"not a URL", "nomad.example.com"},
+          {"a non-http scheme", "file:///etc/passwd"},
+          {"missing a host", "https://"}
+        ] do
+      test "#{label} yields :not_configured and attempts no request" do
+        configure(base_url: unquote(base_url))
+
+        test_pid = self()
+
+        stub(fn conn ->
+          send(test_pid, :request_attempted)
+          Req.Test.json(conn, [])
+        end)
+
+        assert {:error, %Error{kind: :not_configured, details: %{variable: var}}} =
+                 request("/v1/jobs")
+
+        assert var == "NOMAD_ADDR"
+        refute_received :request_attempted
+      end
+    end
+  end
+
+  describe "logging" do
+    test "records the status and a request id, and never the token" do
+      configure(token: "tok_supersecret")
+      respond_json(200, [])
+
+      log = capture_info(fn -> request("/v1/jobs") end)
+
+      assert log =~ "-> 200"
+      assert log =~ ~r/request_id=[0-9a-f]{16}/
+      refute log =~ "tok_supersecret"
+    end
+
+    test "never logs the response body" do
+      configure()
+      respond_json(200, [%{"secret" => "leak-me-please"}])
+
+      log = capture_info(fn -> request("/v1/jobs") end)
+
+      assert log =~ "-> 200"
+      refute log =~ "leak-me-please"
+    end
+  end
+
+  describe "timeouts" do
+    test "are configured independently, and fall back to sane defaults" do
+      configure(connect_timeout_ms: nil, receive_timeout_ms: nil)
+      respond_json(200, [])
+
+      assert {:ok, []} = request("/v1/jobs")
+    end
+  end
+end

--- a/test/nucleus/nomad_jobs/contract_test.exs
+++ b/test/nucleus/nomad_jobs/contract_test.exs
@@ -1,0 +1,87 @@
+defmodule Nucleus.NomadJobs.ContractTest do
+  @moduledoc """
+  The same assertions against every implementation of the `:nomad_jobs`
+  boundary.
+
+  `Local` always runs. `Http` runs only when `TEST_NOMAD_ADDR` names a real
+  Nomad cluster — tagged `:external` and excluded by default in
+  `test_helper.exs`, so a fresh clone with no credentials still goes green.
+
+      TEST_NOMAD_ADDR=https://nomad.example.com TEST_NOMAD_TOKEN=... \\
+        mix test --include external
+
+  """
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Backend.Seed
+  alias Nucleus.NomadJobs.Http
+  alias Nucleus.NomadJobs.Local
+  alias NucleusTest.NomadJobsContract, as: Contract
+
+  @namespace "local"
+
+  describe "Nucleus.NomadJobs.Local" do
+    setup do
+      on_exit(&Seed.reset/0)
+      :ok
+    end
+
+    test "returns a list of jobs" do
+      Contract.assert_lists_jobs(Local, @namespace)
+    end
+
+    test "every element is a fully-formed Job, with detail_error's invariant held" do
+      Contract.assert_element_shape(Local, @namespace)
+    end
+
+    test "a non-periodic job's cron is nil, never a blank string" do
+      Contract.assert_non_periodic_has_no_cron(Local, @namespace)
+    end
+
+    test "health_check/0 returns :ok" do
+      Contract.assert_health_check(Local)
+    end
+
+    test "child jobs never surface as their own rows" do
+      {:ok, jobs} = Local.list_jobs(@namespace)
+      names = Enum.map(jobs, & &1.name)
+
+      refute Enum.any?(names, &String.contains?(&1, "/periodic-"))
+      refute Enum.any?(names, &String.contains?(&1, "/dispatch-"))
+    end
+  end
+
+  describe "Nucleus.NomadJobs.Http" do
+    @describetag :external
+
+    setup do
+      base_url =
+        System.get_env("TEST_NOMAD_ADDR") ||
+          flunk("TEST_NOMAD_ADDR must be set to run the external contract tests")
+
+      original = Application.get_env(:nucleus, Nucleus.Nomad.Transport)
+
+      Application.put_env(:nucleus, Nucleus.Nomad.Transport,
+        base_url: base_url,
+        token: System.get_env("TEST_NOMAD_TOKEN"),
+        connect_timeout_ms: 5_000,
+        receive_timeout_ms: 10_000
+      )
+
+      on_exit(fn -> Application.put_env(:nucleus, Nucleus.Nomad.Transport, original) end)
+      :ok
+    end
+
+    test "returns a list of jobs" do
+      Contract.assert_lists_jobs(Http, @namespace)
+    end
+
+    test "every element is a fully-formed Job, with detail_error's invariant held" do
+      Contract.assert_element_shape(Http, @namespace)
+    end
+
+    test "health_check/0 returns :ok" do
+      Contract.assert_health_check(Http)
+    end
+  end
+end

--- a/test/nucleus/nomad_jobs/http_test.exs
+++ b/test/nucleus/nomad_jobs/http_test.exs
@@ -1,0 +1,272 @@
+defmodule Nucleus.NomadJobs.HttpTest do
+  # Configuration is application-global, so these cannot run concurrently.
+  use ExUnit.Case, async: false
+
+  @moduletag :capture_log
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.NomadJobs.Http
+
+  @stub __MODULE__
+  @namespace "local"
+
+  setup do
+    original = Application.get_env(:nucleus, Nucleus.Nomad.Transport)
+    on_exit(fn -> Application.put_env(:nucleus, Nucleus.Nomad.Transport, original) end)
+    :ok
+  end
+
+  defp configure(overrides \\ []) do
+    Application.put_env(
+      :nucleus,
+      Nucleus.Nomad.Transport,
+      Keyword.merge(
+        [base_url: "https://nomad.example.com", plug: {Req.Test, @stub}],
+        overrides
+      )
+    )
+  end
+
+  defp stub(fun), do: Req.Test.stub(@stub, fun)
+
+  defp json(conn, data), do: Req.Test.json(conn, data)
+
+  defp stub_by_path(routes) do
+    stub(fn conn ->
+      case Map.fetch(routes, conn.request_path) do
+        {:ok, fun} -> fun.(conn)
+        :error -> flunk("unexpected request to #{conn.request_path}")
+      end
+    end)
+  end
+
+  defp list_stub(id, attrs \\ %{}) do
+    Map.merge(
+      %{"ID" => id, "ParentID" => nil, "Name" => id, "Status" => "running", "Periodic" => false},
+      attrs
+    )
+  end
+
+  defp detail(attrs \\ %{}) do
+    Map.merge(
+      %{
+        "Version" => 1,
+        "Periodic" => nil,
+        "TaskGroups" => [
+          %{
+            "Tasks" => [
+              %{
+                "Name" => "primary",
+                "Lifecycle" => nil,
+                "Leader" => true,
+                "Config" => %{"image" => "registry.example.com/acme/primary:v1.0.0"}
+              }
+            ]
+          }
+        ]
+      },
+      attrs
+    )
+  end
+
+  describe "list_jobs/1" do
+    test "lists then fans out one detail call per parent" do
+      configure()
+
+      stub_by_path(%{
+        "/v1/jobs" => &json(&1, [list_stub("api")]),
+        "/v1/job/api" => &json(&1, detail())
+      })
+
+      assert {:ok, [job]} = Http.list_jobs(@namespace)
+      assert job.name == "api"
+      assert job.namespace == @namespace
+    end
+
+    test "sends the namespace as a query parameter on both calls" do
+      configure()
+
+      stub(fn conn ->
+        assert Plug.Conn.fetch_query_params(conn).query_params["namespace"] == @namespace
+
+        case conn.request_path do
+          "/v1/jobs" -> json(conn, [list_stub("api")])
+          "/v1/job/api" -> json(conn, detail())
+        end
+      end)
+
+      assert {:ok, [_job]} = Http.list_jobs(@namespace)
+    end
+
+    test "children — periodic and dispatch alike — are excluded before the fan-out" do
+      configure()
+
+      test_pid = self()
+
+      stub(fn conn ->
+        case conn.request_path do
+          "/v1/jobs" ->
+            json(conn, [
+              list_stub("parent", %{"Periodic" => true}),
+              list_stub("parent/periodic-1", %{"ParentID" => "parent"}),
+              list_stub("other-parent"),
+              list_stub("other-parent/dispatch-1", %{"ParentID" => "other-parent"})
+            ])
+
+          "/v1/job/" <> id ->
+            send(test_pid, {:detail_requested, id})
+            json(conn, detail())
+        end
+      end)
+
+      assert {:ok, jobs} = Http.list_jobs(@namespace)
+      names = Enum.map(jobs, & &1.name)
+
+      assert "parent" in names
+      assert "other-parent" in names
+      refute "parent/periodic-1" in names
+      refute "other-parent/dispatch-1" in names
+
+      assert_received {:detail_requested, "parent"}
+      assert_received {:detail_requested, "other-parent"}
+      refute_received {:detail_requested, "parent/periodic-1"}
+      refute_received {:detail_requested, "other-parent/dispatch-1"}
+    end
+
+    test "version is read from the detail response — it would be nil if read from the list stub" do
+      configure()
+
+      stub_by_path(%{
+        "/v1/jobs" => &json(&1, [list_stub("api")]),
+        "/v1/job/api" => &json(&1, detail(%{"Version" => 42}))
+      })
+
+      assert {:ok, [job]} = Http.list_jobs(@namespace)
+      # The list stub carries no Version field at all — this assertion fails
+      # if the implementation ever reads Version from the list response
+      # instead of the detail response (the prototype's nomad.py:139 bug).
+      assert job.version == 42
+    end
+
+    test "the image comes from the primary task, not a leading prestart task or an injected sidecar" do
+      configure()
+
+      task_shaped_detail =
+        detail(%{
+          "TaskGroups" => [
+            %{
+              "Tasks" => [
+                %{
+                  "Name" => "migrate",
+                  "Lifecycle" => %{"Hook" => "prestart", "Sidecar" => false},
+                  "Leader" => false,
+                  "Config" => %{"image" => "registry.example.com/acme/migrate:sha-aaa"}
+                },
+                %{
+                  "Name" => "api",
+                  "Lifecycle" => nil,
+                  "Leader" => true,
+                  "Config" => %{"image" => "registry.example.com/acme/api:v1.4.0"}
+                },
+                %{
+                  "Name" => "connect-proxy-api",
+                  "Lifecycle" => %{"Hook" => "prestart", "Sidecar" => true},
+                  "Leader" => false,
+                  "Config" => %{"image" => "envoyproxy/envoy:v1.29.0"}
+                }
+              ]
+            }
+          ]
+        })
+
+      stub_by_path(%{
+        "/v1/jobs" => &json(&1, [list_stub("api")]),
+        "/v1/job/api" => &json(&1, task_shaped_detail)
+      })
+
+      assert {:ok, [job]} = Http.list_jobs(@namespace)
+      assert job.image == "registry.example.com/acme/api:v1.4.0"
+    end
+
+    test "one failing detail call degrades only that row" do
+      configure()
+
+      stub(fn conn ->
+        case conn.request_path do
+          "/v1/jobs" ->
+            json(conn, [list_stub("healthy"), list_stub("unhealthy")])
+
+          "/v1/job/healthy" ->
+            json(conn, detail())
+
+          "/v1/job/unhealthy" ->
+            Plug.Conn.resp(conn, 500, "{}")
+        end
+      end)
+
+      assert {:ok, jobs} = Http.list_jobs(@namespace)
+
+      healthy = Enum.find(jobs, &(&1.name == "healthy"))
+      unhealthy = Enum.find(jobs, &(&1.name == "unhealthy"))
+
+      assert healthy.detail_error == nil
+      assert is_integer(healthy.version)
+
+      assert unhealthy.detail_error == :unavailable
+      assert unhealthy.version == nil
+      assert unhealthy.image == nil
+      assert unhealthy.cron == nil
+      # The degraded row still carries its list-stub fields.
+      assert unhealthy.name == "unhealthy"
+      assert unhealthy.status == "running"
+    end
+
+    test "a failing list call fails the whole operation" do
+      configure()
+      stub(fn conn -> Plug.Conn.resp(conn, 500, "{}") end)
+
+      assert {:error, %Error{kind: :unavailable, boundary: :nomad_jobs}} =
+               Http.list_jobs(@namespace)
+    end
+  end
+
+  describe "health_check/0" do
+    test "is :ok on 200" do
+      configure()
+      stub(fn conn -> json(conn, []) end)
+
+      assert Http.health_check() == :ok
+    end
+
+    for status <- [401, 403] do
+      test "is :ok on #{status} — reachability, not permission" do
+        configure()
+        stub(fn conn -> Plug.Conn.resp(conn, unquote(status), "{}") end)
+
+        assert Http.health_check() == :ok
+      end
+    end
+
+    for status <- [500, 502, 503] do
+      test "is :unavailable on #{status}" do
+        configure()
+        stub(fn conn -> Plug.Conn.resp(conn, unquote(status), "{}") end)
+
+        assert {:error, %Error{kind: :unavailable}} = Http.health_check()
+      end
+    end
+
+    test "is :unavailable on a transport error" do
+      configure()
+      stub(fn conn -> Req.Test.transport_error(conn, :timeout) end)
+
+      assert {:error, %Error{kind: :unavailable}} = Http.health_check()
+    end
+
+    test "is :not_configured with no base URL" do
+      configure(base_url: nil)
+
+      assert {:error, %Error{kind: :not_configured}} = Http.health_check()
+    end
+  end
+end

--- a/test/nucleus/nomad_jobs/job_test.exs
+++ b/test/nucleus/nomad_jobs/job_test.exs
@@ -1,0 +1,201 @@
+defmodule Nucleus.NomadJobs.JobTest do
+  use ExUnit.Case, async: true
+
+  alias Nucleus.NomadJobs.Job
+
+  describe "child?/1" do
+    test "false for a nil or blank ParentID" do
+      refute Job.child?(%{"ParentID" => nil})
+      refute Job.child?(%{"ParentID" => ""})
+      refute Job.child?(%{})
+    end
+
+    test "true for any non-blank ParentID — periodic and dispatch alike" do
+      assert Job.child?(%{"ParentID" => "acme-nightly-report"})
+      assert Job.child?(%{"ParentID" => "acme-batch-import"})
+    end
+  end
+
+  describe "from_api/3 — version (Decision 1)" do
+    test "reads Job.Version from the detail response" do
+      stub = %{"Name" => "api", "Status" => "running", "Periodic" => false}
+      detail = %{"Version" => 7, "TaskGroups" => []}
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.version == 7
+    end
+
+    test "never reads Meta.version — the list stub carries no Version field" do
+      # This is the prototype's exact bug (nomad.py:139) made permanent: a
+      # detail response missing Version (as the list stub always is) yields
+      # nil, never a fallback to some other field.
+      stub = %{"Name" => "api", "Status" => "running", "Periodic" => false}
+      detail = %{"Meta" => %{"version" => "9.9.9"}, "TaskGroups" => []}
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.version == nil
+    end
+  end
+
+  describe "from_api/3 — image (Decision 3)" do
+    test "selects the task where Lifecycle == nil, not Tasks[0]" do
+      stub = %{"Name" => "api", "Status" => "running", "Periodic" => false}
+
+      detail = %{
+        "TaskGroups" => [
+          %{
+            "Tasks" => [
+              %{
+                "Name" => "migrate",
+                "Lifecycle" => %{"Hook" => "prestart", "Sidecar" => false},
+                "Leader" => false,
+                "Config" => %{"image" => "registry.example.com/acme/migrate:sha-aaa"}
+              },
+              %{
+                "Name" => "api",
+                "Lifecycle" => nil,
+                "Leader" => true,
+                "Config" => %{"image" => "registry.example.com/acme/api:v1.4.0"}
+              },
+              %{
+                "Name" => "connect-proxy-acme-api",
+                "Lifecycle" => %{"Hook" => "prestart", "Sidecar" => true},
+                "Leader" => false,
+                "Config" => %{"image" => "envoyproxy/envoy:v1.29.0"}
+              }
+            ]
+          }
+        ]
+      }
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.image == "registry.example.com/acme/api:v1.4.0"
+    end
+
+    test "prefers Leader == true when several tasks have Lifecycle == nil" do
+      stub = %{"Name" => "api", "Status" => "running", "Periodic" => false}
+
+      detail = %{
+        "TaskGroups" => [
+          %{
+            "Tasks" => [
+              %{
+                "Name" => "sidekick",
+                "Lifecycle" => nil,
+                "Leader" => false,
+                "Config" => %{"image" => "wrong"}
+              },
+              %{
+                "Name" => "primary",
+                "Lifecycle" => nil,
+                "Leader" => true,
+                "Config" => %{"image" => "right"}
+              }
+            ]
+          }
+        ]
+      }
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.image == "right"
+    end
+
+    test "yields the unresolved template reference for the ingress gateway shape" do
+      stub = %{"Name" => "acme-ingress", "Status" => "running", "Periodic" => false}
+
+      detail = %{
+        "TaskGroups" => [
+          %{
+            "Tasks" => [
+              %{
+                "Name" => "connect-ingress-acme-ingress",
+                "Lifecycle" => nil,
+                "Leader" => false,
+                "Config" => %{"image" => "${meta.connect.gateway_image}"}
+              }
+            ]
+          }
+        ]
+      }
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.image == "${meta.connect.gateway_image}"
+    end
+
+    test "nil, not an error, when no task qualifies" do
+      stub = %{"Name" => "api", "Status" => "running", "Periodic" => false}
+
+      detail = %{
+        "TaskGroups" => [
+          %{
+            "Tasks" => [
+              %{
+                "Name" => "connect-proxy-only",
+                "Lifecycle" => %{"Hook" => "prestart", "Sidecar" => true},
+                "Leader" => false,
+                "Config" => %{"image" => "envoyproxy/envoy:v1.29.0"}
+              }
+            ]
+          }
+        ]
+      }
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.image == nil
+      assert job.detail_error == nil
+    end
+  end
+
+  describe "from_api/3 — cron (Decision 5)" do
+    test "reads Periodic.Spec for a job authored with the legacy cron block" do
+      stub = %{"Name" => "nightly", "Status" => "running", "Periodic" => true}
+      detail = %{"Periodic" => %{"Spec" => "0 3 * * *", "Specs" => []}, "TaskGroups" => []}
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.cron == "0 3 * * *"
+    end
+
+    test "reads Periodic.Specs for a job authored with the modern crons block" do
+      stub = %{"Name" => "hourly", "Status" => "running", "Periodic" => true}
+      detail = %{"Periodic" => %{"Spec" => "", "Specs" => ["0 * * * *"]}, "TaskGroups" => []}
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.cron == "0 * * * *"
+    end
+
+    test "nil, never a blank string, for a non-periodic job" do
+      stub = %{"Name" => "api", "Status" => "running", "Periodic" => false}
+      detail = %{"Periodic" => nil, "TaskGroups" => []}
+
+      job = Job.from_api(stub, detail, "local")
+
+      assert job.cron == nil
+      assert job.periodic? == false
+    end
+  end
+
+  describe "degraded/3 (Decision 6)" do
+    test "sets detail_error and leaves version, image, and cron all nil" do
+      stub = %{"Name" => "api", "Status" => "running", "Periodic" => false}
+
+      job = Job.degraded(stub, "local", :unavailable)
+
+      assert job.name == "api"
+      assert job.status == "running"
+      assert job.namespace == "local"
+      assert job.periodic? == false
+      assert job.version == nil
+      assert job.image == nil
+      assert job.cron == nil
+      assert job.detail_error == :unavailable
+    end
+  end
+end

--- a/test/nucleus/nomad_jobs/local_test.exs
+++ b/test/nucleus/nomad_jobs/local_test.exs
@@ -1,0 +1,152 @@
+defmodule Nucleus.NomadJobs.LocalTest do
+  # Fault injection is read from the OS environment, which is global to the node.
+  use ExUnit.Case, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Seed
+  alias Nucleus.NomadJobs.Job
+  alias Nucleus.NomadJobs.Local
+
+  @namespace "local"
+
+  setup do
+    # The seed owner is mutable and outlives any one test.
+    on_exit(&Seed.reset/0)
+    :ok
+  end
+
+  defp force_error(kind) do
+    System.put_env("LOCAL_FORCE_ERROR", kind)
+    on_exit(fn -> System.delete_env("LOCAL_FORCE_ERROR") end)
+  end
+
+  defp job!(name) do
+    assert {:ok, jobs} = Local.list_jobs(@namespace)
+    assert job = Enum.find(jobs, &(&1.name == name))
+    job
+  end
+
+  describe "the seeded fixtures" do
+    test "children never surface as their own rows — periodic and dispatch alike" do
+      assert {:ok, jobs} = Local.list_jobs(@namespace)
+      names = Enum.map(jobs, & &1.name)
+
+      refute "acme-nightly-report/periodic-1755000000" in names
+      refute "acme-nightly-report/periodic-1755086400" in names
+      refute "acme-batch-import/dispatch-1755000111" in names
+      refute "acme-batch-import/dispatch-1755000222" in names
+
+      assert "acme-nightly-report" in names
+      assert "acme-batch-import" in names
+    end
+
+    test "the primary task's image is selected over a leading prestart task and an injected sidecar" do
+      job = job!("acme-api")
+
+      assert job.image == "registry.example.com/acme/api:v1.4.0"
+      assert job.version == 7
+    end
+
+    test "the ingress gateway job's unresolved template reference passes through as-is" do
+      job = job!("acme-ingress")
+
+      assert job.image == "${meta.connect.gateway_image}"
+    end
+
+    test "a periodic job authored with the legacy cron block reads Periodic.Spec" do
+      job = job!("acme-nightly-report")
+
+      assert job.periodic? == true
+      assert job.cron == "0 3 * * *"
+    end
+
+    test "a periodic job authored with the modern crons block reads Periodic.Specs" do
+      job = job!("acme-hourly-sync")
+
+      assert job.periodic? == true
+      assert job.cron == "0 * * * *"
+    end
+
+    test "a parameterized parent with zero dispatches renders as no-schedule" do
+      job = job!("acme-adhoc-export")
+
+      assert job.periodic? == false
+      assert job.cron == nil
+    end
+
+    test "a job with no qualifying task has image: nil and detail_error: nil — a real absence" do
+      job = job!("acme-legacy-raw-exec")
+
+      assert job.image == nil
+      assert job.detail_error == nil
+    end
+
+    test "one job of each status value is present" do
+      assert {:ok, jobs} = Local.list_jobs(@namespace)
+      statuses = jobs |> Enum.map(& &1.status) |> Enum.uniq() |> Enum.sort()
+
+      assert statuses == ["dead", "pending", "running"]
+    end
+  end
+
+  describe "the shared translation" do
+    test "every element is a fully-formed Job struct" do
+      assert {:ok, jobs} = Local.list_jobs(@namespace)
+
+      for job <- jobs do
+        assert %Job{} = job
+        assert is_binary(job.name) and job.name != ""
+        assert job.namespace == @namespace
+        assert is_boolean(job.periodic?)
+        assert job.detail_error == nil
+      end
+    end
+  end
+
+  describe "fault injection" do
+    test "LOCAL_FORCE_ERROR=unavailable is the hook APP-A07 uses for the error state" do
+      force_error("unavailable")
+
+      assert {:error, %Error{kind: :unavailable, boundary: :nomad_jobs}} =
+               Local.list_jobs(@namespace)
+    end
+
+    test "applies to health_check/0 as well" do
+      force_error("unavailable")
+
+      assert {:error, %Error{kind: :unavailable}} = Local.health_check()
+    end
+
+    test "an unparseable value raises rather than passing silently" do
+      force_error("teapot")
+
+      assert_raise ArgumentError, fn -> Local.list_jobs(@namespace) end
+    end
+  end
+
+  describe "health_check/0" do
+    test "is :ok when the seed is readable" do
+      assert Local.health_check() == :ok
+    end
+  end
+
+  describe "a broken seed section" do
+    test "reads as :not_configured, not :unavailable — a bad file is not an unreachable cluster" do
+      Seed.write(:nomad_jobs, %{"not" => "a list"})
+
+      assert {:error, %Error{kind: :not_configured}} = Local.list_jobs(@namespace)
+    end
+
+    test "reads as :not_configured when the section is absent" do
+      Seed.write(:nomad_jobs, nil)
+
+      assert {:error, %Error{kind: :not_configured}} = Local.list_jobs(@namespace)
+    end
+
+    test "fails health_check/0" do
+      Seed.write(:nomad_jobs, nil)
+
+      assert {:error, %Error{kind: :not_configured}} = Local.health_check()
+    end
+  end
+end

--- a/test/nucleus/nomad_jobs_test.exs
+++ b/test/nucleus/nomad_jobs_test.exs
@@ -1,0 +1,160 @@
+defmodule Nucleus.NomadJobs.StallingImpl do
+  @moduledoc false
+  # A fake implementation used only by Nucleus.NomadJobsTest to prove the
+  # ~15s overall budget resolves into an error rather than blocking, without
+  # the test suite actually waiting out a real Nomad timeout.
+  @behaviour Nucleus.NomadJobs
+
+  @impl Nucleus.NomadJobs
+  def list_jobs(_namespace) do
+    Process.sleep(:infinity)
+  end
+
+  @impl Nucleus.NomadJobs
+  def health_check, do: :ok
+end
+
+defmodule Nucleus.NomadJobs.CrashingImpl do
+  @moduledoc false
+  # A fake implementation used only by Nucleus.NomadJobsTest to prove an
+  # unhandled exception inside the fan-out degrades to {:error, %Error{}}
+  # rather than crashing whatever process called list/1 — only possible
+  # because list/1 runs the implementation via Task.Supervisor.async_nolink/2,
+  # not Task.async/1 (which links, and would take the caller down with it).
+  @behaviour Nucleus.NomadJobs
+
+  @impl Nucleus.NomadJobs
+  def list_jobs(_namespace) do
+    raise "boom"
+  end
+
+  @impl Nucleus.NomadJobs
+  def health_check, do: :ok
+end
+
+defmodule Nucleus.NomadJobsTest do
+  # Swaps the configured implementation and the budget, both application-global.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Nucleus.Backend
+  alias Nucleus.Backend.Error
+  alias Nucleus.NomadJobs
+  alias Nucleus.NomadJobs.CrashingImpl
+  alias Nucleus.NomadJobs.Local
+  alias Nucleus.NomadJobs.StallingImpl
+  alias Nucleus.Scope
+
+  @scope %Scope{}
+
+  setup do
+    original_backends = Application.get_env(:nucleus, :backends)
+    original_module_config = Application.get_env(:nucleus, NomadJobs)
+
+    on_exit(fn ->
+      Application.put_env(:nucleus, :backends, original_backends)
+      Application.put_env(:nucleus, NomadJobs, original_module_config || [])
+    end)
+
+    :ok
+  end
+
+  defp use_backend(module) do
+    Application.put_env(
+      :nucleus,
+      :backends,
+      Keyword.put(Application.get_env(:nucleus, :backends, []), :nomad_jobs, module)
+    )
+  end
+
+  describe "the boundary is registered" do
+    test "impl_for(:nomad_jobs) resolves to a real, loaded module" do
+      assert Backend.impl_for(:nomad_jobs) in [Nucleus.NomadJobs.Http, Nucleus.NomadJobs.Local]
+    end
+
+    test "both registered implementations exist and implement the behaviour" do
+      for mode <- [:real, :local] do
+        module = Backend.impl_for_mode!(:nomad_jobs, mode)
+
+        assert Code.ensure_loaded?(module)
+        assert NomadJobs in module.module_info(:attributes)[:behaviour]
+      end
+    end
+  end
+
+  describe "dispatch" do
+    test "list/1 goes to the configured implementation" do
+      use_backend(Local)
+      assert {:ok, jobs} = NomadJobs.list(@scope)
+      assert jobs != []
+    end
+
+    test "health_check/0 goes to the configured implementation" do
+      use_backend(Local)
+      assert NomadJobs.health_check() == :ok
+    end
+  end
+
+  describe "the scope argument" do
+    test "is accepted but tenancy does not come from it — namespace comes from Scope.tenant_namespace/0" do
+      use_backend(Local)
+
+      # A scope carrying a different tenant does not change which namespace
+      # is queried — see the moduledoc's "asymmetry with Secrets" note.
+      differently_scoped = %Scope{tenant: "some-other-tenant"}
+
+      assert {:ok, jobs} = NomadJobs.list(differently_scoped)
+      assert Enum.all?(jobs, &(&1.namespace == Scope.tenant_namespace()))
+    end
+  end
+
+  describe "the overall budget" do
+    test "returns :unavailable rather than blocking when the implementation stalls" do
+      use_backend(StallingImpl)
+      Application.put_env(:nucleus, NomadJobs, budget_ms: 50)
+
+      assert {:error, %Error{kind: :unavailable, boundary: :nomad_jobs, details: details}} =
+               NomadJobs.list(@scope)
+
+      assert details.budget_ms == 50
+    end
+
+    test "defaults to 15s when unconfigured" do
+      Application.put_env(:nucleus, NomadJobs, [])
+      use_backend(Local)
+
+      assert {:ok, _jobs} = NomadJobs.list(@scope)
+    end
+  end
+
+  describe "a crash inside the fan-out" do
+    test "degrades to {:error, %Error{}} rather than crashing the caller" do
+      use_backend(CrashingImpl)
+      test_pid = self()
+
+      # If list/1 ever regresses to Task.async/1 (which links), the spawned
+      # task's crash takes this spawned caller process down too, and it never
+      # sends :result — the assert_receive below times out instead of failing
+      # on a mismatched value, which is why this runs in its own process
+      # rather than calling NomadJobs.list/1 directly in the test process.
+      capture_log(fn ->
+        {caller, ref} =
+          spawn_monitor(fn -> send(test_pid, {:result, NomadJobs.list(@scope)}) end)
+
+        assert_receive {:result, {:error, %Error{kind: :unavailable, boundary: :nomad_jobs}}}
+        # A clean, normal exit — not the crash's own reason — proves the
+        # caller was never linked to (and so never brought down by) the
+        # failing task.
+        assert_receive {:DOWN, ^ref, :process, ^caller, :normal}
+      end)
+    end
+  end
+
+  describe "boundary/0" do
+    test "names the boundary the errors are tagged with" do
+      assert NomadJobs.boundary() == :nomad_jobs
+      assert NomadJobs.boundary() in Backend.boundaries()
+    end
+  end
+end

--- a/test/support/backend_case.ex
+++ b/test/support/backend_case.ex
@@ -104,6 +104,22 @@ defmodule Nucleus.BackendCase do
   end
 
   @doc """
+  Appends one entry to the `Nucleus.NomadJobs.Local` boundary's seeded list.
+
+  `attrs` is `%{"stub" => ..., "detail" => ...}` — the same two
+  Nomad-shaped maps `Nucleus.NomadJobs.Job.from_api/3` and `.child?/1`
+  consume, matching the seed file's own shape
+  (`Nucleus.NomadJobs.Local`'s moduledoc).
+  """
+  @spec seed_nomad_job(map()) :: :ok
+  def seed_nomad_job(%{"stub" => %{}, "detail" => %{}} = attrs) do
+    Seed.update(:nomad_jobs, fn nomad_jobs ->
+      nomad_jobs = nomad_jobs || []
+      nomad_jobs ++ [attrs]
+    end)
+  end
+
+  @doc """
   Makes every local backend implementation return `{:error, %Error{kind: kind}}`
   on its next call, via `LOCAL_FORCE_ERROR` (`Nucleus.Backend.Faults`).
 

--- a/test/support/nomad_jobs_contract.ex
+++ b/test/support/nomad_jobs_contract.ex
@@ -1,0 +1,70 @@
+defmodule NucleusTest.NomadJobsContract do
+  @moduledoc """
+  Assertions every `Nucleus.NomadJobs` implementation must satisfy.
+
+  Plain functions, not a `__using__` macro — same pattern as
+  `NucleusTest.TenantApiContract` and `NucleusTest.M2MClientsContract`, so the
+  assertions are literally shared between `Local` and `Http` rather than
+  generated twice.
+  """
+
+  import ExUnit.Assertions
+
+  alias Nucleus.NomadJobs.Job
+
+  @doc """
+  Asserts `impl` returns a usable job list for `namespace`.
+  """
+  def assert_lists_jobs(impl, namespace) do
+    assert {:ok, jobs} = impl.list_jobs(namespace)
+    assert is_list(jobs)
+
+    jobs
+  end
+
+  @doc """
+  Asserts every element is a fully-formed `%Job{}`, with the `detail_error`
+  field's own invariant held: non-nil means `version`, `image`, and `cron`
+  are all `nil` (Decision 6, `docs/adr/0022-nomad-jobs-adapter.md`).
+  """
+  def assert_element_shape(impl, namespace) do
+    for job <- assert_lists_jobs(impl, namespace) do
+      assert %Job{} = job
+
+      assert is_binary(job.name) and job.name != "", "name must be a non-blank binary"
+      assert is_binary(job.status) and job.status != "", "status must be a non-blank binary"
+      assert job.namespace == namespace
+      assert is_boolean(job.periodic?), "periodic? must always be a boolean"
+
+      case job.detail_error do
+        nil ->
+          assert is_nil(job.version) or is_integer(job.version)
+          assert is_nil(job.image) or is_binary(job.image)
+          assert is_nil(job.cron) or is_binary(job.cron)
+
+        kind ->
+          assert is_atom(kind)
+          assert is_nil(job.version), "version must be nil when detail_error is set"
+          assert is_nil(job.image), "image must be nil when detail_error is set"
+          assert is_nil(job.cron), "cron must be nil when detail_error is set"
+      end
+    end
+  end
+
+  @doc """
+  Asserts a non-periodic job's `cron` is `nil`, never a blank string
+  (`APP-A05`).
+  """
+  def assert_non_periodic_has_no_cron(impl, namespace) do
+    for %Job{periodic?: false} = job <- assert_lists_jobs(impl, namespace) do
+      assert is_nil(job.cron), "a non-periodic job's cron must be nil, got: #{inspect(job.cron)}"
+    end
+  end
+
+  @doc """
+  Asserts `impl` reports itself reachable.
+  """
+  def assert_health_check(impl) do
+    assert impl.health_check() == :ok
+  end
+end


### PR DESCRIPTION
## What

Adds the `:nomad_jobs` backend boundary that the Applications feature's LiveView slices (APP-S1 #58, APP-S2 #59) will read deployed job status through — the EN-3/EN-10 adapter pattern applied to Nomad's HTTP API. It ships a shared `Req` transport, a facade + behaviour with a real (`Http`) and seeded local (`Local`) implementation, and registers the boundary in `Nucleus.Backend` with `NOMAD_ADDR`/`NOMAD_TOKEN`/`NOMAD_JOBS_BACKEND` config wiring. No LiveView, route, or rendering — deliberately out of scope, per the issue.

This is a pure enabler: it claims no `APP-A*` requirement IDs by design, so it must not (and does not) make `mix nucleus.trace` report coverage that no user-facing behaviour backs yet.

## How

- **`Nucleus.Nomad.Transport`** — a shared `Req` client modelled on `lib/nucleus/tenant_api/http.ex`: SSRF-guarded `NOMAD_ADDR`, `X-Nomad-Token` header only when configured, `retry: false`/`redirect: false`, a 10s `receive_timeout` per request, and the same status-code → `Nucleus.Backend.Error.kind()` mapping convention. Built as its own module (not folded into the jobs adapter) so a future `:nomad_vars` boundary can reuse it unchanged.
- **`Nucleus.NomadJobs`** — the facade + `@behaviour`. `list/1` takes a `Scope` for call-site symmetry (the namespace actually comes from `Scope.tenant_namespace/0`), dispatches through `Backend.impl_for/1` on every call, and enforces a ~15s overall budget across the detail fan-out, returning `{:error, %Error{kind: :unavailable}}` if exceeded so `APP-A07`'s error state stays reachable. No create/update/delete callback exists, and no audit event is emitted — both documented in the moduledoc, matching the omissions `Nucleus.Secrets.Store` and `Nucleus.M2M` already use.
- **`Nucleus.NomadJobs.Job`** — the shared struct (`name`, `status`, `version`, `namespace`, `image`, `cron`, `periodic?`, `detail_error`) and Nomad-JSON translation used by both `Http` and `Local`, so the seeded local fixtures exercise the same parsing rules as the real adapter.
- **`Nucleus.NomadJobs.Http`** — `GET /v1/jobs?namespace=` for the list, filters any job with a non-empty `ParentID` before fan-out, then `Task.async_stream(max_concurrency: 10, timeout: :infinity)` over `GET /v1/job/:id` per parent to fill in version, image, and cron. A per-job detail failure sets `detail_error` and leaves those three fields `nil` on that row only — the rest of the list still renders.
- **`Nucleus.NomadJobs.Local`** — `Faults.maybe_fault(:nomad_jobs)` then `Seed.read(:nomad_jobs)`, backed by 13 fixtures added to `priv/backends/local_seed.json` covering the prestart/sidecar image-selection case, the ingress-gateway template-variable pass-through, periodic and parameterized/dispatch children, both cron field forms, a no-qualifying-task job, and one job per `status` value.
- **Registration** — `:nomad_jobs` added to `Nucleus.Backend`'s boundary map and `@type boundary`, with `NOMAD_ADDR`/`NOMAD_TOKEN`/`NOMAD_JOBS_BACKEND` wired through `config/config.exs`, `config/dev.exs`, `config/test.exs`, and `config/runtime.exs`.
- **Code-review fix, folded into the implementation commit**: `list/1` originally spawned the fan-out with `Task.async/1`, which **links** the task to its caller — an unhandled exception anywhere in the fan-out would have propagated the exit signal to the calling process (the future Applications LiveView) and crashed it, instead of degrading to `{:error, %Error{kind: :unavailable}}`. Fixed by adding a `Task.Supervisor` (`Nucleus.TaskSupervisor`) to `Nucleus.Application`'s children and switching to `Task.Supervisor.async_nolink/2`. A regression test (`test/nucleus/nomad_jobs_test.exs`) spawns the caller in its own monitored process, crashes the fan-out, and asserts the caller exits `:normal` with a classified error rather than going down with the task.

Requirement IDs: none, directly and by design — this ticket is the enabler boundary that APP-S1 (#58), APP-S2 (#59), APP-D1 (#60), and APP-D2 (a follow-up requirements-doc amendment) are blocked by; those claim the `APP-A*` IDs against the LiveView built on top of this.

## Record

`docs/adr/0022-nomad-jobs-adapter.md` consolidates all eight decisions resolved on the issue thread before implementation, plus a `decisions-log.md` row (#22). `business-tech-bridge.md` and `living-notes.md` were deliberately not touched: this ticket changes no requirement-to-code mapping (zero action IDs, and `Applications.md`'s "Planned Phoenix surface" stays planned since no LiveView exists yet) and closes or opens no tracked open question — matching the precedent EN-3/EN-4 set as boundary-only tickets that also got no `business-tech-bridge.md` entry.

## Divergence from the plan

**ADR numbering**: the issue body specified `docs/adr/0021-nomad-jobs-adapter.md`; `0021` was already taken by an unrelated M2M secret-rotation ADR that landed after the issue was written. Used `0022` instead — a numbering correction, not a substantive divergence.

**Eight decisions were resolved on the issue thread before implementation started**, three of which diverge from the plan originally written in the issue body:

1. **Version source** — `Job.Version` from the detail response, not `Meta.version` as the body recommended. The prototype's `job.get("Version", 0)` reads the list stub, which has no `Version` field, so it silently returned `0` for every job forever; that's a bug to fix, not a precedent to inherit.
2. **Periodic run count dropped entirely** — the body recommended a `Children.Pending + Running + Dead` sum with a caveat; `job_gc_threshold`'s default 4h window makes that number look like a lifetime total while never actually growing, so it's removed rather than caveated. `periodic_run_count` does not exist anywhere in the diff. This deletes a binding clause from `APP-A04`, tracked separately as APP-D2.
3. **Image selection** — from the task where `Lifecycle == nil` (preferring `Leader == true`, else first), never `Tasks[0]` as the body assumed. Every job has an injected Consul Connect sidecar task and often an authored prestart task written first, so `Tasks[0]` selects the wrong task; the prototype has the same bug.

Two further decisions filled gaps the body didn't anticipate:

4. `ParentID` filtering applies to parameterized/dispatch children too, not periodic children only — dispatch jobs are in active use in tenant namespaces, so this is load-bearing rather than defensive.
5. Cron spec reads `Periodic.Specs` if non-empty, else `Periodic.Spec` — the body named only `Periodic.Spec`, which would render blank for any job authored with the modern `crons` HCL block (Nomad 1.6.2+).

And two more followed as direct consequences of implementation:

6. A single `detail_error` field replaces the body's per-field `*_error` model — Decision 1 means three fields (`version`, `image`, `cron`) now share one detail call's failure mode, so one field describes it rather than three redundant ones.
7. `:nomad_jobs`/`NOMAD_JOBS_BACKEND` is kept distinct from the wiki's `ADR-0007`, which names a single `NOMAD_BACKEND` — a deliberate, documented divergence: job reads and the future `:nomad_vars` (read+write) boundary are different capabilities that shouldn't share a switch.
8. Async load with a ~15s overall budget (`Nucleus.NomadJobs.list/1`) plus a 10s per-request timeout (`Nucleus.Nomad.Transport`) — the body's `timeout: :infinity` on the stream had no stated bound, which would let a pathological namespace hang a synchronous `mount` for up to 30s.

All eight are documented as GitHub issue comments (linked from the ADR); `docs/adr/0022-nomad-jobs-adapter.md` is the implementation-time consolidated record.

## Verification

`mix precommit` (`compile --warnings-as-errors`, `deps.unlock --unused`, `format`, `test`) run directly against this branch: **928 tests passing** (896 tests + 32 doctests), 0 failures, 31 skipped, 16 excluded (`:external` contract tests against a real Nomad cluster, opt-in via `TEST_NOMAD_ADDR`).

New test coverage added this branch: `test/nucleus/nomad/transport_test.exs`, `test/nucleus/nomad_jobs/{http,local,job,contract}_test.exs`, `test/nucleus/nomad_jobs_test.exs` (including the `async_nolink` crash-isolation regression test and a stalled-detail fixture proving the ~15s budget resolves rather than blocks), plus `:nomad_jobs` additions to `test/nucleus/backend_test.exs` and a `seed_nomad_job/1` helper in `test/support/backend_case.ex`.

Closes #57
