### PR TITLE
APP-S1: Applications table, periodic collapsing, empty/error states, read-only guard

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.22 | Updated: 2026-08-26 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.23 | Updated: 2026-08-26 -->
 
 # Business ↔ Tech Bridge
 
@@ -269,6 +269,33 @@ always reads "View" and the modal's dismiss controls are the hide affordance. `S
 are each claimed on their modal's plain-`phx-click` dismiss control only (Close, Cancel) — the
 one dismissal route `Phoenix.LiveViewTest` can drive; Escape and a backdrop click are wiring-only
 browser gaps for both modals.
+
+`APP-A01`, `APP-A06`, `APP-A07`, and `APP-A08` are now claimed and covered (`APP-S1`/#58):
+`NucleusWeb.ApplicationsLive` (single module, no Index/Show split — Applications has no
+per-item detail route to justify `docs/adr/0018`'s M2M precedent) lists every parent job from
+`Nucleus.NomadJobs.list/1`, sorted name-ascending with a case-insensitive tiebreak — the same
+`{String.downcase(&1.name), &1.name}` `Nucleus.M2M.list/1` uses, since
+`Nucleus.NomadJobs.Local.list_jobs/1` returns seed-file order, not a stable sort. Periodic and
+dispatch children are already excluded by `Nucleus.NomadJobs.Job.child?/1` before this module
+ever sees them (`APP-A01`'s own requirement) — a LiveView-level test still asserts no seeded
+child (`acme-nightly-report/*`, `acme-batch-import/*`) ever renders, so a future
+`Nucleus.NomadJobs` regression is caught at the rendering boundary too, not only at EN-11's own
+context-level test. `stream/3` plus a separate `:job_count` assign, mirroring
+`NucleusWeb.M2MClientsLive.Index` exactly, drives the empty state (`APP-A06`, `#applications-empty`).
+`NucleusWeb.ApplicationsLive.States` collapses every `Nucleus.Backend.Error.kinds/0` value to the
+same three named states `NucleusWeb.M2MClientsLive.States` established —
+`#applications-misconfigured`, `#applications-unavailable` (with retry), `#applications-auth-expired`
+— plus a generic fallback for the three kinds `list/1` has no reason to return today (`APP-A07`).
+`APP-A08`'s read-only guard is enforced one layer below the UI already (`Nucleus.NomadJobs`
+defines no create/update/delete callback of any kind) and reproven by a negative test asserting
+no create/edit/delete/restart/redeploy control or text exists inside `#applications-table`.
+Every column's DOM id is fixed now, even Version/Image/Schedule, which render as empty
+placeholder cells — `APP-S2`/#59 fills in their content without touching this ticket's markup,
+the same service `docs/adr/0010`/`docs/adr/0018` performed for `SEC-S3`–`S6` and the M2M
+listing. The sidebar's Applications entry (`layouts.ex`) is now a real `<.link navigate>`,
+replacing the disabled placeholder EN-7 shipped; `NAV-A03`'s active-section highlighting remains
+unclaimed, matching `M2M-S2`'s identical precedent for its own sidebar link — the view existing
+does not by itself satisfy `NAV-A03`'s "selected item is visually distinguished" clause.
 
 ## Tagging Convention
 

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.26 | Updated: 2026-08-25 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.27 | Updated: 2026-08-26 -->
 
 # Decisions Log
 
@@ -49,6 +49,7 @@ job and the row should point rather than paraphrase.
 | 22 | Nomad jobs adapter — `Job.Version` from the detail response not `Meta.version`; periodic run count dropped entirely; image from the `Lifecycle == nil` task not `Tasks[0]`; `ParentID` filtering covers dispatch children too; cron reads `Periodic.Specs \|\| Periodic.Spec`; one `detail_error` field covers all three detail-sourced fields; `:nomad_jobs` kept distinct from wiki `ADR-0007`'s single `NOMAD_BACKEND`; async load with a ~15s overall budget plus a 10s per-request timeout | 2026-08-25 | Decided | `docs/adr/0022-nomad-jobs-adapter.md` |
 | 23 | Sidebar environment grouping — `NucleusWeb.SidebarEnvironments.group/1` (not `EnvironmentsHook`) now owns archived-exclusion, unit-tested directly; per-category expand/collapse is a socket assign toggled via `Phoenix.LiveView.attach_hook/4` on `:handle_event` (this codebase's first use), not client-side `JS`, since `Layouts.app` is a function component shared across four LiveViews and the toggle must be provable via `render_click/1`; corrected post-review — `with_slugs/1` disambiguates category names that collapse to the same DOM-id slug (e.g. `"Prod East"` vs `"Prod-East"`), which `group/1` treats as distinct but `slug/1` alone did not | 2026-08-25 | Decided | `docs/adr/0023-sidebar-environment-grouping-and-category-toggle-state.md` |
 | 24 | Sidebar expand/collapse survives navigation — `NucleusWeb.SidebarNavState` (a supervised `GenServer` owning a `:protected` ETS table) backs `:expanded_categories` instead of a plain assign, since `<.link navigate>` always remounts `EnvironmentsHook`'s `on_mount`, even to the same LiveView module; keyed by a random `nav_session_id` (`AssignScope`), not `current_scope`, since auth is deferred and every request shares one dev identity; reads bypass the `GenServer` (`:ets.lookup/2` direct), writes go through it (`GenServer.call/2`) so concurrent same-session toggles cannot lose an update | 2026-08-25 | Decided | `docs/adr/0024-sidebar-expand-state-survives-navigation.md` |
+| 25 | Applications listing — one `NucleusWeb.ApplicationsLive` module, bounding `docs/adr/0018`'s Index/Show split to *match the module count to the route count* (no detail route here); row and cell DOM ids derive from the unhashed `Job.name`, resolving the ticket's unreferenced `#job-{id}-*` contract to `name` — safe **only** because `Job.child?/1` filters `/`-bearing child names out at the boundary, since `Job.name` has no validating allowlist and LazyHTML rejects a `/` in a selector outright; the name-ascending sort stays in the LiveView rather than expanding `list/1`'s contract; version/image/schedule ship as empty cells at their final ids so `APP-S2` is content-only | 2026-08-26 | Decided | `docs/adr/0025-applications-listing-single-module-and-name-derived-dom-ids.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -70,7 +71,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0024` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0025` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.22 | Updated: 2026-08-25 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.23 | Updated: 2026-08-26 -->
 
 # Living Notes
 
@@ -156,6 +156,16 @@ deploys it.
   vacuous for exactly this reason until ADR-0012's change caught it. Use
   `refute Enum.empty?(LazyHTML.query(doc, sel))`. `LazyHTML.attribute/2` **does** return a plain
   list, so `== ["ignore"]` and `== []` on an attribute result are fine.
+- **A `/` in an element id makes it unaddressable by any CSS selector, and LazyHTML *raises*
+  rather than not matching.** `has_element?(view, "#job-acme-nightly-report/periodic-1755000000")`
+  fails with `ArgumentError: got invalid css selector`, so a test written that way errors instead
+  of passing or failing — a negative assertion built this way looks like a guard and is not one.
+  Nomad child job names contain a slash by construction (`parent/periodic-<epoch>`), and
+  `Nucleus.NomadJobs.Job.name` comes straight from the API response with no allowlist, so
+  `NucleusWeb.ApplicationsLive`'s `job-<name>` row and cell ids are addressable **only** because
+  `Job.child?/1` filters those names out at the boundary. Prove a child's absence with
+  `refute html =~ child_name`, not a selector. Same class of trap as the `LazyHTML.query/2` entry
+  above. See `docs/adr/0025-applications-listing-single-module-and-name-derived-dom-ids.md`.
 - **A conditionally-rendered modal runs `JS.pop_focus/1` twice** on any dismissal route that
   goes through `data-cancel` (the X, Escape, a backdrop click): once client-side from
   `JS.exec("phx-remove")`, then again when the server removes the element and `phx-remove` fires

--- a/docs/adr/0025-applications-listing-single-module-and-name-derived-dom-ids.md
+++ b/docs/adr/0025-applications-listing-single-module-and-name-derived-dom-ids.md
@@ -1,0 +1,271 @@
+# ADR-0025: Applications Listing — Single-Module Route Shape, Name-Derived DOM Ids, and Pre-Fixed Placeholder Cells
+
+## Status
+
+Accepted — 2026-08-26
+
+Decided on [APP-S1](https://github.com/dave-bell/nucleus/issues/58). Builds on
+`0018-m2m-clients-listing-module-split-and-dom-ids.md` (the immediately
+preceding listing, whose module-split and DOM-id decisions this ADR reaches
+the opposite conclusion on for stated reasons) and
+`0010-secrets-listing-gate-collapse-and-dom-ids.md` (the DOM-id-contract
+precedent both listings follow), and consumes
+`0022-nomad-jobs-adapter.md`'s `Nucleus.NomadJobs.list/1` and `Job` struct
+and `0006-application-shell-and-live-session-composition.md`'s
+`live_session` hook ordering.
+
+## Context
+
+`APP-A01` requires the tenant's deployed applications be listed with name,
+status, version, image, and schedule, and requires periodic child jobs never
+appear as their own rows; `APP-A06`–`APP-A08` require an empty state, per-kind
+error states with the shell intact, and no mutating affordance anywhere.
+
+This is the third listing view in the codebase, after Secrets (ADR-0010) and
+M2M Clients (ADR-0018). Most of the shape was therefore settled precedent and
+needed no decision — `stream/3` plus a separate count assign, exhaustive
+`Nucleus.Backend.Error.kinds/0` handling collapsed to named states, a
+`States` sibling module. Three questions were **not** settled by that
+precedent, and one of them the ticket body got wrong in a way only
+implementation could surface:
+
+1. **Route shape.** ADR-0018 decided M2M's listing as two modules
+   (`Index`/`Show`, the `phx.gen.live` split) and recorded that decision as
+   binding. Whether that split is the standing convention for every
+   subsequent listing, or was specific to M2M having a per-item detail route,
+   was ambiguous — and Applications has no detail route at all.
+2. **Row and cell DOM ids.** Both prior listings recorded an explicit
+   hash-versus-plain decision justified by the natural key's *validating
+   allowlist*: Secrets hashes the ARN because a secret `key` admits unicode,
+   spaces, and dots; M2M uses `client_id` directly because
+   `Nucleus.M2M.ClientId`'s `~r/\A[A-Za-z0-9_+]{1,128}\z/` leaves nothing to
+   sanitise. `Nucleus.NomadJobs.Job` has **no** validating allowlist for any
+   field, so neither precedent's justification transfers unexamined.
+
+   The ticket body's DOM-id contract compounded this by specifying
+   `#job-{id}-version`, `#job-{id}-status`, and so on. `Job.t()` has no `id`
+   field — ADR-0022 fixed its fields as `name, status, version, namespace,
+   image, cron, periodic?, detail_error`. The contract's `{id}` had no
+   referent, and implementation had to choose one.
+3. **How much of `APP-S2`'s markup to fix now.** Version, image, and schedule
+   *content* is explicitly `APP-S2`'s (#59) scope, but whether this ticket
+   ships those columns at all — and if so, whether their DOM ids are settled
+   here or there — determines whether #59 edits this ticket's markup
+   structure or only its cell bodies.
+
+## Decision
+
+### One `NucleusWeb.ApplicationsLive` module, not ADR-0018's Index/Show split
+
+A single LiveView at `/applications`, with
+`NucleusWeb.ApplicationsLive.States` as its only sibling, registered in the
+existing `:authenticated` `live_session` and inheriting `ScopeHook` then
+`EnvironmentsHook` in ADR-0006's fixed order.
+
+ADR-0018's split is **not** a general listing convention, and this ADR
+records that explicitly so the next listing does not have to re-derive it.
+That ADR's own reasoning was that M2M's `/m2m/clients` and
+`/m2m/clients/:client_id` are "two distinct pages, not one page with several
+states," reached only by `navigate` — the split followed from the existence
+of a second route. Applications is one screen, one table, no drill-down, so
+there is no second page to split into and nothing for a `Show` module to do.
+
+The correct reading of ADR-0018 is therefore: *match the module count to the
+route count.* Both it and this ADR follow that rule and reach different
+answers because they have different route counts.
+
+There is likewise no `handle_params/3` — `/applications` carries no
+identifier, so nothing a `<.link patch>` could change without a remount, and
+the single fetch happens in `mount/3`.
+
+### Row and cell DOM ids derive from `Job.name`, unhashed
+
+`stream_configure(:jobs, dom_id: &dom_id/1)` produces `"job-" <> name`, and
+per-cell ids are `"job-" <> name <> "-" <> column`, resolving the ticket
+body's unreferenced `{id}` to `name`. `name` is the only field on `Job.t()`
+that identifies a job, so this was the sole available choice given ADR-0022's
+struct; it is recorded as a decision because of what it rests on, not because
+there was an alternative field.
+
+Every row also carries `data-job-name={job.name}`, so `APP-S2` and any later
+ticket read the authoritative name from the attribute rather than parsing it
+back out of an element id — the same contract ADR-0018 set with
+`data-client-id`.
+
+**What makes this safe is an invariant owned by another module, not a
+property of the id scheme.** `Job.name` is assigned straight from the Nomad
+API response (`Job.from_api/3`: `name: stub["Name"]`) with no validation,
+allowlist, or sanitisation of any kind. Nomad child job names *do* contain a
+forward slash — `acme-nightly-report/periodic-1755000000` is a seeded example
+— and a `/` in an element id makes the id unaddressable by CSS selector.
+Verified, not assumed: `LazyHTML` raises rather than returning no match.
+
+```
+LazyHTML.filter(frag, "#job-acme-nightly-report/periodic-1755000000-status")
+** (ArgumentError) got invalid css selector:
+   #job-acme-nightly-report/periodic-1755000000-status
+```
+
+The scheme works only because `Nucleus.NomadJobs.Job.child?/1` excludes every
+`ParentID`-bearing stub at the boundary, so no `/`-bearing name reaches the
+template. That exclusion exists to satisfy `APP-A01`'s collapsing
+requirement; the DOM-id scheme's addressability is a second, undeclared
+consumer of it. If a future change to `Nucleus.NomadJobs.list/1` starts
+returning children for any reason, the visible symptom is not a duplicated
+row — it is every affected cell id becoming unselectable, and the test that
+would catch it raising `ArgumentError` rather than failing an assertion.
+
+Hashing `name` (Secrets' approach) was rejected, but on a narrower basis than
+ADR-0018 rejected it for `client_id`: there, no character existed that a hash
+would have helped with. Here such characters demonstrably exist and are
+merely filtered out upstream. The plain name is kept because it makes
+`APP-S2`'s tests and every future selector legible, and because `docs`
+recording the invariant is cheaper than an opaque id — but the trade is real,
+and this is the entry that records it.
+
+### The name-ascending sort lives in the LiveView, not the boundary
+
+`Enum.sort_by(jobs, &{String.downcase(&1.name), &1.name})` — case-insensitive
+with an exact-name tiebreak — matching `Nucleus.M2M.list/1`'s identical
+expression. `Nucleus.NomadJobs.Local.list_jobs/1` returns seed-file order and
+the real adapter returns JSON-decoded order; neither is a stable sort, and
+ADR-0022 did not make ordering part of `list/1`'s contract. The sort stays at
+the rendering layer rather than being retrofitted into the boundary, so
+`list/1`'s contract is unchanged and the ordering requirement sits with the
+view that actually has one.
+
+### Every column's DOM id is fixed now; three render as empty placeholders
+
+Version, image, and schedule ship as empty `<td>` elements at their final
+ids. `APP-S2` (#59) fills in cell *content* only and touches no markup
+structure — the same service ADR-0010 performed for `SEC-S3`–`S6` and
+ADR-0018 for the M2M listing.
+
+| Column | This ticket | `APP-S2` (#59) adds |
+|---|---|---|
+| Name | full text | — |
+| Status | raw status text | colour distinction (`APP-A02`) |
+| Version | empty cell, id fixed | version text (`APP-A03`) |
+| Image | empty cell, id fixed | image `name:tag` (`APP-A03`) |
+| Schedule | empty cell, id fixed | cron / explicit no-schedule (`APP-A04`, `APP-A05`) |
+
+### Error kinds collapse to three named states plus a generic fallback
+
+`:not_configured` → `#applications-misconfigured`, `:unavailable` →
+`#applications-unavailable` (the only state carrying a retry control),
+`:auth_expired` → `#applications-auth-expired`, and every remaining kind →
+`:unavailable`. `<Layouts.app>` stays intact in all of them, satisfying
+`APP-A07`'s "rest of the shell remains usable". This mirrors
+`NucleusWeb.M2MClientsLive.States` deliberately rather than inventing a
+second pattern, and accepts the same fallback trade ADR-0018 recorded.
+
+### `APP-A08` is structural, and the test is a re-proof
+
+`Nucleus.NomadJobs` defines no create, update, or delete callback, so
+read-only already holds one layer below the UI. The negative test asserting
+no create/edit/delete/restart/redeploy control or text inside
+`#applications-table` proves the template adds none either — deliberately
+landed with the first render of the view, per the ticket's own reasoning,
+rather than with `APP-S2`.
+
+## Consequences
+
+### Positive
+
+- The module-count-matches-route-count rule is now written down, so the next
+  listing ticket reads one sentence instead of inferring a convention from
+  ADR-0018 and getting it wrong in either direction.
+- `APP-S2` (#59) inherits a complete DOM-id contract and a `States` module,
+  so it can be a content-only change — no markup-structure churn in a
+  follow-up PR, and no second ticket independently inventing cell ids.
+- `NucleusWeb.ApplicationsLive.States` mirrors `M2MClientsLive.States`
+  closely enough that the third such module is a strong candidate for
+  extraction, should a fourth listing appear.
+- `list/1`'s contract stays as ADR-0022 wrote it; ordering is not
+  retroactively pushed into a boundary that never promised it.
+
+### Negative
+
+- **Cell-id addressability depends on `Job.child?/1`, across a module
+  boundary, with nothing enforcing it at the rendering layer.** The
+  LiveView-level test that no seeded child renders is the guard, and it is a
+  text-absence check (`refute html =~ child_name`) rather than a selector
+  assertion — see the deliberate divergence below. A child leaking from
+  `list/1` breaks selectors rather than merely adding a row.
+- `Job.name` has no validating allowlist at all, so this ADR cannot claim
+  what ADR-0018 could — that the id is *inherently* safe. Any future field
+  used in a DOM id from this struct needs the same examination rather than
+  citing this decision as settled precedent.
+- The generic error fallback folds `:not_found`, `:already_exists`, and
+  `:invalid` into `#applications-unavailable`. If `list/1` ever returns one
+  for a real reason it renders as "can't reach Nomad" until the `case` is
+  revisited — the same trade ADR-0010 and ADR-0018 already accept.
+- Three columns render visibly empty until `APP-S2` lands, so `/applications`
+  is briefly a partially-populated table on the default branch.
+- `NAV-A03` (active-section highlighting) remains unclaimed even though the
+  sidebar link is now live, matching `M2M-S2`'s precedent — a working view
+  does not by itself satisfy the "visually distinguished as active" clause.
+
+## Alternatives considered
+
+**Two modules (`Index`/`Show`), applying ADR-0018 as a standing convention.**
+Rejected — there is no second route for `Show` to serve. Following the split
+mechanically would have produced a module with no route, no template, and
+nothing to test.
+
+**Hashing `Job.name` for row and cell ids, as `SecretsLive` hashes the ARN.**
+Rejected — but on the residual-risk basis recorded above, not ADR-0018's
+"no such character exists" basis. A hash would make every `APP-S2` selector
+opaque and require a name→id helper in tests, to defend against a case
+`Job.child?/1` already excludes. Revisit if `list/1`'s child-exclusion
+guarantee is ever relaxed.
+
+**Sanitising `name` into the id (replacing `/` with `-`) instead of relying
+on upstream filtering.** Rejected as the worse failure mode: it would make a
+leaked child job render an id that *looks* valid and silently collides with a
+sibling's, rather than failing loudly. Given children are excluded upstream,
+the sanitiser would be dead code whose only effect is to mask the regression
+it appears to guard against.
+
+**Adding the sort to `Nucleus.NomadJobs.list/1`.** Rejected — expands a
+boundary contract ADR-0022 deliberately scoped, to serve one caller's
+presentation requirement. `Nucleus.M2M.list/1`'s precedent puts the identical
+sort at the same layer.
+
+**Deferring the version/image/schedule columns entirely to `APP-S2`.**
+Rejected — #59 would then own both the markup structure and the cell
+content, reopening this ticket's table markup in a follow-up PR, which is
+precisely what ADR-0010's DOM-id contract exists to prevent.
+
+## Deliberate divergence from the ticket's test plan
+
+The issue's snippet proposed
+`refute has_element?(view, "#job-#{seeded_child_job_id()}-status")`. That
+cannot work: the selector string it builds contains a `/`, which LazyHTML's
+parser rejects outright with `ArgumentError`, so the assertion raises instead
+of passing or failing. The test uses `refute html =~ child_name` — a
+text-absence check proving the child renders nowhere at all, which is
+strictly stronger than the id-absence check intended, and does not depend on
+a selector the parser cannot accept.
+
+This is the same class of finding as ADR-0012's discovery that
+`LazyHTML.query/2` returns a struct rather than a list and made several
+guards vacuous. Both are now recorded together in `living-notes.md`'s
+Gotchas, since either one silently produces a test that does not test what it
+appears to.
+
+## References
+
+- APP-S1 (issue #58) — the deciding issue, including the `#job-{id}-*`
+  DOM-id contract whose `{id}` had no referent on `Job.t()`
+- APP-S2 (issue #59) — the downstream consumer of this ticket's DOM-id
+  contract and `States` module
+- `docs/adr/0018-m2m-clients-listing-module-split-and-dom-ids.md` — the
+  module-split and plain-id decisions this ADR bounds to their route count
+- `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md` — the
+  DOM-id-contract-for-later-tickets precedent
+- `docs/adr/0022-nomad-jobs-adapter.md` — `Nucleus.NomadJobs.list/1`,
+  `Job.child?/1`'s `ParentID` filtering, and the `Job.t()` field list with
+  no `id`
+- `docs/adr/0006-application-shell-and-live-session-composition.md` —
+  the `live_session` hook order this route inherits

--- a/lib/nucleus_web/components/layouts.ex
+++ b/lib/nucleus_web/components/layouts.ex
@@ -76,17 +76,19 @@ defmodule NucleusWeb.Layouts do
               Tenant
             </p>
             <%!--
-              NAV-A03 (active-section highlighting) is out of scope: these
-              tenant-wide features don't exist yet, so they render as
-              visibly disabled placeholders rather than dead links.
-              M2M Clients (M2M-S2, #35) is the first of these three to ship
-              a real view — replaced with a working link, not a placeholder.
+              NAV-A03 (active-section highlighting) is out of scope for
+              every item here, shipped or not.
+              M2M Clients (M2M-S2, #35) and Applications (APP-S1, #58) have
+              shipped their real views — replaced with working links, not
+              placeholders. Data Export's feature doesn't exist yet, so it
+              still renders as a visibly disabled placeholder rather than a
+              dead link, until its own future ticket.
             --%>
             <ul class="menu menu-sm p-0 group-data-[collapsed=true]:hidden">
               <li>
-                <span class="opacity-40 cursor-not-allowed" aria-disabled="true">
+                <.link navigate={~p"/applications"}>
                   Applications
-                </span>
+                </.link>
               </li>
               <li>
                 <span class="opacity-40 cursor-not-allowed" aria-disabled="true">

--- a/lib/nucleus_web/live/applications_live.ex
+++ b/lib/nucleus_web/live/applications_live.ex
@@ -1,0 +1,190 @@
+defmodule NucleusWeb.ApplicationsLive do
+  @moduledoc """
+  Lists the tenant's deployed applications (`APP-A01`), with an empty state
+  (`APP-A06`), distinct error states (`APP-A07`), and no mutating affordance
+  of any kind (`APP-A08`) — issue #58, APP-S1.
+
+  ## Single module — no Index/Show split
+
+  Unlike `NucleusWeb.M2MClientsLive`, there is no per-item detail route to
+  justify `phx.gen.live`'s Index/Show split (`docs/adr/0018`): Applications
+  is one screen, one table, no drill-down. `NucleusWeb.ApplicationsLive.States`
+  is the only sibling module, mirroring `NucleusWeb.M2MClientsLive.States`.
+
+  ## No URL params to gate — `mount/3`, not `handle_params/3`
+
+  `/applications` carries no identifier, matching
+  `NucleusWeb.M2MClientsLive.Index`'s own reasoning: nothing a `<.link
+  patch={...}>` could change without a remount, so the one fetch happens in
+  `mount/3` directly.
+
+  ## One call to `Nucleus.NomadJobs.list/1`
+
+  `list/1` already excludes periodic and dispatch children before returning
+  (`Nucleus.NomadJobs.Job.child?/1`) — `APP-A01`'s periodic-collapsing
+  requirement needs no work here beyond consuming what comes back. A
+  LiveView-level test still asserts no seeded child ever renders its own
+  row, so a future `Nucleus.NomadJobs` regression that starts leaking
+  children is caught at the rendering boundary too, not only at EN-11's own
+  context-level test.
+
+  `Nucleus.NomadJobs.Local.list_jobs/1` returns entries in the seed file's
+  own order, not sorted — this module sorts name-ascending with a
+  case-insensitive tiebreak, matching `Nucleus.M2M.list/1`'s own
+  `Enum.sort_by(&{String.downcase(&1.name), &1.name})`, for the same
+  flakiness reasons EN-10's Cognito pagination and this feature's
+  JSON-decoded map both lack a stable native order.
+
+  ## Every outcome gets its own assign and DOM id
+
+  `Nucleus.NomadJobs.list/1` can succeed or fail with any
+  `Nucleus.Backend.Error.kinds/0` value — this `case` collapses them to
+  three states via `NucleusWeb.ApplicationsLive.States`, mirroring
+  `NucleusWeb.M2MClientsLive.Index` exactly (`docs/adr/0010`):
+
+  | Outcome | `:status` | DOM id |
+  |---|---|---|
+  | `{:ok, jobs}` | `:ok` | `#applications-table` / `#applications-empty` |
+  | `kind: :not_configured` | `:misconfigured` | `#applications-misconfigured` |
+  | `kind: :unavailable` | `:unavailable` | `#applications-unavailable` |
+  | `kind: :auth_expired` | `:auth_expired` | `#applications-auth-expired` |
+  | anything else (`:not_found`, `:already_exists`, `:invalid` — none of
+    which `list/1` has reason to return today) | `:unavailable` | `#applications-unavailable` |
+
+  Every branch keeps `<Layouts.app>` intact (`#tenant-identifier` present)
+  so the user can navigate away — `APP-A07`'s "rest of the shell remains
+  usable".
+
+  ## `stream/3`, plus a separate count assign
+
+  Streams are not enumerable (`AGENTS.md`), so `:job_count` — set alongside
+  the stream, from the same `Nucleus.NomadJobs.list/1` call, never
+  recomputed separately — drives the empty-state branch (`APP-A06`). Unlike
+  `NucleusWeb.M2MClientsLive.Index`'s create button, there is no affordance
+  that must stay visible alongside the empty state, so the explicit
+  `@job_count == 0` conditional is used for consistency with that module's
+  established pattern rather than because anything here needs it.
+
+  ## Row cells this ticket fills in, and the placeholders `APP-S2` (#59) replaces
+
+  Every column's DOM id is fixed now, even the ones this ticket doesn't
+  finish styling (`docs/adr/0010`, `docs/adr/0018`):
+
+  | Column | This ticket | `APP-S2` (#59) adds |
+  |---|---|---|
+  | Name | full text | — |
+  | Status | raw status text | colour distinction (`APP-A02`) |
+  | Version | placeholder cell, DOM id fixed | explicit version text (`APP-A03`) |
+  | Image | placeholder cell, DOM id fixed | image name:tag (`APP-A03`) |
+  | Schedule | placeholder cell, DOM id fixed | cron text / explicit "no schedule" (`APP-A04`, `APP-A05`) |
+
+  ## `APP-A08` — no mutating affordance anywhere
+
+  No create button, no per-row edit/delete/restart/redeploy control, no
+  "Actions" column. This is enforced one layer below the UI already —
+  `Nucleus.NomadJobs` defines no create/update/delete callback of any kind
+  — but the negative test here proves the template itself adds none either.
+
+  `current_scope` and `environments`/`expanded_categories` come from the
+  `:authenticated` `live_session`'s `on_mount` hooks (`NucleusWeb.ScopeHook`,
+  `NucleusWeb.EnvironmentsHook`), same order as `NucleusWeb.M2MClientsLive.Index`
+  — this module does not assign any of them itself.
+  """
+
+  use NucleusWeb, :live_view
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.NomadJobs
+  alias Nucleus.NomadJobs.Job
+  alias NucleusWeb.ApplicationsLive.States
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> stream_configure(:jobs, dom_id: &dom_id/1)
+      |> stream(:jobs, [])
+      |> fetch_jobs()
+
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("retry", _params, socket) do
+    {:noreply, fetch_jobs(socket)}
+  end
+
+  defp fetch_jobs(socket) do
+    case NomadJobs.list(socket.assigns.current_scope) do
+      {:ok, jobs} ->
+        sorted = Enum.sort_by(jobs, &{String.downcase(&1.name), &1.name})
+
+        socket
+        |> assign(status: :ok, job_count: length(sorted))
+        |> stream(:jobs, sorted, reset: true)
+
+      {:error, %Error{kind: :not_configured}} ->
+        assign(socket, status: :misconfigured, job_count: 0)
+
+      {:error, %Error{kind: :auth_expired}} ->
+        assign(socket, status: :auth_expired, job_count: 0)
+
+      {:error, %Error{}} ->
+        assign(socket, status: :unavailable, job_count: 0)
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_scope={@current_scope}
+      environments={@environments}
+      expanded_categories={@expanded_categories}
+    >
+      <States.misconfigured :if={@status == :misconfigured} />
+      <States.unavailable :if={@status == :unavailable} />
+      <States.auth_expired :if={@status == :auth_expired} />
+
+      <div :if={@status == :ok}>
+        <h1 class="text-lg font-semibold pb-4">Applications</h1>
+
+        <.empty_state
+          :if={@job_count == 0}
+          id="applications-empty"
+          icon="hero-inbox"
+          message="No jobs found in this namespace."
+        />
+
+        <div :if={@job_count > 0} id="applications-table">
+          <table class="table table-zebra">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Status</th>
+                <th>Version</th>
+                <th>Image</th>
+                <th>Schedule</th>
+              </tr>
+            </thead>
+            <tbody id="applications-table-body" phx-update="stream">
+              <tr :for={{dom_id, job} <- @streams.jobs} id={dom_id} data-job-name={job.name}>
+                <td class="font-medium">{job.name}</td>
+                <td id={cell_id(job.name, "status")}>{job.status}</td>
+                <td id={cell_id(job.name, "version")}></td>
+                <td id={cell_id(job.name, "image")}></td>
+                <td id={cell_id(job.name, "schedule")}></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp dom_id(%Job{name: name}), do: "job-" <> name
+
+  defp cell_id(name, column), do: "job-" <> name <> "-" <> column
+end

--- a/lib/nucleus_web/live/applications_live/states.ex
+++ b/lib/nucleus_web/live/applications_live/states.ex
@@ -1,0 +1,77 @@
+defmodule NucleusWeb.ApplicationsLive.States do
+  @moduledoc """
+  Shared error-state function components for `NucleusWeb.ApplicationsLive`
+  (`APP-A07`) — mirrors `NucleusWeb.M2MClientsLive.States` exactly (issue
+  #58's plan names it as the pattern to follow), including the "mirror
+  whatever landed for `:auth_expired`, don't invent a second pattern" rule.
+
+  `Nucleus.NomadJobs.list/1` can return any `Nucleus.Backend.Error.kinds/0`
+  value — `NucleusWeb.ApplicationsLive` collapses every kind to one of the
+  three states here, so no kind is left unhandled and no branch crashes the
+  LiveView:
+
+  | Outcome | `:status` | DOM id |
+  |---|---|---|
+  | `kind: :not_configured` | `:misconfigured` | `#applications-misconfigured` |
+  | `kind: :unavailable` | `:unavailable` | `#applications-unavailable` |
+  | `kind: :auth_expired` | `:auth_expired` | `#applications-auth-expired` |
+  | anything else (`:not_found`, `:already_exists`, `:invalid` — none of
+    which `list/1` has reason to return today) | `:unavailable` | `#applications-unavailable` |
+  """
+
+  use NucleusWeb, :html
+
+  @doc """
+  The `:nomad_jobs` boundary has no usable configuration — an operations
+  problem, not something the user did wrong.
+  """
+  attr :id, :string, default: "applications-misconfigured"
+
+  def misconfigured(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-shield-exclamation"
+      message="Applications isn't configured yet. This is an operations issue, not something you can fix here."
+    />
+    """
+  end
+
+  @doc """
+  Nomad (or the local backend standing in for it) can't be reached right
+  now — carries a retry affordance, unlike the other two states (`APP-A07`).
+  """
+  attr :id, :string, default: "applications-unavailable"
+
+  def unavailable(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-exclamation-triangle"
+      message="Can't reach Nomad right now. Try again shortly."
+    >
+      <:action>
+        <.button phx-click="retry">Retry</.button>
+      </:action>
+    </.empty_state>
+    """
+  end
+
+  @doc """
+  Nucleus's own credentials for the backend expired. Mirrors whatever
+  `NucleusWeb.M2MClientsLive.States.auth_expired/1` (in turn mirroring
+  `SEC-A18`/`SEC-S7`) landed for this kind, rather than inventing a second
+  pattern.
+  """
+  attr :id, :string, default: "applications-auth-expired"
+
+  def auth_expired(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-lock-closed"
+      message="Applications can't be reached right now."
+    />
+    """
+  end
+end

--- a/lib/nucleus_web/router.ex
+++ b/lib/nucleus_web/router.ex
@@ -55,6 +55,10 @@ defmodule NucleusWeb.Router do
       # replaces its body without touching this route or `Index`.
       live "/m2m/clients", M2MClientsLive.Index, :index
       live "/m2m/clients/:client_id", M2MClientsLive.Show, :show
+
+      # Single module, no Index/Show split — APP-S1 (#58), see
+      # `NucleusWeb.ApplicationsLive`'s moduledoc.
+      live "/applications", ApplicationsLive, :index
     end
   end
 

--- a/test/nucleus_web/live/applications_live_test.exs
+++ b/test/nucleus_web/live/applications_live_test.exs
@@ -1,0 +1,268 @@
+defmodule NucleusWeb.ApplicationsLiveTest do
+  # `force_error/2` mutates the node-global `LOCAL_FORCE_ERROR` env var
+  # (`Nucleus.Backend.Faults`) — matching `Nucleus.BackendCase`'s own
+  # `async: false` requirement.
+  use NucleusWeb.LiveCase, async: false
+
+  alias Nucleus.Backend.Error
+
+  # Seeded in priv/backends/local_seed.json — parent jobs only, per
+  # `Nucleus.NomadJobs.Job.child?/1`'s exclusion.
+  @seeded_parent_names [
+    "acme-api",
+    "acme-ingress",
+    "acme-nightly-report",
+    "acme-hourly-sync",
+    "acme-batch-import",
+    "acme-adhoc-export",
+    "acme-legacy-raw-exec",
+    "acme-worker-pending",
+    "acme-worker-dead"
+  ]
+
+  # Seeded children — periodic and dispatch alike — that must never render
+  # as their own row (`APP-A01`).
+  @seeded_child_names [
+    "acme-nightly-report/periodic-1755000000",
+    "acme-nightly-report/periodic-1755086400",
+    "acme-batch-import/dispatch-1755000111",
+    "acme-batch-import/dispatch-1755000222"
+  ]
+
+  describe "APP-A01 — view the tenant's deployed applications" do
+    @tag action: "APP-A01"
+    test "lists every seeded parent job with name, status, and its fixed-id cells", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/applications")
+
+      assert has_element?(view, "#applications-table")
+
+      for name <- @seeded_parent_names do
+        assert has_element?(view, "#applications-table-body", name)
+        assert has_element?(view, "#job-#{name}-status")
+        assert has_element?(view, "#job-#{name}-version")
+        assert has_element?(view, "#job-#{name}-image")
+        assert has_element?(view, "#job-#{name}-schedule")
+      end
+    end
+
+    @tag action: "APP-A01"
+    test "a periodic parent's children never render as their own rows", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/applications")
+
+      for child_name <- [
+            "acme-nightly-report/periodic-1755000000",
+            "acme-nightly-report/periodic-1755086400"
+          ] do
+        refute html =~ child_name
+      end
+    end
+
+    @tag action: "APP-A01"
+    test "a dispatch parent's children never render as their own rows", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/applications")
+
+      for child_name <- [
+            "acme-batch-import/dispatch-1755000111",
+            "acme-batch-import/dispatch-1755000222"
+          ] do
+        refute html =~ child_name
+      end
+    end
+
+    @tag action: "APP-A01"
+    test "no seeded child name appears anywhere in the rendered HTML", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/applications")
+
+      for child_name <- @seeded_child_names do
+        refute html =~ child_name
+      end
+    end
+
+    @tag action: "APP-A01"
+    test "row order is stable across two mounts", %{conn: conn} do
+      {:ok, view1, _html} = live(conn, ~p"/applications")
+      {:ok, view2, _html} = live(conn, ~p"/applications")
+
+      names1 = row_job_names(view1)
+      names2 = row_job_names(view2)
+
+      assert names1 != []
+      assert names1 == names2
+      assert names1 == Enum.sort_by(names1, &String.downcase/1)
+    end
+  end
+
+  describe "APP-A06 — empty state" do
+    @tag action: "APP-A06"
+    test "zero seeded jobs renders #applications-empty, not the table", %{conn: conn} do
+      Nucleus.Backend.Seed.write(:nomad_jobs, [])
+
+      {:ok, view, _html} = live(conn, ~p"/applications")
+
+      assert has_element?(view, "#applications-empty")
+      refute has_element?(view, "#applications-table")
+    end
+  end
+
+  describe "APP-A07 — error state when Nomad is unreachable" do
+    @tag action: "APP-A07"
+    test "forced :unavailable renders #applications-unavailable, shell intact, with a retry control",
+         %{conn: conn} do
+      force_error(:nomad_jobs, :unavailable)
+
+      {:ok, view, _html} = live(conn, ~p"/applications")
+
+      assert has_element?(view, "#applications-unavailable")
+      refute has_element?(view, "#applications-table")
+      refute has_element?(view, "#applications-empty")
+      # the shell survives — the rest of the header/sidebar remains usable.
+      assert has_element?(view, "#tenant-identifier")
+    end
+
+    @tag action: "APP-A07"
+    test "retry re-fetches and shows the table once the fault clears", %{conn: conn} do
+      force_error(:nomad_jobs, :unavailable)
+
+      {:ok, view, _html} = live(conn, ~p"/applications")
+      assert has_element?(view, "#applications-unavailable")
+
+      clear_faults()
+
+      view |> element("[phx-click='retry']") |> render_click()
+
+      assert has_element?(view, "#applications-table")
+      refute has_element?(view, "#applications-unavailable")
+    end
+  end
+
+  describe "every Nucleus.Backend.Error kind renders a distinct state, shell intact, no crash" do
+    @error_state_ids %{
+      not_configured: "applications-misconfigured",
+      unavailable: "applications-unavailable",
+      auth_expired: "applications-auth-expired"
+    }
+
+    for {kind, expected_id} <- @error_state_ids do
+      @tag kind: kind
+      @tag expected_id: expected_id
+      test "#{kind} renders #{expected_id}, mutually exclusive, shell intact", %{
+        conn: conn,
+        kind: kind,
+        expected_id: expected_id
+      } do
+        force_error(:nomad_jobs, kind)
+
+        {:ok, view, _html} = live(conn, ~p"/applications")
+
+        assert has_element?(view, "##{expected_id}")
+
+        for other_id <- Map.values(@error_state_ids) -- [expected_id] do
+          refute has_element?(view, "##{other_id}")
+        end
+
+        refute has_element?(view, "#applications-table")
+        refute has_element?(view, "#applications-empty")
+        assert has_element?(view, "#tenant-identifier")
+      end
+    end
+
+    test "every remaining kind collapses to #applications-unavailable and never crashes", %{
+      conn: conn
+    } do
+      named_kinds = Map.keys(@error_state_ids)
+
+      for kind <- Error.kinds() -- named_kinds do
+        force_error(:nomad_jobs, kind)
+
+        assert {:ok, view, _html} = live(conn, ~p"/applications")
+        assert has_element?(view, "#applications-unavailable")
+        assert has_element?(view, "#tenant-identifier")
+
+        clear_faults()
+      end
+    end
+
+    test "live/2 returns {:ok, ...} for every error kind — the LiveView never crashes", %{
+      conn: conn
+    } do
+      for kind <- Error.kinds() do
+        force_error(:nomad_jobs, kind)
+        assert {:ok, _view, _html} = live(conn, ~p"/applications")
+        clear_faults()
+      end
+    end
+  end
+
+  describe "APP-A08 — read-only, no mutating affordance" do
+    @tag action: "APP-A08"
+    test "no create, edit, delete, restart, or redeploy control exists anywhere on the view", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/applications")
+
+      refute has_element?(view, "[phx-click='create']")
+      refute has_element?(view, "[phx-click='edit']")
+      refute has_element?(view, "[phx-click='delete']")
+      refute has_element?(view, "[phx-click='restart']")
+      refute has_element?(view, "[phx-click='redeploy']")
+      refute has_element?(view, "button", "New")
+      refute has_element?(view, "th", "Actions")
+    end
+
+    @tag action: "APP-A08"
+    test "none of the words Restart, Redeploy, Delete, or Edit appear inside #applications-table",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/applications")
+
+      table_html = view |> element("#applications-table") |> render()
+
+      refute table_html =~ "Restart"
+      refute table_html =~ "Redeploy"
+      refute table_html =~ "Delete"
+      refute table_html =~ "Edit"
+    end
+  end
+
+  describe "sidebar — Applications is a real, functional link" do
+    test "the sidebar renders a navigate link to /applications, not a disabled span", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/applications")
+
+      doc = view |> render() |> LazyHTML.from_fragment()
+
+      applications_link =
+        doc
+        |> LazyHTML.query("#sidebar a")
+        |> Enum.find(fn node -> LazyHTML.text(node) =~ "Applications" end)
+
+      refute is_nil(applications_link)
+      assert LazyHTML.attribute(applications_link, "href") == ["/applications"]
+
+      refute has_element?(view, "#sidebar span[aria-disabled='true']", "Applications")
+    end
+
+    test "clicking the sidebar link from another authenticated view navigates to /applications",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert {:ok, applications_view, _html} =
+               view
+               |> element("#sidebar a", "Applications")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/applications")
+
+      assert has_element?(applications_view, "#applications-table")
+    end
+  end
+
+  defp row_job_names(view) do
+    view
+    |> render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("#applications-table-body [data-job-name]")
+    |> LazyHTML.attribute("data-job-name")
+  end
+end


### PR DESCRIPTION
## What

Ships the tenant-facing Applications listing: a new `/applications` route rendering the tenant's deployed Nomad jobs in a table, with an empty state, three collapsed error states, and no mutating affordance of any kind. The sidebar's "Applications" entry — a disabled placeholder since EN-7 — now links to it. This closes out APP-A01, APP-A06, APP-A07, and APP-A08; the version/image/status/schedule column *content* is deliberately left for APP-S2 (#59).

## How

- `NucleusWeb.ApplicationsLive` (+ `.States`) is a single module — no Index/Show split, since Applications has no per-item detail route to justify the M2M precedent (`docs/adr/0018`). It's registered inside the existing `:authenticated` `live_session`.
- Rows come from `Nucleus.NomadJobs.list/1` (EN-11/#57), sorted name-ascending with a case-insensitive tiebreak (`Enum.sort_by(&{String.downcase(&1.name), &1.name})`) — the boundary itself doesn't guarantee order, so the sort lives here, matching `Nucleus.M2M.list/1`'s identical reasoning.
- **APP-A01** (periodic collapsing): `Nucleus.NomadJobs.Job.child?/1` already filters children out at the boundary, so no filtering logic was needed in the LiveView — but a LiveView-level test was added anyway, asserting no seeded periodic/dispatch child (`acme-nightly-report/*`, `acme-batch-import/*`) ever renders, catching a future boundary regression at the rendering layer too.
- **APP-A06**: `stream/3` plus a separate `:job_count` assign (streams aren't enumerable) drives the `#applications-empty` conditional, mirroring `NucleusWeb.M2MClientsLive.Index`'s established pattern.
- **APP-A07**: every `Nucleus.Backend.Error.kinds/0` value is handled exhaustively, collapsed to `#applications-misconfigured`, `#applications-unavailable` (with a retry control), `#applications-auth-expired`, or a generic fallback for kinds `list/1` has no reason to return today. `<Layouts.app>` stays intact in every branch, so the shell remains usable.
- **APP-A08**: no create/edit/delete/restart/redeploy control exists in the template, proven by a negative test asserting the absence of any such control or text inside `#applications-table`. This is a re-proof, not the primary guard — `Nucleus.NomadJobs` defines no create/update/delete callback at all, so the read-only property already holds one layer below the UI.
- Version, Image, and Schedule render as empty placeholder `<td>` cells with fixed DOM ids (`#job-{name}-version`, `#job-{name}-image`, `#job-{name}-schedule`). This is intentional scope, not an oversight: fixing every column's DOM id now — the same service `docs/adr/0010` and `docs/adr/0018` performed for earlier listings — means APP-S2 (#59) only needs to fill in cell content, not touch this ticket's markup.
- The sidebar's Applications entry in `lib/nucleus_web/components/layouts.ex` becomes a real `<.link navigate={~p"/applications"}>`, replacing EN-7's disabled `<span>`. `NAV-A03` (active-section highlighting) is explicitly not claimed — the same call `M2M-S2` made for its own sidebar link, since a working view doesn't by itself satisfy NAV-A03's "visually distinguished as active" clause. `test/nucleus_web/live/shell_test.exs` had no assertion on the disabled state, so nothing needed updating there.
- Tests: `test/nucleus_web/live/applications_live_test.exs`, tagged `action: "APP-A01"` / `"APP-A06"` / `"APP-A07"` / `"APP-A08"`.

## Record

`docs/adr/0025-applications-listing-single-module-and-name-derived-dom-ids.md` records the three
choices this ticket settled that its precedents did not cover:

1. **Route shape.** One module, not `docs/adr/0018`'s Index/Show split. The ADR bounds 0018's
   decision to its stated reason — *match the module count to the route count* — so the next
   listing does not have to infer the convention and get it wrong in either direction.
2. **Row and cell DOM ids.** The ticket body's contract specified `#job-{id}-*`, but `Job.t()` has
   no `id` field (`docs/adr/0022` fixed its fields), so implementation resolved `{id}` to `name`.
   Unlike `Nucleus.M2M.ClientId`, `Job.name` has **no** validating allowlist — it is assigned
   straight from the API response — and Nomad child names contain a `/`, which makes an element id
   unaddressable and makes LazyHTML *raise* rather than not match (verified, see below).
   Addressability therefore rests entirely on `Job.child?/1` filtering children out at the
   boundary, an invariant that previously existed only to satisfy `APP-A01`. That dependency is now
   written down, along with why hashing was still rejected and what would make it right.
3. **Pre-fixing the placeholder cells' ids** so `APP-S2`/#59 is a content-only change.

`decisions-log.md` gains index row 25 and the `adr/0001`–`0025` binding range (index row only —
that file's v1.11 restructure explicitly forbids per-decision prose sections). `living-notes.md`
gains a Gotchas entry for the `/`-in-selector trap, as a direct sibling to the existing
`LazyHTML.query/2`-returns-a-struct entry: both silently produce a test that does not test what it
appears to. `business-tech-bridge.md` carries the requirement traceability for
`APP-A01`/`A06`/`A07`/`A08`. Version/date bumped on all three context files.

The record landed as its own commit (`e4d5a17`), separate from the implementation.

## Divergence from the plan

The issue's test-plan snippet suggested proving the periodic-collapsing negative case with `refute has_element?(view, "#job-#{seeded_child_job_id()}-status")`. Seeded child job names contain a `/` (e.g. `acme-nightly-report/periodic-1755000000`), which `Phoenix.LiveViewTest`'s LazyHTML-backed CSS selector parser rejects outright — running it raised `ArgumentError: got invalid css selector`, not just an assertion failure. The test uses `refute html =~ child_name` instead: a textual absence check that proves the same thing (the child never renders anywhere) without depending on a selector string the parser can't accept.

## Verification

`mix precommit` passes: compile with `--warnings-as-errors`, `deps.unlock --unused`, `format`, and the full test suite — 975 tests passed (34 doctests + 941 tests), 31 skipped, 16 excluded, 0 failures. Neither `format` nor `deps.unlock` modified any file.

Closes #58

