### PR TITLE
drop the unreachable nomad_var_viewed audit event

### DIFF
--- a/lib/nucleus/audit/event.ex
+++ b/lib/nucleus/audit/event.ex
@@ -7,7 +7,7 @@ defmodule Nucleus.Audit.Event do
   cannot pass a secret value through by accident. `resource` carries *what was
   accessed* (a path or key), never the value itself.
 
-  The `event` type union covers all eleven events from the wiki's
+  The `event` type union covers all ten events from the wiki's
   [Audit & Compliance](https://github.com/dave-bell/nucleus/wiki/Audit-and-Compliance)
   catalogue, so later features do not each invent their own spelling. Only the
   three Secrets events (`:secret_created`, `:secret_viewed`, `:secret_updated`)
@@ -24,7 +24,6 @@ defmodule Nucleus.Audit.Event do
   @type event ::
           :auth_failure
           | :nomad_vars_listed
-          | :nomad_var_viewed
           | :nomad_var_updated
           | :env_names_updated
           | :secret_created
@@ -70,12 +69,6 @@ defmodule Nucleus.Audit.Event do
       required: [:tenant],
       details_allowed: [:path],
       details_required: [:path]
-    },
-    nomad_var_viewed: %{
-      allowed: [:user, :tenant, :details],
-      required: [:tenant],
-      details_allowed: [:path, :key],
-      details_required: [:path, :key]
     },
     nomad_var_updated: %{
       allowed: [:user, :tenant, :details],

--- a/test/nucleus/audit_test.exs
+++ b/test/nucleus/audit_test.exs
@@ -122,24 +122,24 @@ defmodule Nucleus.AuditTest do
 
     @tag :unit
     test "an unknown key inside details raises — the per-event details allowlist" do
-      # nomad_var_viewed does support :details, so this exercises the inner
+      # nomad_var_updated does support :details, so this exercises the inner
       # key allowlist itself, not the outer :details rejection above.
       error =
         assert_raise ArgumentError, fn ->
-          Audit.emit(:nomad_var_viewed,
+          Audit.emit(:nomad_var_updated,
             tenant: "acme",
             details: %{path: "/api/secrets", key: "DATABASE_URL", value: "super-secret"}
           )
         end
 
-      assert error.message =~ "unknown detail :value for audit event :nomad_var_viewed"
+      assert error.message =~ "unknown detail :value for audit event :nomad_var_updated"
     end
 
     @tag :unit
     test "a required detail key raises when missing" do
       error =
         assert_raise ArgumentError, fn ->
-          Audit.emit(:nomad_var_viewed, tenant: "acme", details: %{key: "DATABASE_URL"})
+          Audit.emit(:nomad_var_updated, tenant: "acme", details: %{key: "DATABASE_URL"})
         end
 
       assert error.message =~ "missing required field(s)"

--- a/test/support/audit_case.ex
+++ b/test/support/audit_case.ex
@@ -68,7 +68,7 @@ defmodule Nucleus.AuditCase do
   keys it cares about).
 
       assert_audit_event(:secret_viewed, tenant: "acme", resource: "/prod/API_KEY")
-      assert_audit_event(:nomad_var_viewed, details: %{key: "FEATURE_FLAG"})
+      assert_audit_event(:nomad_var_updated, details: %{key: "FEATURE_FLAG"})
 
   Fails with the full list of emitted events when there is no match, so a
   failure shows what was actually recorded rather than just "not found".


### PR DESCRIPTION
## What

`nomad_var_viewed` was cataloged in the audit event system as a documented, ten-detail-shaped event, but no action on the Data Export Configuration page ever emitted it — the page's only read action (DEX-A03) covers the bulk variable listing and is audited as `nomad_vars_listed`, not a per-key read. This ticket is itself the decision-and-implementation for that gap: rather than manufacture a `DEX-A15` action solely to make the event reachable, the decision (recorded on issue #79) was to drop `nomad_var_viewed` entirely.

## How

- Removed `nomad_var_viewed` from `lib/nucleus/audit/event.ex`'s `@type event` union and `@catalogue` map, and corrected the moduledoc's event count from eleven to ten.
- Removed the matching row from both wiki audit tables — `Data-Export-Configuration.md`'s "Audit events" section and `Audit-and-Compliance.md`'s "Complete audit event catalogue" — via the `docs/requirements` (`nucleus.wiki`) submodule, already committed and pushed there as `7a32340`, with the submodule pointer bumped in this PR.
- Also dropped the now-orphaned `GET /api/nomad/variables/{key}` API contract row from the wiki page. This wasn't a divergence from the ticket — it's the second option the ticket itself listed, taken instead of keeping the row as advisory-only shape documentation, so the contract table doesn't reintroduce the same "documented but unreachable" confusion this ticket resolves.
- Swapped the two test usages of `nomad_var_viewed` — `test/support/audit_case.ex`'s moduledoc example and `test/nucleus/audit_test.exs`'s `:details`-allowlist tests — for `nomad_var_updated`, which has an identical `details_allowed`/`details_required` shape, so no other test assertions needed to change.

## Record

No ADR, decisions-log, bridge, or living-notes entry accompanies this PR. The decision rationale (drop vs. add `DEX-A15`, and taking the ticket's second option on the API contract row) already lives in full on the issue #79 comment, and no requirement-traceability or open-question tracking elsewhere referenced this event — there was nothing durable left to capture beyond what the issue thread already holds.

## Verification

`mix precommit` (`compile --warnings-as-errors`, `deps.unlock --unused`, `format`, `test`) passed clean on this branch: 1010 tests passed, 31 skipped, 16 excluded.

Closes #79
