### PR TITLE
DEX-S1: Enablement gate, configuration table, empty/error states, no-create-or-delete guard

### DIFF
--- a/.opencode/context/project-intelligence/business-tech-bridge.md
+++ b/.opencode/context/project-intelligence/business-tech-bridge.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.24 | Updated: 2026-08-26 -->
+<!-- Context: project-intelligence/bridge | Priority: high | Version: 1.25 | Updated: 2026-08-27 -->
 
 # Business ↔ Tech Bridge
 
@@ -314,6 +314,36 @@ id itself, with `align-middle` on the `<td>` so the pill sits centered in the ro
 coloring the whole cell. The rendered status *colour* itself (as opposed to the CSS class)
 joins `test/README.md`'s gap table alongside `M2M-A10`/`SEC-A04`, rather than reopening
 `docs/adr/0008` — see `docs/adr/0026-applications-row-formatters-and-status-colour-test-gap.md`.
+
+`DEX-A01`, `A03`, `A12`, `A13`, and `A14` are now claimed and covered (`DEX-S1`/#73):
+`NucleusWeb.DataExportLive` (single module, no Index/Show split — the same
+module-count-matches-route-count rule `docs/adr/0025` established, applied here for a second
+listing rather than re-derived) lists every key/value from `Nucleus.NomadVars.list/1`, sorted
+name-ascending with a case-insensitive tiebreak. Row/cell DOM ids (`#var-{key}-value`) use the
+raw, unhashed key — unlike `docs/adr/0025`'s `Job.name`, no upstream filter exists or could
+exist for a Nomad Variables key, so the safety argument rests on provenance (every key today is
+ops-provisioned, not tenant-supplied) rather than a filter the code enforces; see
+`docs/adr/0028` for the full reasoning and its residual risk. `Nucleus.NomadVars` gained a second
+function, `fetch/1` (no audit), alongside `list/1` (`fetch/1` plus `nomad_vars_listed` on
+success) — caught in review after the ticket's literal plan (one `connected?`-gated call to
+`list/1`) left the disconnected static render blank, since `Phoenix.LiveViewTest.live/2` never
+exercises that pass. `NucleusWeb.DataExportLive.mount/3` now calls `fetch/1` disconnected and
+`list/1` once connected, mirroring `NucleusWeb.M2MClientsLive.Show`'s `M2M.fetch/2`/`view/2`
+split (`docs/adr/0019`) — the first time that split has been applied to a listing rather than a
+detail view, since `Nucleus.NomadVars.list/1` is the first listing-level context function that
+audits at all. `{:error, %Error{kind: :not_found}}` maps to its own `#data-export-not-enabled`
+state (`DEX-A01`), not a generic error — `Nucleus.NomadVars.Store`'s own moduledoc states plainly
+that `:not_found` here means "not enabled," not "the load failed." `VariableSet.t()`'s single
+`modify_index`/`modified_at` for the whole path (`docs/adr/0027`, DEX-D1's correction of the
+wiki's per-key shape) renders once at `#data-export-modified-at`, never per row.
+`NucleusWeb.DataExportLive.States` collapses every other `Nucleus.Backend.Error.kinds/0` value
+the same way `docs/adr/0025` collapsed `Nucleus.NomadJobs`'s, including a documented defensive
+fallback for `:conflict`, which nothing here can produce yet. `DEX-A14`'s read-only guard is
+enforced one layer below the UI already (`Nucleus.NomadVars.Store` defines no create/delete
+callback of any kind) and reproven by a negative test. The sidebar's Data Export entry
+(`layouts.ex`) is now a real `<.link navigate>`, replacing the disabled placeholder EN-7 shipped;
+`NAV-A03`'s active-section highlighting remains unclaimed, matching `M2M-S2`'s and `APP-S1`'s
+identical precedent.
 
 ## Tagging Convention
 

--- a/.opencode/context/project-intelligence/decisions-log.md
+++ b/.opencode/context/project-intelligence/decisions-log.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.30 | Updated: 2026-08-27 -->
+<!-- Context: project-intelligence/decisions | Priority: high | Version: 1.31 | Updated: 2026-08-27 -->
 
 # Decisions Log
 
@@ -52,6 +52,7 @@ job and the row should point rather than paraphrase.
 | 25 | Applications listing — one `NucleusWeb.ApplicationsLive` module, bounding `docs/adr/0018`'s Index/Show split to *match the module count to the route count* (no detail route here); row and cell DOM ids derive from the unhashed `Job.name`, resolving the ticket's unreferenced `#job-{id}-*` contract to `name` — safe **only** because `Job.child?/1` filters `/`-bearing child names out at the boundary, since `Job.name` has no validating allowlist and LazyHTML rejects a `/` in a selector outright; the name-ascending sort stays in the LiveView rather than expanding `list/1`'s contract; version/image/schedule ship as empty cells at their final ids so `APP-S2` is content-only | 2026-08-26 | Decided | `docs/adr/0025-applications-listing-single-module-and-name-derived-dom-ids.md` |
 | 26 | Applications row formatters — shared `NucleusWeb.Nomad.JobFormat` (`status_class/1`, `status_text/1`, `version_text/1`, `image_text/1`, `schedule_text/1`) over `Job.t()`, unblocking DEX-S5; `detail_error` degrades version/image/schedule text identically, including a degraded periodic job's cron; status badge is a `<span>` nested in the `#job-{name}-status` cell (id moves onto the span), `align-middle` on the `<td>` so the pill centers vertically in the row; Version column retitled "Job revision"; rendered status colour (not the CSS class) recorded as a `test/README.md` gap, following `M2M-A10`/`SEC-A04`'s precedent of not reopening `docs/adr/0008` itself | 2026-08-26 | Decided | `docs/adr/0026-applications-row-formatters-and-status-colour-test-gap.md` |
 | 27 | Nomad vars adapter — `Nucleus.Nomad.Transport` gains `:json`, `404`→`:not_found`, `409`→`:conflict` (carrying `ModifyIndex`), and an empty-body-success decode; `Nucleus.Backend.Error` gains a seventh kind, `:conflict`, with every existing exhaustive `case` already carrying a safe catch-all; `Nucleus.NomadVars.Store` (read+write, CAS-enforced, no create/delete) mirrors `Nucleus.Secrets.Store`'s shape; `Nucleus.NomadVars.Value.validate/1` returns a bare reason atom, not a wrapped `Error`; `Local`'s "tenant not enabled" sentinel is the JSON literal `false`, not `null` as the plan proposed — `Nucleus.Backend.Seed.read/2` cannot distinguish an absent section from an explicit `null` one; `Nucleus.Backend.Seed` gains `get_and_update/3` after review caught the first pass's check-and-set as a non-atomic read-then-write (a lost-update race under concurrent writers) | 2026-08-27 | Decided | `docs/adr/0027-nomad-vars-adapter.md` |
+| 28 | Data Export listing — one `NucleusWeb.DataExportLive` module, a second confirmation of `docs/adr/0025`'s module-count-matches-route-count rule; row/cell DOM ids use the unhashed variable key, resting on ops-provisioned-key provenance rather than an upstream filter (no `Job.child?/1` equivalent exists for `Items` keys); `Nucleus.NomadVars` gains `fetch/1` (no audit) alongside `list/1` (`fetch/1` plus `nomad_vars_listed` on success), mirroring `M2M.fetch/2`/`view/2` — caught in review after the plan's literal `connected?`-gated single call left the disconnected static render blank | 2026-08-27 | Decided | `docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md` |
 
 No **"re-platform" decision** (fresh start) and no **inherited ADRs** — the wiki's `ADR-0001`–
 `ADR-0007` are reference only; adopting one is a decision made on its own merits.
@@ -73,7 +74,7 @@ the ADR it points at stays findable.
 
 ## Onboarding Checklist
 
-- [ ] Read the Decision Index above; `adr/0001`–`0027` are binding
+- [ ] Read the Decision Index above; `adr/0001`–`0028` are binding
 - [ ] New formal ADRs belong in `docs/adr/`, with only an index row mirrored here — the wiki's
       ADR-0001–0007 are reference only, not adopted
 - [ ] Know which decisions are pending (see `living-notes.md`)

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.26 | Updated: 2026-08-27 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.27 | Updated: 2026-08-27 -->
 
 # Living Notes
 
@@ -211,10 +211,16 @@ deploys it.
   `live/2` test. Fixed by giving the context module a second, non-auditing function (`fetch/1`)
   for the disconnected pass, called disconnected while the auditing `list/1` runs only once
   connected — the same split `NucleusWeb.M2MClientsLive.Show` already uses
-  (`M2M.fetch/2`/`view/2`, `docs/adr/0019`), applied to a listing for the first time. If a future
-  context function needs to audit and is called from `mount/3`, check whether its LiveView gates
-  the whole call behind `connected?/1` — if so, it needs the same split, and a test that drives
-  a real disconnected HTTP request, not just `live/2`. See
+  (`M2M.fetch/2`/`view/2`, `docs/adr/0019`), applied to a listing for the first time. **This split
+  is safe here only because neither Data Export configuration nor an M2M client list is
+  sensitive** — `DEX-A03` says so explicitly for the former, and the latter is a client list, not
+  secret data. It does not generalize to a future audited listing of secret/sensitive data: an
+  unaudited `fetch/1`-style counterpart added specifically to populate the disconnected render
+  would then be an unaudited path to that data, regardless of whether a human ever actually sees
+  the disconnected pass — the audit requirement does not care who's watching. Check whether the
+  listed data is sensitive before reaching for this pattern; if it is, audit unconditionally (both
+  the disconnected and connected calls) or accept a blank/loading disconnected render instead of
+  serving real content unaudited. See
   `docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md`.
 - **A key/field with no validating allowlist used in a DOM id is a per-case examination, not a
   fact you can inherit from a sibling ADR.** `docs/adr/0025`'s `Job.name` and `Nucleus.NomadVars`'

--- a/.opencode/context/project-intelligence/living-notes.md
+++ b/.opencode/context/project-intelligence/living-notes.md
@@ -1,4 +1,4 @@
-<!-- Context: project-intelligence/notes | Priority: high | Version: 1.25 | Updated: 2026-08-27 -->
+<!-- Context: project-intelligence/notes | Priority: high | Version: 1.26 | Updated: 2026-08-27 -->
 
 # Living Notes
 
@@ -202,6 +202,29 @@ deploys it.
   `Nucleus.NomadVars.Store.Local` needed exactly this (`:not_configured` vs. a tenant lacking
   Data Export) and uses the JSON literal `false` as the second sentinel instead — reuse that
   pattern rather than reaching for `null` again. See `docs/adr/0027-nomad-vars-adapter.md`.
+- **A `connected?/1`-gated single fetch, applied literally, leaves the disconnected static
+  render blank — and `Phoenix.LiveViewTest.live/2` will not catch it**, since `live/2` connects
+  before returning and never exercises the disconnected pass. `NucleusWeb.DataExportLive`'s first
+  pass gated its only read (`Nucleus.NomadVars.list/1`, which audits) entirely behind
+  `connected?(socket)`, exactly as `DEX-S1`'s plan specified, and the static HTML was empty until
+  the socket connected — caught in review with a real `get/2` + `html_response/2` request, not a
+  `live/2` test. Fixed by giving the context module a second, non-auditing function (`fetch/1`)
+  for the disconnected pass, called disconnected while the auditing `list/1` runs only once
+  connected — the same split `NucleusWeb.M2MClientsLive.Show` already uses
+  (`M2M.fetch/2`/`view/2`, `docs/adr/0019`), applied to a listing for the first time. If a future
+  context function needs to audit and is called from `mount/3`, check whether its LiveView gates
+  the whole call behind `connected?/1` — if so, it needs the same split, and a test that drives
+  a real disconnected HTTP request, not just `live/2`. See
+  `docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md`.
+- **A key/field with no validating allowlist used in a DOM id is a per-case examination, not a
+  fact you can inherit from a sibling ADR.** `docs/adr/0025`'s `Job.name` and `Nucleus.NomadVars`'
+  `Items` keys are the same *shape* of problem (no allowlist, `/` breaks `LazyHTML` selectors
+  outright) but have different resolutions: `Job.name`'s is safe because `Job.child?/1` filters
+  `/`-bearing names out upstream; `Items` keys have no equivalent filter and never will (no
+  create/delete callback exists to filter), so `NucleusWeb.DataExportLive` instead rests on
+  ops-provisioned-key provenance — a convention, not a code guarantee. Citing ADR-0025 as
+  settling this key too, without re-examining whether an upstream filter actually exists, would
+  have been wrong. See `docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md`.
 
 ## Active Projects
 

--- a/docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md
+++ b/docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md
@@ -1,0 +1,220 @@
+# ADR-0028: Data Export Listing — Single Module, Unhashed Variable-Key DOM Ids, and the Fetch/List Audit Split
+
+## Status
+
+Accepted — 2026-08-27
+
+Decided on [DEX-S1](https://github.com/dave-bell/nucleus/issues/73). Builds on
+`0025-applications-listing-single-module-and-name-derived-dom-ids.md` (the
+module-count-matches-route-count rule this ADR applies rather than
+re-derives, and the DOM-id residual-risk framing this ADR follows for a
+different key), `0010-secrets-listing-gate-collapse-and-dom-ids.md` (the
+DOM-id-contract precedent both listings before this one followed), and
+`0027-nomad-vars-adapter.md` (`Nucleus.NomadVars.Store`, `VariableSet.t()`'s
+one-timestamp-per-set shape, and the enablement signal this ticket's gate
+consumes). Also draws on `0019-m2m-client-detail-mount-audit-guard-and-token-validity.md`'s
+`fetch/2`/`view/2` split, applied here for the first time to a *listing*
+rather than a detail view.
+
+## Context
+
+`DEX-A01`, `A03`, `A12`, `A13`, `A14` require: detect whether Data Export is
+enabled and show a clear message with no table when it is not; list every
+configuration key and value unmasked; an empty state when enabled but
+nothing is configured; a distinct error state when Nomad is unreachable,
+shell intact; and no create-or-delete affordance of any kind.
+
+This is the fourth listing view in the codebase, after Secrets (ADR-0010),
+M2M Clients (ADR-0018), and Applications (ADR-0025). The module-shape
+question ADR-0025 settled — *match the module count to the route count* —
+answers itself here without re-litigation: Data Export has no per-item
+detail route, so one module. Two questions were not settled by precedent:
+
+1. **Row/cell DOM ids.** `VariableSet.t()`'s `items` is a
+   `%{String.t() => String.t()}` with no validating allowlist on its keys at
+   all — Nomad's own API restricts the variable *path* to an RFC3986-safe
+   character set but places no charset restriction on an `Items` key beyond
+   the 64KiB total-size cap. ADR-0025 faced the identical shape of problem
+   for `Job.name` and resolved it by relying on an *upstream filter*
+   (`Job.child?/1`) that removes every `/`-bearing name before the template
+   ever sees one. No equivalent filter exists or could exist here — Data
+   Export's `Items` keys are not filtered by anything, upstream or
+   otherwise.
+2. **The disconnected (static) render.** `Nucleus.NomadVars` exposes only
+   one read function, and the ticket's plan called for gating the entire
+   fetch behind `connected?(socket)` so the `nomad_vars_listed` audit event
+   fires once per human page open, not once per disconnected-plus-connected
+   `mount/3` pair. Implemented literally, this leaves the disconnected
+   render with nothing to show — caught in review, not by any test written
+   against the plan as given, since `Phoenix.LiveViewTest.live/2` connects
+   before returning and so never exercises the disconnected pass at all.
+
+## Decision
+
+### One `NucleusWeb.DataExportLive` module, applying ADR-0025's rule directly
+
+A single LiveView at `/data-export`, with `NucleusWeb.DataExportLive.States`
+as its only sibling, registered in the existing `:authenticated`
+`live_session`, `ScopeHook` then `EnvironmentsHook`. No `handle_params/3` —
+the route carries no identifier — so the one fetch happens in `mount/3`.
+This ADR does not re-derive ADR-0025's reasoning; it is the second
+confirmation that the rule holds for a fourth listing with no detail route.
+
+### Row and cell DOM ids use the raw configuration key, unhashed — a different resolution than ADR-0025's, for a different reason
+
+`#var-{key}-value` uses the key exactly as it appears in `Items`, matching
+`env_names`/`description` as displayed. This was **not** resolved by finding
+an upstream filter analogous to `Job.child?/1` — none exists, and none
+could: `Nucleus.NomadVars.Store` has no create/delete callback, so every key
+that will ever reach this view was chosen by whoever provisioned the Nomad
+variable, not filtered by Nucleus code at any layer.
+
+The decision instead rests on **provenance, not filtering**: every key this
+feature can show today (`description`, `env_names`, `destination_bucket`) is
+an identifier Nucleus's own ops team defines when setting up the variable —
+the same class of input as an environment variable name, not tenant-supplied
+data. `DEX-A14` additionally guarantees no *new* key is ever created through
+this feature, so the keyspace cannot grow through the UI itself. Hashing
+(Secrets' approach) was rejected for the same reason ADR-0010 and ADR-0025
+both gave: the key is not sensitive, is already visible in the adjacent
+cell, and hashing it would only cost `DEX-S2`/future tickets' selector
+legibility.
+
+This is recorded as its own decision, distinct from ADR-0025's, because the
+residual risk is real and the safety argument is different in kind — a
+convention ops follows, not a filter the code enforces. A future key that
+violates the convention (contains a `/`, say) produces exactly ADR-0025's
+symptom: a technically-valid HTML `id` that is not a valid CSS selector, and
+`LazyHTML`-backed test helpers raise `ArgumentError` rather than failing an
+assertion. Nothing in this module detects or guards against that; it is an
+ops-process failure, not a code path.
+
+### `Nucleus.NomadVars.fetch/1` (no audit) and `list/1` (`fetch/1` plus audit) — the `M2M.fetch/2`/`view/2` split, applied to a listing for the first time
+
+`Nucleus.NomadVars` originally exposed only `list/1`, matching the ticket's
+plan literally: one call answering "is it enabled," "what's configured,"
+and "why did it fail" together, auditing `nomad_vars_listed` on success.
+`NucleusWeb.DataExportLive.mount/3` called this once, gated on
+`connected?(socket)`, exactly as the plan specified — and the disconnected
+render showed nothing at all, since no non-audited path existed to call
+instead.
+
+Caught in review: `NucleusWeb.M2MClientsLive.Show` (ADR-0019) already solves
+this exact problem for a *detail* view by splitting `M2M.fetch/2` (no
+audit) from `M2M.view/2` (`fetch/2` plus the audit emission), calling
+`fetch/2` disconnected and `view/2` only once connected. `Nucleus.NomadVars`
+gains the identical split: `fetch/1` resolves `Store.read()` with no side
+effect; `list/1` is `fetch/1` plus `Audit.emit(:nomad_vars_listed, ...)` on
+success. `mount/3` now calls `fetch/1` disconnected and `list/1` once
+connected — the static HTML shows the real table, empty state, or error
+state immediately, and the audit still fires exactly once per human page
+open.
+
+This is the first time this split has been applied to a *listing* rather
+than a detail view — ADR-0018's and ADR-0025's listings both fetch
+unconditionally in `mount/3` with no `connected?` gate at all, because
+neither `Nucleus.M2M.list/1` nor `Nucleus.NomadJobs.list/1` emits an audit
+event for a listing in the first place (per each boundary's own moduledoc).
+`Nucleus.NomadVars.list/1` is the first listing-level context function that
+*does* audit, which is what makes the gate — and therefore the split —
+necessary here and not there.
+
+### The enablement gate is a state, not a filtered error
+
+`{:error, %Error{kind: :not_found}}` from `Nucleus.NomadVars.list/1`/`fetch/1`
+maps to its own `:not_enabled` status and `#data-export-not-enabled`, with
+no retry affordance — matching `Nucleus.NomadVars.Store`'s own moduledoc,
+which states plainly that `:not_found` here means "not enabled," not "the
+load failed." Every other kind collapses through
+`NucleusWeb.DataExportLive.States` the same way ADR-0025 collapsed
+`Nucleus.NomadJobs`'s: `:not_configured` → misconfigured,
+`:auth_expired` → auth-expired, everything else (including `:conflict`,
+which nothing here can produce yet) → `:unavailable` with a retry control.
+
+### One shared "last modified," never per row
+
+`VariableSet.t()` carries a single `modify_index`/`modified_at` for the
+whole path (ADR-0027, DEX-D1's correction of the wiki), so it renders once,
+outside the row loop, at `#data-export-modified-at` — never
+`#var-{key}-modified`. This is a straightforward consumption of ADR-0027's
+struct, not a new decision, but is named here because the wiki's original
+per-key shape made the opposite choice look plausible to a reader who had
+not seen that correction.
+
+## Consequences
+
+### Positive
+
+- The module-count-matches-route-count rule (ADR-0025) now has a second,
+  independent confirmation rather than resting on one data point.
+- `Nucleus.NomadVars.fetch/1` exists for any future caller that needs the
+  variable set without triggering an audit record — the same reusable seam
+  `M2M.fetch/2` already provides for M2M.
+- The disconnected render showing real content is now verified by a test
+  that exercises the actual static HTTP response (`get/2` +
+  `html_response/2`), not inferred from `live/2` succeeding — `live/2`
+  connects before returning and would not have caught the original gap.
+
+### Negative
+
+- **Row/cell id addressability rests on an ops convention, not a code
+  guarantee**, unlike ADR-0025's `Job.child?/1` filter. There is no test
+  that can prove a future key will never contain a `/` — only a moduledoc
+  comment recording the assumption. This is a strictly weaker guarantee
+  than ADR-0025's, carried forward deliberately rather than accidentally.
+- `Nucleus.NomadVars.list/1` now has two callers of `fetch/1` to keep in
+  sync (itself, and `NucleusWeb.DataExportLive.mount/3`'s disconnected
+  branch) where before there was one function and one call site. A future
+  change to `fetch/1`'s contract must be checked against both.
+- The generic error fallback folds `:already_exists`, `:conflict`, and
+  `:invalid` into `#data-export-unavailable`, the same trade ADR-0010,
+  ADR-0018, and ADR-0025 already accept for their own boundaries.
+
+## Alternatives considered
+
+**Hashing the variable key, mirroring Secrets' ARN hash.** Rejected — the
+key is not sensitive and is already visible in the adjacent cell; hashing
+would only cost `DEX-S2`'s future selectors, for no protection gained.
+
+**Sanitising the key into the id (replacing `/` with `-`) instead of
+documenting the residual risk.** Rejected for the same reason ADR-0025
+rejected it for `Job.name`: it would make a future violating key render an
+id that looks valid and silently collides, rather than failing loudly via
+`LazyHTML`'s own `ArgumentError`. Given every key today is ops-provisioned,
+the sanitiser would be dead code whose only effect is to mask the
+regression it appears to guard against.
+
+**Leaving `fetch_variables/1` gated entirely behind `connected?/1`, as the
+ticket's plan specified literally, and adding an explicit `:loading`
+skeleton state to the template instead of a second context function.**
+Rejected — it would work, but reproduces the disconnected-static-render gap
+one layer up (an empty-looking page until the socket connects) rather than
+closing it, and diverges from `M2M.fetch/2`/`view/2`'s already-established
+pattern for the identical problem. Adding `fetch/1` reuses a seam this
+codebase already trusts instead of inventing a new one.
+
+**Merging `fetch/1` and `list/1` into one function taking an `audit?:
+boolean` option.** Rejected — `Nucleus.M2M`'s `fetch/2`/`view/2` split
+already establishes two named functions, not one parameterised one, as the
+convention for "the same read, audited or not." A boolean flag would read
+correctly at the call site but hides the audit decision behind a value
+instead of a name.
+
+## References
+
+- DEX-S1 (issue #73) — the deciding issue, and its comment thread's request
+  to examine the variable-key DOM-id question explicitly rather than cite
+  ADR-0025 unexamined
+- `docs/adr/0025-applications-listing-single-module-and-name-derived-dom-ids.md` —
+  the module-shape rule this ADR applies, and the DOM-id residual-risk
+  framing this ADR follows for a key with a different safety argument
+- `docs/adr/0010-secrets-listing-gate-collapse-and-dom-ids.md` — the
+  DOM-id-contract-for-later-tickets precedent
+- `docs/adr/0019-m2m-client-detail-mount-audit-guard-and-token-validity.md` —
+  the `fetch/2`/`view/2` split this ADR applies to a listing for the first
+  time
+- `docs/adr/0027-nomad-vars-adapter.md` — `Nucleus.NomadVars.Store`,
+  `VariableSet.t()`'s one-timestamp-per-set shape, and `:not_found` as the
+  enablement signal this ticket's gate consumes
+- DEX-S2 (issue #74) — the downstream consumer of this ticket's DOM-id
+  contract, `fetch/1`, and `:modify_index` assign

--- a/docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md
+++ b/docs/adr/0028-data-export-listing-single-module-dom-ids-and-fetch-list-split.md
@@ -119,6 +119,19 @@ event for a listing in the first place (per each boundary's own moduledoc).
 *does* audit, which is what makes the gate — and therefore the split —
 necessary here and not there.
 
+**This does not generalize to a future listing of sensitive data.** The
+split is safe only because Data Export configuration is not secret data —
+`DEX-A03` states this explicitly, the same premise `Nucleus.M2M.fetch/2`'s
+own split rests on for a client list. An unaudited `fetch/1`-shaped
+counterpart, added specifically so the disconnected render has something
+real to show, is itself an unaudited path to whatever it reads — that is
+true regardless of whether a human ever actually loads the page
+disconnected. A future listing over sensitive data cannot copy this pattern
+by rote; it needs either unconditional auditing (both the disconnected and
+connected calls) or a disconnected render that shows no real content at
+all, accepting the blank-shell cost this ADR spent its Context section
+arguing against.
+
 ### The enablement gate is a state, not a filtered error
 
 `{:error, %Error{kind: :not_found}}` from `Nucleus.NomadVars.list/1`/`fetch/1`
@@ -166,6 +179,15 @@ not seen that correction.
   sync (itself, and `NucleusWeb.DataExportLive.mount/3`'s disconnected
   branch) where before there was one function and one call site. A future
   change to `fetch/1`'s contract must be checked against both.
+- **The `fetch/1`/`list/1` split reads as a general "how to fix a blank
+  disconnected render" recipe if lifted out of context — it is not one.**
+  It is sound here only because the underlying data (Data Export
+  configuration) is not sensitive; the same fix applied to a future
+  sensitive-data listing would introduce an unaudited read of that data.
+  Caught in review on this ticket's own PR, not by any test — recorded here
+  and in `living-notes.md`'s Gotchas so the next listing checks data
+  sensitivity before reusing this pattern rather than pattern-matching on
+  "audited call gated behind `connected?/1`" alone.
 - The generic error fallback folds `:already_exists`, `:conflict`, and
   `:invalid` into `#data-export-unavailable`, the same trade ADR-0010,
   ADR-0018, and ADR-0025 already accept for their own boundaries.

--- a/lib/nucleus/nomad_vars.ex
+++ b/lib/nucleus/nomad_vars.ex
@@ -1,0 +1,89 @@
+defmodule Nucleus.NomadVars do
+  @moduledoc """
+  Scope and audit over `Nucleus.NomadVars.Store` (EN-12/#72) — the same split
+  `Nucleus.Secrets` performs over `Nucleus.Secrets.Store` and `Nucleus.M2M`
+  performs over `Nucleus.M2M.Clients`. Backs Data Export configuration
+  (`docs/requirements/Data-Export-Configuration.md`).
+
+  ## `fetch/1` vs. `list/1` — the same split `Nucleus.M2M.fetch/2`/`view/2` draw
+
+  `fetch/1` resolves the variable set with **no** audit side effect;
+  `list/1` is `fetch/1` plus the `nomad_vars_listed` emission on success.
+  `NucleusWeb.DataExportLive.mount/3` calls `fetch/1` on the disconnected
+  (static) render and `list/1` only once `connected?(socket)` is true — the
+  same reasoning `NucleusWeb.M2MClientsLive.Show` gives for its own
+  `fetch/2`/`view/2` split: `mount/3` runs once disconnected and once more
+  after the socket connects, and an audited call on both passes would
+  record two listings for one human page open. Unlike `M2M`, there is only
+  one non-audited *and* one audited call here — `fetch/1` has no other
+  caller today, but exists as its own function (not inlined into `list/1`)
+  so the disconnected render still shows real data instead of nothing, the
+  same guarantee `M2M.fetch/2` gives `M2MClientsLive.Show`'s static render.
+
+  ## `list/1` audits on success only
+
+  Mirrors `Nucleus.M2M.view/2` (`lib/nucleus/m2m.ex:224-239`): on
+  `{:ok, var_set}`, emits `nomad_vars_listed` (`user: Scope.audit_user(scope)`,
+  `tenant: scope.tenant`, `details: %{path: var_set.path}`) and *then* returns
+  `{:ok, var_set}`. On any error, the error is returned unchanged and nothing
+  is emitted — a listing that did not happen must not be recorded as one that
+  did (AUD-A07).
+
+  ## `:not_found` is not translated here
+
+  `Nucleus.NomadVars.Store.read/0`'s `{:error, %Error{kind: :not_found}}`
+  means "Data Export is not enabled for this tenant" (`DEX-A01`), not "the
+  configuration failed to load" — see `Nucleus.NomadVars.Store`'s own
+  moduledoc and `docs/adr/0027-nomad-vars-adapter.md`, Decision 7. This
+  module passes that (and every other `Nucleus.Backend.Error.kind()`)
+  through unchanged; `NucleusWeb.DataExportLive` is what maps `:not_found`
+  to its own not-enabled state. A reader used to every other boundary's
+  `:not_found` meaning "no such resource" would otherwise assume this one
+  means "the load failed" — it does not.
+  """
+
+  alias Nucleus.Audit
+  alias Nucleus.Backend.Error
+  alias Nucleus.NomadVars.Store
+  alias Nucleus.NomadVars.VariableSet
+  alias Nucleus.Scope
+
+  @doc """
+  Reads this tenant's Data Export variable set, with no audit side effect.
+
+  `scope` is accepted for call-site symmetry with every other context
+  function (and to leave room for a future tenant-scoped read), but is not
+  read by this function — see `list/1` for the audited equivalent, and the
+  module doc for why both exist.
+  """
+  @spec fetch(Scope.t()) :: {:ok, VariableSet.t()} | {:error, Error.t()}
+  def fetch(%Scope{} = _scope) do
+    Store.read()
+  end
+
+  @doc """
+  `fetch/1` plus the `nomad_vars_listed` audit emission (`DEX-A03`).
+
+  On success, emits `nomad_vars_listed` with `details: %{path: var_set.path}`
+  before returning. On failure, returns the error unchanged and emits
+  nothing — see the moduledoc for why `:not_found` in particular is not
+  translated into a different shape here.
+  """
+  @spec list(Scope.t()) :: {:ok, VariableSet.t()} | {:error, Error.t()}
+  def list(%Scope{} = scope) do
+    case fetch(scope) do
+      {:ok, %VariableSet{} = var_set} = ok ->
+        :ok =
+          Audit.emit(:nomad_vars_listed,
+            user: Scope.audit_user(scope),
+            tenant: scope.tenant,
+            details: %{path: var_set.path}
+          )
+
+        ok
+
+      {:error, %Error{}} = error ->
+        error
+    end
+  end
+end

--- a/lib/nucleus_web/components/layouts.ex
+++ b/lib/nucleus_web/components/layouts.ex
@@ -78,11 +78,9 @@ defmodule NucleusWeb.Layouts do
             <%!--
               NAV-A03 (active-section highlighting) is out of scope for
               every item here, shipped or not.
-              M2M Clients (M2M-S2, #35) and Applications (APP-S1, #58) have
-              shipped their real views — replaced with working links, not
-              placeholders. Data Export's feature doesn't exist yet, so it
-              still renders as a visibly disabled placeholder rather than a
-              dead link, until its own future ticket.
+              M2M Clients (M2M-S2, #35), Applications (APP-S1, #58), and
+              Data Export (DEX-S1, #73) have shipped their real views —
+              replaced with working links, not placeholders.
             --%>
             <ul class="menu menu-sm p-0 group-data-[collapsed=true]:hidden">
               <li>
@@ -91,9 +89,9 @@ defmodule NucleusWeb.Layouts do
                 </.link>
               </li>
               <li>
-                <span class="opacity-40 cursor-not-allowed" aria-disabled="true">
+                <.link navigate={~p"/data-export"}>
                   Data Export
-                </span>
+                </.link>
               </li>
               <li>
                 <.link navigate={~p"/m2m/clients"}>

--- a/lib/nucleus_web/live/data_export_live.ex
+++ b/lib/nucleus_web/live/data_export_live.ex
@@ -1,0 +1,224 @@
+defmodule NucleusWeb.DataExportLive do
+  @moduledoc """
+  The Data Export configuration table: enablement gate (`DEX-A01`), every
+  key/value listed unmasked (`DEX-A03`), the empty state (`DEX-A12`), every
+  `Nucleus.Backend.Error.kinds/0` value rendered as a distinct, shell-intact
+  state (`DEX-A13` and friends), and no mutating affordance of any kind
+  (`DEX-A14`) — issue #73, DEX-S1.
+
+  ## Single module — no Index/Show split
+
+  Unlike `NucleusWeb.M2MClientsLive`, there is no per-item detail route to
+  justify `phx.gen.live`'s Index/Show split (`docs/adr/0018`): Data Export is
+  one screen, one table, no drill-down — the same reasoning
+  `NucleusWeb.ApplicationsLive` gives (`docs/adr/0025`).
+  `NucleusWeb.DataExportLive.States` is the only sibling module.
+
+  ## One call to `Nucleus.NomadVars.fetch/1`/`list/1`
+
+  That single call answers three questions at once: whether Data Export is
+  enabled at all (`DEX-A01`), what its current configuration is (`DEX-A03`),
+  and — via `Nucleus.Backend.Error.kind()` — why it could not be shown
+  (`DEX-A13` and every other kind). `assign_result/2` collapses every
+  outcome to one of five states via `NucleusWeb.DataExportLive.States`:
+
+  | Outcome | `:status` | DOM id |
+  |---|---|---|
+  | `{:ok, var_set}` | `:ok` | `#data-export-table` / `#data-export-empty` |
+  | `kind: :not_found` | `:not_enabled` | `#data-export-not-enabled` |
+  | `kind: :not_configured` | `:misconfigured` | `#data-export-misconfigured` |
+  | `kind: :auth_expired` | `:auth_expired` | `#data-export-auth-expired` |
+  | anything else (`:already_exists`, `:conflict`, `:invalid` — none of
+    which `list/1` has reason to return today) | `:unavailable` |
+    `#data-export-unavailable` |
+
+  Every branch keeps `<Layouts.app>` intact (`#tenant-identifier` present) so
+  the user can navigate away — the same "rest of the shell remains usable"
+  guarantee `APP-A07` established.
+
+  ## No URL params to gate — `mount/3`, not `handle_params/3`
+
+  `/data-export` carries no identifier, matching `NucleusWeb.ApplicationsLive`'s
+  own reasoning: nothing a `<.link patch={...}>` could change without a
+  remount, so the one fetch happens in `mount/3` directly.
+
+  `mount/3` runs once for the disconnected (static) render and once more
+  after the client connects over the LiveView socket. Resolving via
+  `Nucleus.NomadVars.fetch/1` (no audit) on the disconnected pass keeps the
+  static HTML real — an empty content area until the socket connects would
+  be a regression from every sibling this ticket patterns itself on, none of
+  which leave the static render blank. Resolving via `Nucleus.NomadVars.list/1`
+  (`fetch/1` + `Audit.emit(:nomad_vars_listed, ...)`) only once
+  `connected?(socket)` is true means the one-time audit side effect fires
+  exactly once per human page open, never twice for the same open — the same
+  split `NucleusWeb.M2MClientsLive.Show` draws between `M2M.fetch/2` and
+  `M2M.view/2`.
+
+  ## `Items` is a plain map, not a stream
+
+  Unlike `M2M`/`Secrets`/`Applications`' lists of structs, `VariableSet.t()`'s
+  `items` is a `%{String.t() => String.t()}` with no stable native order and
+  no per-row lifecycle — nothing to `stream_insert/3` or `stream_delete/3`.
+  Rendered via a sorted `for` over
+  `Enum.sort_by(Map.to_list(items), fn {key, _} -> String.downcase(key) end)`,
+  the same name-ascending case-insensitive tiebreak `Nucleus.M2M.list/1` and
+  `Nucleus.Secrets.list/1` use, for the same JSON-decoded-map ordering
+  reason.
+
+  ## One shared "last modified", not one per row
+
+  `VariableSet.t()` carries a single `modify_index`/`modified_at` for the
+  *whole* path, not one per key (EN-12/#72's correction of the wiki's
+  per-key shape, DEX-D1) — so it renders once, outside the row loop, at
+  `#data-export-modified-at`, never `#var-{key}-modified`.
+
+  ## Row keys are not hashed
+
+  `{key}` in `#var-{key}-value` is the raw configuration key (`description`,
+  `env_names`, ...), unlike Secrets' ARN-hashed row ids (`docs/adr/0010`). A
+  Nomad Variables key is not sensitive and is already visible in the cell
+  next to it, so hashing it would add no protection and only cost
+  readability.
+
+  This does carry a residual assumption worth stating rather than leaving
+  implicit: Nomad's own `Items` map imposes no charset restriction on a key
+  (only the *path* is restricted to `docs/adr/0027`'s RFC3986-safe set — a
+  key can be any string up to the 64KiB total-size cap), so a key containing
+  `/` would produce a technically-valid HTML `id` that is not a valid CSS
+  selector — `has_element?/2`'s `LazyHTML` selector would raise, not merely
+  fail to match. This module accepts that risk rather than sanitizing or
+  hashing, the same "dependency on upstream filtering" `docs/adr/0025`
+  recorded for `Job.name` (which has no validating allowlist either): every
+  known key today (`description`, `env_names`, `destination_bucket`) is an
+  identifier Nucleus's own ops team defines when provisioning the variable,
+  not arbitrary tenant input, and `DEX-A14` guarantees no new key is ever
+  created through this feature. A future key that violates this convention
+  is an ops-process bug, not something this view can validate against.
+
+  ## `DEX-A14` — no mutating affordance anywhere
+
+  No create button, no per-row edit/delete control, no "Actions" column.
+  This is enforced one layer below the UI already — `Nucleus.NomadVars.Store`
+  defines no create/delete callback of any kind — but the negative test
+  proves the template itself adds none either.
+
+  `:modify_index` is carried in assigns because DEX-S2's edit flow needs the
+  value the page was loaded with for CAS — this ticket's job is only to
+  carry it forward, not to use it.
+
+  `current_scope` and `environments`/`expanded_categories` come from the
+  `:authenticated` `live_session`'s `on_mount` hooks (`NucleusWeb.ScopeHook`,
+  `NucleusWeb.EnvironmentsHook`), same order as `NucleusWeb.ApplicationsLive`
+  — this module does not assign any of them itself.
+  """
+
+  use NucleusWeb, :live_view
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.NomadVars
+  alias NucleusWeb.DataExportLive.States
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    scope = socket.assigns.current_scope
+
+    result =
+      if connected?(socket) do
+        NomadVars.list(scope)
+      else
+        NomadVars.fetch(scope)
+      end
+
+    {:ok, assign_result(socket, result)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("retry", _params, socket) do
+    result = NomadVars.list(socket.assigns.current_scope)
+    {:noreply, assign_result(socket, result)}
+  end
+
+  defp assign_result(socket, {:ok, var_set}) do
+    sorted =
+      Enum.sort_by(Map.to_list(var_set.items), fn {key, _value} -> String.downcase(key) end)
+
+    assign(socket,
+      status: :ok,
+      variables: sorted,
+      variable_count: map_size(var_set.items),
+      variable_path: var_set.path,
+      modify_index: var_set.modify_index,
+      modified_at: var_set.modified_at
+    )
+  end
+
+  defp assign_result(socket, {:error, %Error{kind: :not_found}}) do
+    assign(socket, status: :not_enabled, variables: [], variable_count: 0)
+  end
+
+  defp assign_result(socket, {:error, %Error{kind: :not_configured}}) do
+    assign(socket, status: :misconfigured, variables: [], variable_count: 0)
+  end
+
+  defp assign_result(socket, {:error, %Error{kind: :auth_expired}}) do
+    assign(socket, status: :auth_expired, variables: [], variable_count: 0)
+  end
+
+  defp assign_result(socket, {:error, %Error{}}) do
+    assign(socket, status: :unavailable, variables: [], variable_count: 0)
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app
+      flash={@flash}
+      current_scope={@current_scope}
+      environments={@environments}
+      expanded_categories={@expanded_categories}
+    >
+      <States.not_enabled :if={@status == :not_enabled} />
+      <States.misconfigured :if={@status == :misconfigured} />
+      <States.unavailable :if={@status == :unavailable} />
+      <States.auth_expired :if={@status == :auth_expired} />
+
+      <div :if={@status == :ok}>
+        <h1 class="text-lg font-semibold pb-4">Data Export</h1>
+
+        <.empty_state
+          :if={@variable_count == 0}
+          id="data-export-empty"
+          icon="hero-inbox"
+          message="No variables configured."
+        />
+
+        <div :if={@variable_count > 0} id="data-export-table">
+          <p class="text-sm text-base-content/70 pb-2">
+            Last modified: <span id="data-export-modified-at">{modified_at_text(@modified_at)}</span>
+          </p>
+          <table class="table table-zebra">
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody id="data-export-table-body">
+              <tr :for={{key, value} <- @variables} id={"var-" <> key} data-var-key={key}>
+                <td class="font-medium">{key}</td>
+                <td id={"var-" <> key <> "-value"}>{value}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp modified_at_text(%DateTime{} = datetime) do
+    Calendar.strftime(datetime, "%Y-%m-%d %H:%M UTC")
+  end
+
+  defp modified_at_text(nil), do: "unavailable"
+end

--- a/lib/nucleus_web/live/data_export_live/states.ex
+++ b/lib/nucleus_web/live/data_export_live/states.ex
@@ -1,0 +1,97 @@
+defmodule NucleusWeb.DataExportLive.States do
+  @moduledoc """
+  Shared non-content function components for `NucleusWeb.DataExportLive` —
+  the enablement gate (`DEX-A01`) plus every `Nucleus.Backend.Error.kinds/0`
+  value the configuration load can surface (`DEX-A13` and friends), mirroring
+  `NucleusWeb.ApplicationsLive.States`/`NucleusWeb.M2MClientsLive.States`
+  exactly, including the "mirror whatever landed for `:auth_expired`, don't
+  invent a second pattern" rule.
+
+  | Outcome | `:status` | DOM id |
+  |---|---|---|
+  | `kind: :not_found` | `:not_enabled` | `#data-export-not-enabled` |
+  | `kind: :not_configured` | `:misconfigured` | `#data-export-misconfigured` |
+  | `kind: :auth_expired` | `:auth_expired` | `#data-export-auth-expired` |
+  | anything else (`:already_exists`, `:conflict`, `:invalid` — none of
+    which `Nucleus.NomadVars.list/1` has reason to return today) |
+    `:unavailable` | `#data-export-unavailable` |
+
+  `:not_enabled` is its own state, distinct from every other kind below — it
+  means the tenant genuinely has no Data Export configuration to show, not
+  that a load failed. It carries no retry affordance, unlike `:unavailable`:
+  retrying a call that will keep 404ing is not a transient-failure recovery,
+  it is noise.
+  """
+
+  use NucleusWeb, :html
+
+  @doc """
+  Data Export has never been enabled for this tenant — `read/0`'s
+  `:not_found` (`DEX-A01`). Not a transient failure, so no retry affordance.
+  """
+  attr :id, :string, default: "data-export-not-enabled"
+
+  def not_enabled(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-no-symbol"
+      message="Data Export is not enabled for this tenant."
+    />
+    """
+  end
+
+  @doc """
+  The `:nomad_vars` boundary has no usable configuration — an operations
+  problem, not something the user did wrong.
+  """
+  attr :id, :string, default: "data-export-misconfigured"
+
+  def misconfigured(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-shield-exclamation"
+      message="Data Export isn't configured yet. This is an operations issue, not something you can fix here."
+    />
+    """
+  end
+
+  @doc """
+  Nomad (or the local backend standing in for it) can't be reached right
+  now — carries a retry affordance, unlike the other states here (`DEX-A13`).
+  """
+  attr :id, :string, default: "data-export-unavailable"
+
+  def unavailable(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-exclamation-triangle"
+      message="Can't reach Nomad right now. Try again shortly."
+    >
+      <:action>
+        <.button phx-click="retry">Retry</.button>
+      </:action>
+    </.empty_state>
+    """
+  end
+
+  @doc """
+  Nucleus's own credentials for the backend expired. Mirrors
+  `NucleusWeb.ApplicationsLive.States.auth_expired/1` (in turn mirroring
+  `NucleusWeb.M2MClientsLive.States`/`SEC-A18`/`SEC-S7`), rather than
+  inventing a second pattern.
+  """
+  attr :id, :string, default: "data-export-auth-expired"
+
+  def auth_expired(assigns) do
+    ~H"""
+    <.empty_state
+      id={@id}
+      icon="hero-lock-closed"
+      message="Data Export can't be reached right now."
+    />
+    """
+  end
+end

--- a/lib/nucleus_web/router.ex
+++ b/lib/nucleus_web/router.ex
@@ -59,6 +59,10 @@ defmodule NucleusWeb.Router do
       # Single module, no Index/Show split — APP-S1 (#58), see
       # `NucleusWeb.ApplicationsLive`'s moduledoc.
       live "/applications", ApplicationsLive, :index
+
+      # Single module, no Index/Show split — DEX-S1 (#73), see
+      # `NucleusWeb.DataExportLive`'s moduledoc.
+      live "/data-export", DataExportLive, :index
     end
   end
 

--- a/test/nucleus/nomad_vars_test.exs
+++ b/test/nucleus/nomad_vars_test.exs
@@ -33,13 +33,23 @@ defmodule Nucleus.NomadVars.FakeStore do
 end
 
 defmodule Nucleus.NomadVarsTest do
-  # Swaps the configured implementation, application-global.
-  use ExUnit.Case, async: false
+  # Swaps the configured implementation, application-global (the Store
+  # dispatch tests below), plus seeds/faults the local backend and asserts
+  # on emitted audit records (the Nucleus.NomadVars context tests, DEX-S1)
+  # — composed the same way Nucleus.M2MTest is, both pinned to
+  # async: false to match Nucleus.BackendCase's constraint.
+  use Nucleus.BackendCase, async: false
+  use Nucleus.AuditCase, async: false
 
   alias Nucleus.Backend
+  alias Nucleus.Backend.Error
+  alias Nucleus.NomadVars
   alias Nucleus.NomadVars.FakeStore
   alias Nucleus.NomadVars.Store
   alias Nucleus.NomadVars.VariableSet
+  alias Nucleus.Scope
+
+  @scope %Scope{tenant: "local", user: %{email: "a@b.com", username: nil}}
 
   setup do
     original_backends = Application.get_env(:nucleus, :backends)
@@ -98,6 +108,84 @@ defmodule Nucleus.NomadVarsTest do
     @tag :unit
     test "health_check/0 resolves to the configured implementation" do
       assert Store.health_check() == :ok
+    end
+  end
+
+  describe "Nucleus.NomadVars.fetch/1 — no audit, ever" do
+    test "returns {:ok, var_set} for the seeded enabled fixture, with no audit emission" do
+      assert {:ok, %VariableSet{} = var_set} = NomadVars.fetch(@scope)
+
+      assert var_set.path == "nomad/jobs/local-data_export"
+      assert_no_audit_event(:nomad_vars_listed)
+    end
+
+    test "a :not_found tenant emits nothing either" do
+      Backend.Seed.write(:nomad_vars, false)
+
+      assert {:error, %Error{kind: :not_found}} = NomadVars.fetch(@scope)
+      assert_no_audit_event(:nomad_vars_listed)
+    end
+  end
+
+  describe "Nucleus.NomadVars.list/1 — DEX-A03 the seeded enabled fixture" do
+    @tag action: "DEX-A03"
+    test "returns {:ok, var_set} with every seeded key/value" do
+      assert {:ok, %VariableSet{} = var_set} = NomadVars.list(@scope)
+
+      assert var_set.path == "nomad/jobs/local-data_export"
+      assert var_set.items["description"] =~ "Nightly export"
+      assert var_set.items["env_names"] == "prod,staging"
+      assert is_integer(var_set.modify_index)
+    end
+
+    @tag action: "DEX-A03"
+    test "emits exactly one nomad_vars_listed, with the path in details and the tenant set" do
+      assert {:ok, var_set} = NomadVars.list(@scope)
+
+      assert_audit_event(:nomad_vars_listed,
+        tenant: "local",
+        details: %{path: var_set.path}
+      )
+
+      assert audit_events() |> Enum.filter(&(&1.event == :nomad_vars_listed)) |> length() == 1
+    end
+  end
+
+  describe "Nucleus.NomadVars.list/1 — no audit on any error" do
+    @tag action: "DEX-A01"
+    test "a tenant with no Data Export variable path (:not_found) emits nothing" do
+      Backend.Seed.write(:nomad_vars, false)
+
+      assert {:error, %Error{kind: :not_found}} = NomadVars.list(@scope)
+      assert_no_audit_event(:nomad_vars_listed)
+    end
+
+    test "an unconfigured boundary (:not_configured) emits nothing" do
+      Backend.Seed.write(:nomad_vars, nil)
+
+      assert {:error, %Error{kind: :not_configured}} = NomadVars.list(@scope)
+      assert_no_audit_event(:nomad_vars_listed)
+    end
+
+    test "an unavailable backend emits nothing" do
+      force_error(:nomad_vars, :unavailable)
+
+      assert {:error, %Error{kind: :unavailable}} = NomadVars.list(@scope)
+      assert_no_audit_event(:nomad_vars_listed)
+    end
+  end
+
+  describe "Nucleus.NomadVars.list/1 — every Error.kind() passes through unchanged" do
+    for kind <- Error.kinds() do
+      @tag kind: kind
+      test "#{kind} is returned unflattened, :not_found included, with no translation", %{
+        kind: kind
+      } do
+        force_error(:nomad_vars, kind)
+
+        assert {:error, %Error{kind: ^kind, boundary: :nomad_vars}} = NomadVars.list(@scope)
+        assert_no_audit_event(:nomad_vars_listed)
+      end
     end
   end
 end

--- a/test/nucleus_web/live/data_export_live_test.exs
+++ b/test/nucleus_web/live/data_export_live_test.exs
@@ -1,0 +1,295 @@
+defmodule NucleusWeb.DataExportLiveTest do
+  # `force_error/2`/`Nucleus.Backend.Seed.write/2` mutate node-global state
+  # (`Nucleus.Backend.Faults`, `Nucleus.Backend.Seed`) — matching
+  # `Nucleus.BackendCase`'s own `async: false` requirement.
+  use NucleusWeb.LiveCase, async: false
+
+  alias Nucleus.Backend.Error
+  alias Nucleus.Backend.Seed
+
+  # Seeded in priv/backends/local_seed.json under TENANT_NAMESPACE = "local".
+  @seeded_path "nomad/jobs/local-data_export"
+  @seeded_keys ["description", "env_names", "destination_bucket"]
+
+  describe "DEX-A01 — detect whether Data Export is enabled" do
+    @tag action: "DEX-A01"
+    test "a tenant without the variable path sees a clear not-enabled message, no table", %{
+      conn: conn
+    } do
+      Seed.write(:nomad_vars, false)
+
+      {:ok, view, _html} = live_data_export(conn)
+
+      assert has_element?(view, "#data-export-not-enabled")
+      refute has_element?(view, "#data-export-table")
+      refute has_element?(view, "#data-export-empty")
+      # the shell survives even when the feature itself is off.
+      assert has_element?(view, "#tenant-identifier")
+    end
+
+    @tag action: "DEX-A01"
+    test "no retry affordance is offered — this is not a transient failure", %{conn: conn} do
+      Seed.write(:nomad_vars, false)
+
+      {:ok, view, _html} = live_data_export(conn)
+
+      refute has_element?(view, "#data-export-not-enabled [phx-click='retry']")
+    end
+
+    @tag action: "DEX-A01"
+    test "the seeded enabled fixture does not show the not-enabled message", %{conn: conn} do
+      {:ok, view, _html} = live_data_export(conn)
+
+      refute has_element?(view, "#data-export-not-enabled")
+    end
+
+    @tag action: "DEX-A01"
+    test "the disconnected (static, pre-websocket) render already reflects not-enabled, not a blank shell",
+         %{conn: conn} do
+      Seed.write(:nomad_vars, false)
+
+      html = conn |> get(~p"/data-export") |> html_response(200)
+
+      assert html =~ "data-export-not-enabled"
+      refute html =~ "data-export-table"
+    end
+  end
+
+  describe "DEX-A03 — view current Data Export configuration" do
+    @tag action: "DEX-A03"
+    test "every seeded key/value renders unmasked, plus one shared modified-at", %{conn: conn} do
+      {:ok, view, _html} = live_data_export(conn)
+
+      assert has_element?(view, "#data-export-table")
+
+      for key <- @seeded_keys do
+        assert has_element?(view, "#var-#{key}-value")
+      end
+
+      assert view |> element("#var-description-value") |> render() =~
+               "Nightly export of tenant usage metrics"
+
+      assert view |> element("#var-env_names-value") |> render() =~ "prod,staging"
+
+      # values are unmasked — no bullet/dot masking character present.
+      refute view |> element("#var-env_names-value") |> render() =~ "•"
+
+      assert has_element?(view, "#data-export-modified-at")
+    end
+
+    @tag action: "DEX-A03"
+    test "the modified-at value is shared, not rendered once per row", %{conn: conn} do
+      {:ok, view, _html} = live_data_export(conn)
+
+      # exactly one shared element, not one per seeded key.
+      doc = view |> render() |> LazyHTML.from_fragment()
+      assert doc |> LazyHTML.query("#data-export-modified-at") |> Enum.count() == 1
+
+      for key <- @seeded_keys do
+        refute has_element?(view, "#var-#{key}-modified")
+      end
+    end
+
+    @tag action: "DEX-A03"
+    test "rows render in stable, case-insensitive name order across repeated loads", %{
+      conn: conn
+    } do
+      {:ok, view1, _html} = live_data_export(conn)
+      {:ok, view2, _html} = live_data_export(conn)
+
+      names1 = row_keys(view1)
+      names2 = row_keys(view2)
+
+      assert names1 != []
+      assert names1 == names2
+      assert names1 == Enum.sort_by(names1, &String.downcase/1)
+    end
+
+    @tag action: "DEX-A03"
+    test "the disconnected (static, pre-websocket) render already shows the real table, not a blank shell",
+         %{conn: conn} do
+      html = conn |> get(~p"/data-export") |> html_response(200)
+
+      assert html =~ "data-export-table"
+      assert html =~ "Nightly export of tenant usage metrics"
+      refute html =~ "data-export-not-enabled"
+      refute html =~ "data-export-unavailable"
+    end
+  end
+
+  describe "DEX-A12 — empty configuration state" do
+    @tag action: "DEX-A12"
+    test "an enabled-but-empty fixture renders #data-export-empty, no table", %{conn: conn} do
+      Seed.write(:nomad_vars, %{
+        "path" => @seeded_path,
+        "items" => %{},
+        "modify_index" => 1,
+        "modified_at" => nil
+      })
+
+      {:ok, view, _html} = live_data_export(conn)
+
+      assert has_element?(view, "#data-export-empty")
+      refute has_element?(view, "#data-export-table")
+      refute has_element?(view, "#data-export-not-enabled")
+    end
+  end
+
+  describe "DEX-A13 — error loading configuration" do
+    @tag action: "DEX-A13"
+    test "forced :unavailable renders #data-export-unavailable, shell intact, with retry", %{
+      conn: conn
+    } do
+      force_error(:nomad_vars, :unavailable)
+
+      {:ok, view, _html} = live_data_export(conn)
+
+      assert has_element?(view, "#data-export-unavailable")
+      refute has_element?(view, "#data-export-table")
+      refute has_element?(view, "#data-export-empty")
+      assert has_element?(view, "#tenant-identifier")
+    end
+
+    @tag action: "DEX-A13"
+    test "retry re-fetches and shows the table once the fault clears", %{conn: conn} do
+      force_error(:nomad_vars, :unavailable)
+
+      {:ok, view, _html} = live_data_export(conn)
+      assert has_element?(view, "#data-export-unavailable")
+
+      clear_faults()
+
+      view |> element("[phx-click='retry']") |> render_click()
+
+      assert has_element?(view, "#data-export-table")
+      refute has_element?(view, "#data-export-unavailable")
+    end
+  end
+
+  describe "every Nucleus.Backend.Error kind renders a distinct state, shell intact, no crash" do
+    @error_state_ids %{
+      not_found: "data-export-not-enabled",
+      not_configured: "data-export-misconfigured",
+      unavailable: "data-export-unavailable",
+      auth_expired: "data-export-auth-expired"
+    }
+
+    for {kind, expected_id} <- @error_state_ids do
+      @tag kind: kind
+      @tag expected_id: expected_id
+      test "#{kind} renders #{expected_id}, mutually exclusive, shell intact", %{
+        conn: conn,
+        kind: kind,
+        expected_id: expected_id
+      } do
+        force_error(:nomad_vars, kind)
+
+        {:ok, view, _html} = live_data_export(conn)
+
+        assert has_element?(view, "##{expected_id}")
+
+        for other_id <- Map.values(@error_state_ids) -- [expected_id] do
+          refute has_element?(view, "##{other_id}")
+        end
+
+        refute has_element?(view, "#data-export-table")
+        refute has_element?(view, "#data-export-empty")
+        assert has_element?(view, "#tenant-identifier")
+      end
+    end
+
+    test "every remaining kind (including :conflict) collapses to #data-export-unavailable and never crashes",
+         %{conn: conn} do
+      named_kinds = Map.keys(@error_state_ids)
+
+      for kind <- Error.kinds() -- named_kinds do
+        force_error(:nomad_vars, kind)
+
+        assert {:ok, view, _html} = live_data_export(conn)
+        assert has_element?(view, "#data-export-unavailable")
+        assert has_element?(view, "#tenant-identifier")
+
+        clear_faults()
+      end
+    end
+
+    test "live/2 returns {:ok, ...} for every error kind — the LiveView never crashes", %{
+      conn: conn
+    } do
+      for kind <- Error.kinds() do
+        force_error(:nomad_vars, kind)
+        assert {:ok, _view, _html} = live_data_export(conn)
+        clear_faults()
+      end
+    end
+  end
+
+  describe "DEX-A14 — no create or delete of configuration keys" do
+    @tag action: "DEX-A14"
+    test "no create, edit, or delete control exists anywhere on the view", %{conn: conn} do
+      {:ok, view, _html} = live_data_export(conn)
+
+      refute has_element?(view, "[phx-click='create']")
+      refute has_element?(view, "[phx-click='new_variable']")
+      refute has_element?(view, "[phx-click='delete']")
+      refute has_element?(view, "[phx-click='remove']")
+      refute has_element?(view, "button", "New")
+      refute has_element?(view, "th", "Actions")
+    end
+
+    @tag action: "DEX-A14"
+    test "none of the words Add, New, Delete, or Remove appear inside #data-export-table", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live_data_export(conn)
+
+      table_html = view |> element("#data-export-table") |> render()
+
+      refute table_html =~ "Add"
+      refute table_html =~ "New"
+      refute table_html =~ "Delete"
+      refute table_html =~ "Remove"
+    end
+  end
+
+  describe "sidebar — Data Export is a real, functional link" do
+    test "the sidebar renders a navigate link to /data-export, not a disabled span", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live_data_export(conn)
+
+      doc = view |> render() |> LazyHTML.from_fragment()
+
+      data_export_link =
+        doc
+        |> LazyHTML.query("#sidebar a")
+        |> Enum.find(fn node -> LazyHTML.text(node) =~ "Data Export" end)
+
+      refute is_nil(data_export_link)
+      assert LazyHTML.attribute(data_export_link, "href") == ["/data-export"]
+
+      refute has_element?(view, "#sidebar span[aria-disabled='true']", "Data Export")
+    end
+
+    test "clicking the sidebar link from another authenticated view navigates to /data-export",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/m2m/clients")
+
+      assert {:ok, data_export_view, _html} =
+               view
+               |> element("#sidebar a", "Data Export")
+               |> render_click()
+               |> follow_redirect(conn, ~p"/data-export")
+
+      assert has_element?(data_export_view, "#data-export-table")
+    end
+  end
+
+  defp row_keys(view) do
+    view
+    |> render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("#data-export-table-body [data-var-key]")
+    |> LazyHTML.attribute("data-var-key")
+  end
+end

--- a/test/nucleus_web/live/shell_test.exs
+++ b/test/nucleus_web/live/shell_test.exs
@@ -95,6 +95,19 @@ defmodule NucleusWeb.ShellTest do
   end
 
   @tag :unit
+  test "the sidebar Data Export item is a real link and navigates to this view", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
+
+    assert {:ok, data_export_view, _html} =
+             view
+             |> element("a", "Data Export")
+             |> render_click()
+             |> follow_redirect(conn, ~p"/data-export")
+
+    assert has_element?(data_export_view, "#tenant-identifier")
+  end
+
+  @tag :unit
   test "shows the identity control with the dev email, and no sign-out control", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/environments/prod/secrets")
 

--- a/test/support/live_case.ex
+++ b/test/support/live_case.ex
@@ -66,4 +66,16 @@ defmodule NucleusWeb.LiveCase do
       Phoenix.LiveViewTest.live(unquote(conn), "/environments/#{unquote(environment)}")
     end
   end
+
+  @doc """
+  Mounts `NucleusWeb.DataExportLive`, the `/data-export` route the sidebar
+  links to (`DEX-S1`, #73).
+
+  A macro for the same reason as `live_secrets/2` above.
+  """
+  defmacro live_data_export(conn) do
+    quote do
+      Phoenix.LiveViewTest.live(unquote(conn), "/data-export")
+    end
+  end
 end


### PR DESCRIPTION
## What

This ships the Data Export listing screen at `/data-export`: an enablement gate, an unmasked configuration table (keys are ops-provisioned infrastructure config, not secrets), and distinct empty/error states — all behind a guard that no create-or-delete affordance ever exists on this view. It's the fourth listing view in the codebase, following the same shape as Secrets, M2M Clients, and Applications, and activates the Data Export sidebar link that was previously a disabled placeholder.

## How

- `Nucleus.NomadVars` wraps `Nucleus.NomadVars.Store` (EN-12/#72) with scope and audit — `fetch/1` (no audit) and `list/1` (`fetch/1` plus a `nomad_vars_listed` emission on success only; `:not_found` is returned untranslated, since here it means "not enabled," not "load failed").
- `NucleusWeb.DataExportLive` is a single module (no Index/Show split — there's no per-item route to justify one), rendering a sorted, case-insensitive key/value table with one shared `#data-export-modified-at` (`VariableSet.t()` carries one timestamp for the whole set, not one per key) and five collapsed states via `NucleusWeb.DataExportLive.States` (`:ok`, `:not_enabled`, `:misconfigured`, `:auth_expired`, and `:unavailable` as the catch-all covering `:conflict` and anything else).
- No create/delete control anywhere on the table, proven by a negative test rather than left to be noticed by absence.
- Sidebar Data Export link activated in `layouts.ex` (was `aria-disabled`), route added to the `:authenticated` live_session, and a `live_data_export/1` macro added to `test/support/live_case.ex`.
- Satisfies `DEX-A01`, `DEX-A03`, `DEX-A12`, `DEX-A13`, `DEX-A14`.

## Record

ADR-0028 settles the module shape (single module, matching ADR-0025's route-count rule), the `fetch/1`/`list/1` audit split (mirroring `M2MClientsLive.Show`'s `fetch/2`/`view/2`), and the decision to use raw, unhashed variable keys in DOM ids rather than hashing them. `decisions-log.md`, `business-tech-bridge.md`, and `living-notes.md` were updated alongside it.

## Divergence from the plan

Two corrections were made during code review, both already folded into the implementation and recorded in ADR-0028 rather than left as open questions:

1. **Disconnected render was blank.** The plan called for `Nucleus.NomadVars` to expose only `list/1`, invoked from `mount/3` entirely behind `connected?(socket)` so the audit fires once per page open. Implemented literally, this left the disconnected (pre-websocket) static HTML completely empty — no table, no error state — until the socket connected. No `live/2`-based test caught this, because `live/2` connects before returning and never exercises the disconnected pass. It surfaced in review and was confirmed with a direct `get/2` + `html_response/2` request against the disconnected HTML. The fix adds `Nucleus.NomadVars.fetch/1`, a non-auditing counterpart to `list/1`, mirroring the split `NucleusWeb.M2MClientsLive.Show` already uses between `Nucleus.M2M.fetch/2` and `Nucleus.M2M.view/2`: `mount/3` now calls `fetch/1` on the disconnected pass and `list/1` only once connected. Two regression tests hit the real disconnected HTTP response directly (not `live/2`) — one for the enabled/table case, one for not-enabled.

2. **DOM-id key examination went further than the plan's resolution.** The issue's own comment thread (posted after APP-S1/#58 landed) flagged that Nomad Variables' `Items` keys have no validating allowlist, and a `/` in a key would produce a valid HTML `id` that is not a valid CSS selector — `LazyHTML`-backed `has_element?/2` would raise rather than fail to match. The plan resolved this by choosing raw, unhashed keys (`#var-{key}-value`) over hashing, reasoning the key isn't sensitive and is already visible in the adjacent cell. This PR follows that resolution, but goes one step further and documents the residual risk explicitly, in both a moduledoc section in `data_export_live.ex` and in ADR-0028: unlike APP-S1's sibling case (ADR-0025), which points to a real upstream filter (`Job.child?/1` strips `/`-bearing names before the template sees them), no equivalent filter exists or could exist for Nomad Variables — `Nucleus.NomadVars.Store` has no create/delete callback at all, so there's nothing to filter. The safety argument here rests on convention and provenance (every key today is ops-provisioned config, not tenant input), not a code-enforced guarantee — a deliberately weaker guarantee than ADR-0025's, called out as such rather than silently inherited.

## Verification

`mix precommit` passed: 1106 tests, 0 failures (compile with `--warnings-as-errors`, `deps.unlock --unused`, format, full test suite). `mix nucleus.trace --feature DEX` shows `DEX-A01`, `A03`, `A12`, `A13`, `A14` covered; the remaining 9 DEX actions are correctly still uncovered, belonging to later tickets DEX-S2 through DEX-S5.

Closes #73
